### PR TITLE
Only run e2e tests if commenter is a member of Upbound org

### DIFF
--- a/.github/workflows/uptest.yml
+++ b/.github/workflows/uptest.yml
@@ -69,7 +69,7 @@ jobs:
   uptest:
     runs-on: ubuntu-22.04
     needs: get-example-list
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/test-examples') }}
+    if: ${{ github.event.comment.author_association == 'MEMBER' && github.event.issue.pull_request && contains(github.event.comment.body, '/test-examples') }}
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
### Description of your changes

This PR ensures that issue commenter is a member of Upbound org to trigger the end to end tests.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Can only be tested after merge.
