### PR TITLE
Remove reference to provider_name output in uptest workflow

### DIFF
--- a/.github/workflows/uptest.yml
+++ b/.github/workflows/uptest.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/test-examples') }}
     outputs:
-      provider_name: ${{ steps.get-example-list-name.outputs.provider-name }}
       example_list: ${{ steps.get-example-list-name.outputs.example-list }}
       example_hash: ${{ steps.get-example-list-name.outputs.example-hash }}
     steps:
@@ -163,7 +162,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: cluster-dump-${{ needs.get-example-list.outputs.provider_name }}
+          name: cluster-dump-aws
           path: ./_output/cluster-dump
 
       - name: Cleanup


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Proposes to remove reference to the `provider_name` output from the `get-example-list-name` step.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
