### PR TITLE
Use pull_request as the CI workflow trigger event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,27 +13,27 @@ env:
   GO_VERSION: '1.19'
   GOLANGCI_VERSION: 'v1.50.0'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
-
+  UPBOUND_BOT_GITHUB_TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
   UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
   UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
   CDN_DOMAIN: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_CDN }}
   BUCKET_NAME: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_NAME }}
   GOOGLE_APPLICATION_CREDENTIALS_JSON_ENCODED: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_SA_JSON_ENCODED }}
-  UPBOUND_BOT_GITHUB_TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
+  TEST_SECRET: ${{ secrets.TEST_SECRET }}
 jobs:
   detect-noop:
     runs-on: ubuntu-22.04
     outputs:
       noop: ${{ steps.noop.outputs.should_skip }}
+    secrets: inherit
     steps:
+      - name: test-ci
+        run: |
+          echo "test: $TEST_SECRET"
+
       - name: Detect No-op Changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v2.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          paths_ignore: '["**.md", "**.png", "**.jpg"]'
-          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
-
+        run: echo "noop=false" >> $GITHUB_OUTPUT
 
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release-*
-  pull_request_target: {}
+  pull_request: {}
   workflow_dispatch: {}
 
 env:
@@ -14,6 +14,11 @@ env:
   GOLANGCI_VERSION: 'v1.50.0'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
+  UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
+  UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+  CDN_DOMAIN: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_CDN }}
+  BUCKET_NAME: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_NAME }}
+  GOOGLE_APPLICATION_CREDENTIALS_JSON_ENCODED: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_SA_JSON_ENCODED }}
   UPBOUND_BOT_GITHUB_TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
 jobs:
   detect-noop:
@@ -194,11 +199,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS_JSON_ENCODED: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_SA_JSON_ENCODED }}
-      BUCKET_NAME: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_NAME }}
-      CDN_DOMAIN: ${{ secrets.UPBOUND_MARKETPLACE_DOCS_BUCKET_PROD_CDN }}
-
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
@@ -221,8 +221,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: xpkg.upbound.io
-          username: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
-          password: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+          username: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
+          password: ${{ env.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
 
       - name: Prepare to Upload Docs
         run: echo "${GOOGLE_APPLICATION_CREDENTIALS_JSON_ENCODED}" | base64 -d > /tmp/gcp_sa.json


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes to change the Github workflow trigger event to `pull_request`. With @sergenyalcin, we have debugged a CI issue in [PR#10](https://github.com/upbound/upjet-provider-template/pull/10). Looks like when we use the pull_request_target[ event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) as the trigger, the jobs are running not on the actual feature branch but rather on the PR's base branch.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Observed the CI runs in this PR and also behavior validation from https://github.com/upbound/upjet-provider-template/pull/10.

Please also see:
https://github.com/upbound/provider-aws/actions/runs/3328668590