### PR TITLE
Remove kuttl input from cluster_dump target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,6 @@ cluster_dump: $(KUBECTL)
 	@mkdir -p ${DUMP_DIRECTORY}
 	@$(KUBECTL) cluster-info dump --output-directory ${DUMP_DIRECTORY} --all-namespaces || true
 	@$(KUBECTL) get managed -o yaml > ${DUMP_DIRECTORY}/managed.yaml || true
-	@cat /tmp/automated-tests/case/*.yaml > ${DUMP_DIRECTORY}/kuttl-inputs.yaml
 
 .PHONY: pull-docs
 


### PR DESCRIPTION
### Description of your changes

Kuttl test case will already be outputted to the dump directory with uptest's --test-directory flag passed in CI.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Will be tested with uptest action.