### PR TITLE
makefile: fix version given to updoc upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,14 +82,14 @@ xpkg.build.provider-aws: do.build.images
 # Setup Upbound Docs
 
 updoc-upload:
-	@$(INFO) uploading docs for $(VERSION_MINOR)
+	@$(INFO) uploading docs for v$(VERSION_MAJOR).$(VERSION_MINOR)
 	@go run github.com/upbound/official-providers/updoc/cmd upload \
         --docs-dir=$(ROOT_DIR)/docs \
         --name=$(PROJECT_NAME) \
-        --version=$(VERSION_MINOR) \
+        --version=v$(VERSION_MAJOR).$(VERSION_MINOR) \
         --bucket-name=$(BUCKET_NAME) \
         --cdn-domain=$(CDN_DOMAIN) || $(FAIL)
-	@$(OK) uploaded docs for $(VERSION_MINOR)
+	@$(OK) uploaded docs for v$(VERSION_MAJOR).$(VERSION_MINOR)
 
 ifneq ($(filter release-%,$(BRANCH_NAME)),)
 publish.artifacts: updoc-upload


### PR DESCRIPTION
### Description of your changes

It should push to `v0.17` instead of `17`

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Reproduced that `v$(VERSION_MAJOR).$(VERSION_MINOR)` is calculated correctly when run on top of a version tag.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
