### PR TITLE
fix(asg): fix observed failed availability_zones / vpc_zone_identifier

### DIFF
--- a/apis/autoscaling/v1beta1/zz_generated_terraformed.go
+++ b/apis/autoscaling/v1beta1/zz_generated_terraformed.go
@@ -151,6 +151,7 @@ func (tr *AutoscalingGroup) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AvailabilityZones"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/autoscaling/config.go
+++ b/config/autoscaling/config.go
@@ -16,6 +16,12 @@ func Configure(p *config.Provider) {
 		// These are mutually exclusive with aws_autoscaling_attachment.
 		config.MoveToStatus(r.TerraformResource, "load_balancers", "target_group_arns")
 
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{
+				"availability_zones",
+			},
+		}
+
 		r.References["vpc_zone_identifier"] = config.Reference{
 			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
 		}


### PR DESCRIPTION
Signed-off-by: Christopher Paul Haar <christopherpaul.haar@dkb.de>

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
we tested today upbound/provider-aws and found one Issue regarding  fields in asg **availability_zones** - looks like this issue has open PRs in crossplane-contrib/provider-jet-aws as well

```
observe failed: cannot run refresh: refresh failed: Conflicting configuration arguments: "availability_zones": conflicts with vpc_zone_identifier: File name: main.tf.json
Conflicting configuration arguments: "vpc_zone_identifier": conflicts with availability_zones: File name: main.tf.json
```

https://github.com/crossplane-contrib/provider-jet-aws/pull/238
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #106

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
