### PR TITLE
documentation: add resource option for all tag fields to remove terraform feature call out

### DIFF
--- a/apis/acm/v1beta1/zz_certificate_types.go
+++ b/apis/acm/v1beta1/zz_certificate_types.go
@@ -69,7 +69,7 @@ type CertificateParameters struct {
 	// +kubebuilder:validation:Optional
 	SubjectAlternativeNames []*string `json:"subjectAlternativeNames,omitempty" tf:"subject_alternative_names,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/acmpca/v1beta1/zz_certificateauthority_types.go
+++ b/apis/acmpca/v1beta1/zz_certificateauthority_types.go
@@ -87,7 +87,7 @@ type CertificateAuthorityParameters struct {
 	// +kubebuilder:validation:Optional
 	RevocationConfiguration []RevocationConfigurationParameters `json:"revocationConfiguration,omitempty" tf:"revocation_configuration,omitempty"`
 
-	// Specifies a key-value map of user-defined tags that are attached to the certificate authority. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/amp/v1beta1/zz_workspace_types.go
+++ b/apis/amp/v1beta1/zz_workspace_types.go
@@ -39,7 +39,7 @@ type WorkspaceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/apigateway/v1beta1/zz_apikey_types.go
+++ b/apis/apigateway/v1beta1/zz_apikey_types.go
@@ -50,7 +50,7 @@ type APIKeyParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/apigateway/v1beta1/zz_clientcertificate_types.go
+++ b/apis/apigateway/v1beta1/zz_clientcertificate_types.go
@@ -45,7 +45,7 @@ type ClientCertificateParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/apigateway/v1beta1/zz_domainname_types.go
+++ b/apis/apigateway/v1beta1/zz_domainname_types.go
@@ -115,7 +115,7 @@ type DomainNameParameters struct {
 	// +kubebuilder:validation:Optional
 	SecurityPolicy *string `json:"securityPolicy,omitempty" tf:"security_policy,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/apigateway/v1beta1/zz_restapi_types.go
+++ b/apis/apigateway/v1beta1/zz_restapi_types.go
@@ -96,7 +96,7 @@ type RestAPIParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/apigateway/v1beta1/zz_stage_types.go
+++ b/apis/apigateway/v1beta1/zz_stage_types.go
@@ -137,7 +137,7 @@ type StageParameters struct {
 	// +kubebuilder:validation:Required
 	StageName *string `json:"stageName" tf:"stage_name,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/apigateway/v1beta1/zz_usageplan_types.go
+++ b/apis/apigateway/v1beta1/zz_usageplan_types.go
@@ -126,7 +126,7 @@ type UsagePlanParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/apigateway/v1beta1/zz_vpclink_types.go
+++ b/apis/apigateway/v1beta1/zz_vpclink_types.go
@@ -38,7 +38,7 @@ type VPCLinkParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/apigatewayv2/v1beta1/zz_api_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_api_types.go
@@ -89,7 +89,7 @@ type APIParameters struct {
 	// +kubebuilder:validation:Optional
 	RouteSelectionExpression *string `json:"routeSelectionExpression,omitempty" tf:"route_selection_expression,omitempty"`
 
-	// A map of tags to assign to the API. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/apigatewayv2/v1beta1/zz_domainname_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_domainname_types.go
@@ -85,7 +85,7 @@ type DomainNameParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Map of tags to assign to the domain name. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/apigatewayv2/v1beta1/zz_stage_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_stage_types.go
@@ -171,7 +171,7 @@ type StageParameters struct {
 	// +kubebuilder:validation:Optional
 	StageVariables map[string]*string `json:"stageVariables,omitempty" tf:"stage_variables,omitempty"`
 
-	// A map of tags to assign to the stage. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/apigatewayv2/v1beta1/zz_vpclink_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_vpclink_types.go
@@ -66,7 +66,7 @@ type VPCLinkParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// A map of tags to assign to the VPC Link. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/athena/v1beta1/zz_datacatalog_types.go
+++ b/apis/athena/v1beta1/zz_datacatalog_types.go
@@ -40,7 +40,7 @@ type DataCatalogParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/athena/v1beta1/zz_workgroup_types.go
+++ b/apis/athena/v1beta1/zz_workgroup_types.go
@@ -155,7 +155,7 @@ type WorkgroupParameters struct {
 	// +kubebuilder:validation:Optional
 	State *string `json:"state,omitempty" tf:"state,omitempty"`
 
-	// Key-value map of resource tags for the workgroup. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/autoscaling/v1beta1/zz_autoscalinggroup_types.go
+++ b/apis/autoscaling/v1beta1/zz_autoscalinggroup_types.go
@@ -179,7 +179,7 @@ type AutoscalingGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	Tag []TagParameters `json:"tag,omitempty" tf:"tag,omitempty"`
 
-	// Set of maps containing resource tags. Conflicts with tag. See Tags below for more details.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags []map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/backup/v1beta1/zz_framework_types.go
+++ b/apis/backup/v1beta1/zz_framework_types.go
@@ -71,7 +71,7 @@ type FrameworkParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Metadata that you can assign to help organize the frameworks you create. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }
@@ -103,7 +103,7 @@ type ScopeParameters struct {
 	// +kubebuilder:validation:Optional
 	ComplianceResourceTypes []*string `json:"complianceResourceTypes,omitempty" tf:"compliance_resource_types,omitempty"`
 
-	// Metadata that you can assign to help organize the frameworks you create. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/backup/v1beta1/zz_plan_types.go
+++ b/apis/backup/v1beta1/zz_plan_types.go
@@ -89,7 +89,7 @@ type PlanParameters struct {
 	// +kubebuilder:validation:Required
 	Rule []RuleParameters `json:"rule" tf:"rule,omitempty"`
 
-	// Metadata that you can assign to help organize the plans you create. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/backup/v1beta1/zz_reportplan_types.go
+++ b/apis/backup/v1beta1/zz_reportplan_types.go
@@ -72,7 +72,7 @@ type ReportPlanParameters struct {
 	// +kubebuilder:validation:Required
 	ReportSetting []ReportSettingParameters `json:"reportSetting" tf:"report_setting,omitempty"`
 
-	// Metadata that you can assign to help organize the report plans you create. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/backup/v1beta1/zz_vault_types.go
+++ b/apis/backup/v1beta1/zz_vault_types.go
@@ -49,7 +49,7 @@ type VaultParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Metadata that you can assign to help organize the resources that you create. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/cloudfront/v1beta1/zz_distribution_types.go
+++ b/apis/cloudfront/v1beta1/zz_distribution_types.go
@@ -325,7 +325,7 @@ type DistributionParameters struct {
 	// +kubebuilder:validation:Optional
 	RetainOnDelete *bool `json:"retainOnDelete,omitempty" tf:"retain_on_delete,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/cloudwatch/v1beta1/zz_compositealarm_types.go
+++ b/apis/cloudwatch/v1beta1/zz_compositealarm_types.go
@@ -76,7 +76,7 @@ type CompositeAlarmParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to associate with the alarm. Up to 50 tags are allowed. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/cloudwatch/v1beta1/zz_metricalarm_types.go
+++ b/apis/cloudwatch/v1beta1/zz_metricalarm_types.go
@@ -104,7 +104,7 @@ type MetricAlarmParameters struct {
 	// +kubebuilder:validation:Optional
 	Statistic *string `json:"statistic,omitempty" tf:"statistic,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/cloudwatch/v1beta1/zz_metricstream_types.go
+++ b/apis/cloudwatch/v1beta1/zz_metricstream_types.go
@@ -104,7 +104,7 @@ type MetricStreamParameters struct {
 	// +kubebuilder:validation:Optional
 	RoleArnSelector *v1.Selector `json:"roleArnSelector,omitempty" tf:"-"`
 
-	// Map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/cloudwatchlogs/v1beta1/zz_group_types.go
+++ b/apis/cloudwatchlogs/v1beta1/zz_group_types.go
@@ -52,7 +52,7 @@ type GroupParameters struct {
 	// +kubebuilder:validation:Optional
 	RetentionInDays *float64 `json:"retentionInDays,omitempty" tf:"retention_in_days,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/codecommit/v1beta1/zz_repository_types.go
+++ b/apis/codecommit/v1beta1/zz_repository_types.go
@@ -48,7 +48,7 @@ type RepositoryParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/codepipeline/v1beta1/zz_codepipeline_types.go
+++ b/apis/codepipeline/v1beta1/zz_codepipeline_types.go
@@ -140,7 +140,7 @@ type CodepipelineParameters struct {
 	// +kubebuilder:validation:Required
 	Stage []StageParameters `json:"stage" tf:"stage,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/codepipeline/v1beta1/zz_webhook_types.go
+++ b/apis/codepipeline/v1beta1/zz_webhook_types.go
@@ -75,7 +75,7 @@ type WebhookParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/codestarconnections/v1beta1/zz_connection_types.go
+++ b/apis/codestarconnections/v1beta1/zz_connection_types.go
@@ -47,7 +47,7 @@ type ConnectionParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Map of key-value resource tags to associate with the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/codestarnotifications/v1beta1/zz_notificationrule_types.go
+++ b/apis/codestarnotifications/v1beta1/zz_notificationrule_types.go
@@ -67,7 +67,7 @@ type NotificationRuleParameters struct {
 	// +kubebuilder:validation:Optional
 	Status *string `json:"status,omitempty" tf:"status,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/cognitoidentity/v1beta1/zz_pool_types.go
+++ b/apis/cognitoidentity/v1beta1/zz_pool_types.go
@@ -102,7 +102,7 @@ type PoolParameters struct {
 	// +kubebuilder:validation:Optional
 	SupportedLoginProviders map[string]*string `json:"supportedLoginProviders,omitempty" tf:"supported_login_providers,omitempty"`
 
-	// A map of tags to assign to the Identity Pool. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/cognitoidp/v1beta1/zz_userpool_types.go
+++ b/apis/cognitoidp/v1beta1/zz_userpool_types.go
@@ -436,7 +436,7 @@ type UserPoolParameters struct {
 	// +kubebuilder:validation:Optional
 	SoftwareTokenMfaConfiguration []SoftwareTokenMfaConfigurationParameters `json:"softwareTokenMfaConfiguration,omitempty" tf:"software_token_mfa_configuration,omitempty"`
 
-	// Map of tags to assign to the User Pool. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/dax/v1beta1/zz_cluster_types.go
+++ b/apis/dax/v1beta1/zz_cluster_types.go
@@ -127,7 +127,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetGroupName *string `json:"subnetGroupName,omitempty" tf:"subnet_group_name,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/deploy/v1beta1/zz_app_types.go
+++ b/apis/deploy/v1beta1/zz_app_types.go
@@ -45,7 +45,7 @@ type AppParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/deploy/v1beta1/zz_deploymentgroup_types.go
+++ b/apis/deploy/v1beta1/zz_deploymentgroup_types.go
@@ -159,7 +159,7 @@ type DeploymentGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	ServiceRoleArnSelector *v1.Selector `json:"serviceRoleArnSelector,omitempty" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/docdb/v1beta1/zz_cluster_types.go
+++ b/apis/docdb/v1beta1/zz_cluster_types.go
@@ -144,7 +144,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageEncrypted *bool `json:"storageEncrypted,omitempty" tf:"storage_encrypted,omitempty"`
 
-	// A map of tags to assign to the DB cluster. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/docdb/v1beta1/zz_clusterinstance_types.go
+++ b/apis/docdb/v1beta1/zz_clusterinstance_types.go
@@ -108,7 +108,7 @@ type ClusterInstanceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/docdb/v1beta1/zz_subnetgroup_types.go
+++ b/apis/docdb/v1beta1/zz_subnetgroup_types.go
@@ -49,7 +49,7 @@ type SubnetGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIdsSelector *v1.Selector `json:"subnetIdsSelector,omitempty" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/dynamodb/v1beta1/zz_table_types.go
+++ b/apis/dynamodb/v1beta1/zz_table_types.go
@@ -236,7 +236,7 @@ type TableParameters struct {
 	// +kubebuilder:validation:Optional
 	TableClass *string `json:"tableClass,omitempty" tf:"table_class,omitempty"`
 
-	// A map of tags to populate on the created table. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_defaultroutetable_types.go
+++ b/apis/ec2/v1beta1/zz_defaultroutetable_types.go
@@ -60,7 +60,7 @@ type DefaultRouteTableParameters struct {
 	// +kubebuilder:validation:Optional
 	Route []RouteParameters `json:"route,omitempty" tf:"route,omitempty"`
 
-	// Map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_ebssnapshot_types.go
+++ b/apis/ec2/v1beta1/zz_ebssnapshot_types.go
@@ -66,7 +66,7 @@ type EBSSnapshotParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageTier *string `json:"storageTier,omitempty" tf:"storage_tier,omitempty"`
 
-	// A map of tags to assign to the snapshot. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_ebsvolume_types.go
+++ b/apis/ec2/v1beta1/zz_ebsvolume_types.go
@@ -73,7 +73,7 @@ type EBSVolumeParameters struct {
 	// +kubebuilder:validation:Optional
 	SnapshotID *string `json:"snapshotId,omitempty" tf:"snapshot_id,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_egressonlyinternetgateway_types.go
+++ b/apis/ec2/v1beta1/zz_egressonlyinternetgateway_types.go
@@ -29,7 +29,7 @@ type EgressOnlyInternetGatewayParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_eip_types.go
+++ b/apis/ec2/v1beta1/zz_eip_types.go
@@ -102,7 +102,7 @@ type EIPParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Map of tags to assign to the resource. Tags can only be applied to EIPs in a VPC. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_flowlog_types.go
+++ b/apis/ec2/v1beta1/zz_flowlog_types.go
@@ -118,7 +118,7 @@ type FlowLogParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_instance_types.go
+++ b/apis/ec2/v1beta1/zz_instance_types.go
@@ -330,7 +330,7 @@ type InstanceParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
-	// A map of tags to assign to the resource. Note that these tags apply to the instance and not block storage devices. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_internetgateway_types.go
+++ b/apis/ec2/v1beta1/zz_internetgateway_types.go
@@ -35,7 +35,7 @@ type InternetGatewayParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_keypair_types.go
+++ b/apis/ec2/v1beta1/zz_keypair_types.go
@@ -42,7 +42,7 @@ type KeyPairParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_launchtemplate_types.go
+++ b/apis/ec2/v1beta1/zz_launchtemplate_types.go
@@ -562,7 +562,7 @@ type LaunchTemplateParameters_2 struct {
 	// +kubebuilder:validation:Optional
 	TagSpecifications []TagSpecificationsParameters `json:"tagSpecifications,omitempty" tf:"tag_specifications,omitempty"`
 
-	// A map of tags to assign to the launch template. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_managedprefixlist_types.go
+++ b/apis/ec2/v1beta1/zz_managedprefixlist_types.go
@@ -78,7 +78,7 @@ type ManagedPrefixListParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Map of tags to assign to this resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_natgateway_types.go
+++ b/apis/ec2/v1beta1/zz_natgateway_types.go
@@ -69,7 +69,7 @@ type NATGatewayParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_networkacl_types.go
+++ b/apis/ec2/v1beta1/zz_networkacl_types.go
@@ -128,7 +128,7 @@ type NetworkACLParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_networkinterface_types.go
+++ b/apis/ec2/v1beta1/zz_networkinterface_types.go
@@ -151,7 +151,7 @@ type NetworkInterfaceParameters_2 struct {
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
-	// Map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_placementgroup_types.go
+++ b/apis/ec2/v1beta1/zz_placementgroup_types.go
@@ -45,7 +45,7 @@ type PlacementGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Strategy *string `json:"strategy" tf:"strategy,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_routetable_types.go
+++ b/apis/ec2/v1beta1/zz_routetable_types.go
@@ -42,7 +42,7 @@ type RouteTableParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_securitygroup_types.go
+++ b/apis/ec2/v1beta1/zz_securitygroup_types.go
@@ -119,7 +119,7 @@ type SecurityGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	RevokeRulesOnDelete *bool `json:"revokeRulesOnDelete,omitempty" tf:"revoke_rules_on_delete,omitempty"`
 
-	// Map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_spotinstancerequest_types.go
+++ b/apis/ec2/v1beta1/zz_spotinstancerequest_types.go
@@ -75,7 +75,7 @@ type SpotInstanceRequestEBSBlockDeviceParameters struct {
 	// +kubebuilder:validation:Optional
 	SnapshotID *string `json:"snapshotId,omitempty" tf:"snapshot_id,omitempty"`
 
-	// A map of tags to assign to the Spot Instance Request. These tags are not automatically applied to the launched Instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
@@ -152,7 +152,7 @@ type SpotInstanceRequestMetadataOptionsParameters struct {
 	// +kubebuilder:validation:Optional
 	HTTPTokens *string `json:"httpTokens,omitempty" tf:"http_tokens,omitempty"`
 
-	// A map of tags to assign to the Spot Instance Request. These tags are not automatically applied to the launched Instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	InstanceMetadataTags *string `json:"instanceMetadataTags,omitempty" tf:"instance_metadata_tags,omitempty"`
 }
@@ -372,7 +372,7 @@ type SpotInstanceRequestParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
-	// A map of tags to assign to the Spot Instance Request. These tags are not automatically applied to the launched Instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
@@ -410,7 +410,7 @@ type SpotInstanceRequestParameters struct {
 	// +kubebuilder:validation:Optional
 	ValidUntil *string `json:"validUntil,omitempty" tf:"valid_until,omitempty"`
 
-	// A map of tags to assign to the Spot Instance Request. These tags are not automatically applied to the launched Instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	VolumeTags map[string]*string `json:"volumeTags,omitempty" tf:"volume_tags,omitempty"`
 
@@ -440,7 +440,7 @@ type SpotInstanceRequestRootBlockDeviceParameters struct {
 	// +kubebuilder:validation:Optional
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 
-	// A map of tags to assign to the Spot Instance Request. These tags are not automatically applied to the launched Instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_subnet_types.go
+++ b/apis/ec2/v1beta1/zz_subnet_types.go
@@ -99,7 +99,7 @@ type SubnetParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_transitgateway_types.go
+++ b/apis/ec2/v1beta1/zz_transitgateway_types.go
@@ -68,7 +68,7 @@ type TransitGatewayParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value tags for the EC2 Transit Gateway. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_transitgatewaymulticastdomain_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewaymulticastdomain_types.go
@@ -47,7 +47,7 @@ type TransitGatewayMulticastDomainParameters struct {
 	// +kubebuilder:validation:Optional
 	StaticSourcesSupport *string `json:"staticSourcesSupport,omitempty" tf:"static_sources_support,omitempty"`
 
-	// Key-value tags for the EC2 Transit Gateway Multicast Domain. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_transitgatewaypeeringattachment_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewaypeeringattachment_types.go
@@ -51,7 +51,7 @@ type TransitGatewayPeeringAttachmentParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value tags for the EC2 Transit Gateway Peering Attachment. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_transitgatewayroutetable_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayroutetable_types.go
@@ -38,7 +38,7 @@ type TransitGatewayRouteTableParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value tags for the EC2 Transit Gateway Route Table. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_transitgatewayvpcattachment_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayvpcattachment_types.go
@@ -59,7 +59,7 @@ type TransitGatewayVPCAttachmentParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// Key-value tags for the EC2 Transit Gateway VPC Attachment. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_transitgatewayvpcattachmentaccepter_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayvpcattachmentaccepter_types.go
@@ -50,7 +50,7 @@ type TransitGatewayVPCAttachmentAccepterParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value tags for the EC2 Transit Gateway VPC Attachment. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_vpc_types.go
+++ b/apis/ec2/v1beta1/zz_vpc_types.go
@@ -110,7 +110,7 @@ type VPCParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_vpcdhcpoptions_types.go
+++ b/apis/ec2/v1beta1/zz_vpcdhcpoptions_types.go
@@ -55,7 +55,7 @@ type VPCDHCPOptionsParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_vpcendpoint_types.go
+++ b/apis/ec2/v1beta1/zz_vpcendpoint_types.go
@@ -102,7 +102,7 @@ type VPCEndpointParameters struct {
 	// +kubebuilder:validation:Optional
 	ServiceNameSelector *v1.Selector `json:"serviceNameSelector,omitempty" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ec2/v1beta1/zz_vpcendpointservice_types.go
+++ b/apis/ec2/v1beta1/zz_vpcendpointservice_types.go
@@ -90,7 +90,7 @@ type VPCEndpointServiceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ec2/v1beta1/zz_vpcpeeringconnection_types.go
+++ b/apis/ec2/v1beta1/zz_vpcpeeringconnection_types.go
@@ -107,7 +107,7 @@ type VPCPeeringConnectionParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ecr/v1beta1/zz_repository_types.go
+++ b/apis/ecr/v1beta1/zz_repository_types.go
@@ -83,7 +83,7 @@ type RepositoryParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ecs/v1beta1/zz_capacityprovider_types.go
+++ b/apis/ecs/v1beta1/zz_capacityprovider_types.go
@@ -64,7 +64,7 @@ type CapacityProviderParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ecs/v1beta1/zz_cluster_types.go
+++ b/apis/ecs/v1beta1/zz_cluster_types.go
@@ -47,7 +47,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	Setting []SettingParameters `json:"setting,omitempty" tf:"setting,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ecs/v1beta1/zz_service_types.go
+++ b/apis/ecs/v1beta1/zz_service_types.go
@@ -268,7 +268,7 @@ type ServiceParameters struct {
 	// +kubebuilder:validation:Optional
 	ServiceRegistries []ServiceRegistriesParameters `json:"serviceRegistries,omitempty" tf:"service_registries,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/ecs/v1beta1/zz_taskdefinition_types.go
+++ b/apis/ecs/v1beta1/zz_taskdefinition_types.go
@@ -257,7 +257,7 @@ type TaskDefinitionParameters struct {
 	// +kubebuilder:validation:Optional
 	SkipDestroy *bool `json:"skipDestroy,omitempty" tf:"skip_destroy,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/efs/v1beta1/zz_accesspoint_types.go
+++ b/apis/efs/v1beta1/zz_accesspoint_types.go
@@ -59,7 +59,7 @@ type AccessPointParameters struct {
 	// +kubebuilder:validation:Optional
 	RootDirectory []RootDirectoryParameters `json:"rootDirectory,omitempty" tf:"root_directory,omitempty"`
 
-	// Key-value mapping of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/efs/v1beta1/zz_filesystem_types.go
+++ b/apis/efs/v1beta1/zz_filesystem_types.go
@@ -87,7 +87,7 @@ type FileSystemParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the file system. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/eks/v1beta1/zz_addon_types.go
+++ b/apis/eks/v1beta1/zz_addon_types.go
@@ -85,7 +85,7 @@ type AddonParameters struct {
 	// +kubebuilder:validation:Optional
 	ServiceAccountRoleArnSelector *v1.Selector `json:"serviceAccountRoleArnSelector,omitempty" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/eks/v1beta1/zz_cluster_types.go
+++ b/apis/eks/v1beta1/zz_cluster_types.go
@@ -89,7 +89,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	RoleArnSelector *v1.Selector `json:"roleArnSelector,omitempty" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/eks/v1beta1/zz_fargateprofile_types.go
+++ b/apis/eks/v1beta1/zz_fargateprofile_types.go
@@ -81,7 +81,7 @@ type FargateProfileParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/eks/v1beta1/zz_identityproviderconfig_types.go
+++ b/apis/eks/v1beta1/zz_identityproviderconfig_types.go
@@ -86,7 +86,7 @@ type IdentityProviderConfigParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/eks/v1beta1/zz_nodegroup_types.go
+++ b/apis/eks/v1beta1/zz_nodegroup_types.go
@@ -148,7 +148,7 @@ type NodeGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/elasticache/v1beta1/zz_cluster_types.go
+++ b/apis/elasticache/v1beta1/zz_cluster_types.go
@@ -177,7 +177,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetGroupNameSelector *v1.Selector `json:"subnetGroupNameSelector,omitempty" tf:"-"`
 
-	// Map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/elasticache/v1beta1/zz_parametergroup_types.go
+++ b/apis/elasticache/v1beta1/zz_parametergroup_types.go
@@ -48,7 +48,7 @@ type ParameterGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value mapping of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/elasticache/v1beta1/zz_replicationgroup_types.go
+++ b/apis/elasticache/v1beta1/zz_replicationgroup_types.go
@@ -257,7 +257,7 @@ type ReplicationGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetGroupNameSelector *v1.Selector `json:"subnetGroupNameSelector,omitempty" tf:"-"`
 
-	// Map of tags to assign to the resource. Adding tags to this resource will add or overwrite any existing tags on the clusters in the replication group and not to the group itself. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/elasticache/v1beta1/zz_subnetgroup_types.go
+++ b/apis/elasticache/v1beta1/zz_subnetgroup_types.go
@@ -48,7 +48,7 @@ type SubnetGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/elasticache/v1beta1/zz_user_types.go
+++ b/apis/elasticache/v1beta1/zz_user_types.go
@@ -46,7 +46,7 @@ type UserParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A list of tags to be added to this resource. A tag is a key-value pair.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/elb/v1beta1/zz_elb_types.go
+++ b/apis/elb/v1beta1/zz_elb_types.go
@@ -142,7 +142,7 @@ type ELBParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetsSelector *v1.Selector `json:"subnetsSelector,omitempty" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/elbv2/v1beta1/zz_lb_types.go
+++ b/apis/elbv2/v1beta1/zz_lb_types.go
@@ -166,7 +166,7 @@ type LBParameters struct {
 	// +kubebuilder:validation:Optional
 	Subnets []*string `json:"subnets,omitempty" tf:"subnets,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/elbv2/v1beta1/zz_lblistener_types.go
+++ b/apis/elbv2/v1beta1/zz_lblistener_types.go
@@ -236,7 +236,7 @@ type LBListenerParameters struct {
 	// +kubebuilder:validation:Optional
 	SSLPolicy *string `json:"sslPolicy,omitempty" tf:"ssl_policy,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/elbv2/v1beta1/zz_lbtargetgroup_types.go
+++ b/apis/elbv2/v1beta1/zz_lbtargetgroup_types.go
@@ -129,7 +129,7 @@ type LBTargetGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	Stickiness []LBTargetGroupStickinessParameters `json:"stickiness,omitempty" tf:"stickiness,omitempty"`
 
-	// Map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/firehose/v1beta1/zz_deliverystream_types.go
+++ b/apis/firehose/v1beta1/zz_deliverystream_types.go
@@ -134,7 +134,7 @@ type DeliveryStreamParameters struct {
 	// +kubebuilder:validation:Optional
 	SplunkConfiguration []SplunkConfigurationParameters `json:"splunkConfiguration,omitempty" tf:"splunk_configuration,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/gamelift/v1beta1/zz_alias_types.go
+++ b/apis/gamelift/v1beta1/zz_alias_types.go
@@ -44,7 +44,7 @@ type AliasParameters struct {
 	// +kubebuilder:validation:Required
 	RoutingStrategy []RoutingStrategyParameters `json:"routingStrategy" tf:"routing_strategy,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/gamelift/v1beta1/zz_build_types.go
+++ b/apis/gamelift/v1beta1/zz_build_types.go
@@ -44,7 +44,7 @@ type BuildParameters struct {
 	// +kubebuilder:validation:Required
 	StorageLocation []StorageLocationParameters `json:"storageLocation" tf:"storage_location,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/gamelift/v1beta1/zz_fleet_types.go
+++ b/apis/gamelift/v1beta1/zz_fleet_types.go
@@ -146,7 +146,7 @@ type FleetParameters struct {
 	// +kubebuilder:validation:Optional
 	ScriptID *string `json:"scriptId,omitempty" tf:"script_id,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/gamelift/v1beta1/zz_gamesessionqueue_types.go
+++ b/apis/gamelift/v1beta1/zz_gamesessionqueue_types.go
@@ -39,7 +39,7 @@ type GameSessionQueueParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/gamelift/v1beta1/zz_script_types.go
+++ b/apis/gamelift/v1beta1/zz_script_types.go
@@ -40,7 +40,7 @@ type ScriptParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageLocation []ScriptStorageLocationParameters `json:"storageLocation,omitempty" tf:"storage_location,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/globalaccelerator/v1beta1/zz_accelerator_types.go
+++ b/apis/globalaccelerator/v1beta1/zz_accelerator_types.go
@@ -56,7 +56,7 @@ type AcceleratorParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/glue/v1beta1/zz_job_types.go
+++ b/apis/glue/v1beta1/zz_job_types.go
@@ -122,7 +122,7 @@ type JobParameters struct {
 	// +kubebuilder:validation:Optional
 	SecurityConfiguration *string `json:"securityConfiguration,omitempty" tf:"security_configuration,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/glue/v1beta1/zz_registry_types.go
+++ b/apis/glue/v1beta1/zz_registry_types.go
@@ -36,7 +36,7 @@ type RegistryParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/glue/v1beta1/zz_trigger_types.go
+++ b/apis/glue/v1beta1/zz_trigger_types.go
@@ -175,7 +175,7 @@ type TriggerParameters struct {
 	// +kubebuilder:validation:Optional
 	StartOnCreation *bool `json:"startOnCreation,omitempty" tf:"start_on_creation,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/glue/v1beta1/zz_workflow_types.go
+++ b/apis/glue/v1beta1/zz_workflow_types.go
@@ -44,7 +44,7 @@ type WorkflowParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/grafana/v1beta1/zz_workspace_types.go
+++ b/apis/grafana/v1beta1/zz_workspace_types.go
@@ -93,7 +93,7 @@ type WorkspaceParameters struct {
 	// +kubebuilder:validation:Optional
 	StackSetName *string `json:"stackSetName,omitempty" tf:"stack_set_name,omitempty"`
 
-	// Key-value mapping of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_instanceprofile_types.go
+++ b/apis/iam/v1beta1/zz_instanceprofile_types.go
@@ -50,7 +50,7 @@ type InstanceProfileParameters struct {
 	// +kubebuilder:validation:Optional
 	RoleSelector *v1.Selector `json:"roleSelector,omitempty" tf:"-"`
 
-	// Map of resource tags for the IAM Instance Profile. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_openidconnectprovider_types.go
+++ b/apis/iam/v1beta1/zz_openidconnectprovider_types.go
@@ -30,7 +30,7 @@ type OpenIDConnectProviderParameters struct {
 	// +kubebuilder:validation:Required
 	ClientIDList []*string `json:"clientIdList" tf:"client_id_list,omitempty"`
 
-	// Map of resource tags for the IAM OIDC provider. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/iam/v1beta1/zz_policy_types.go
+++ b/apis/iam/v1beta1/zz_policy_types.go
@@ -43,7 +43,7 @@ type PolicyParameters struct {
 	// +kubebuilder:validation:Required
 	Policy *string `json:"policy" tf:"policy,omitempty"`
 
-	// Map of resource tags for the IAM Policy. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_role_types.go
+++ b/apis/iam/v1beta1/zz_role_types.go
@@ -75,7 +75,7 @@ type RoleParameters struct {
 	// +kubebuilder:validation:Optional
 	PermissionsBoundary *string `json:"permissionsBoundary,omitempty" tf:"permissions_boundary,omitempty"`
 
-	// Key-value mapping of tags for the IAM role. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_samlprovider_types.go
+++ b/apis/iam/v1beta1/zz_samlprovider_types.go
@@ -33,7 +33,7 @@ type SAMLProviderParameters struct {
 	// +kubebuilder:validation:Required
 	SAMLMetadataDocument *string `json:"samlMetadataDocument" tf:"saml_metadata_document,omitempty"`
 
-	// Map of resource tags for the IAM SAML provider. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_servercertificate_types.go
+++ b/apis/iam/v1beta1/zz_servercertificate_types.go
@@ -53,7 +53,7 @@ type ServerCertificateParameters struct {
 	// +kubebuilder:validation:Required
 	PrivateKeySecretRef v1.SecretKeySelector `json:"privateKeySecretRef" tf:"-"`
 
-	// Map of resource tags for the server certificate. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_servicelinkedrole_types.go
+++ b/apis/iam/v1beta1/zz_servicelinkedrole_types.go
@@ -51,7 +51,7 @@ type ServiceLinkedRoleParameters struct {
 	// +kubebuilder:validation:Optional
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
-	// Key-value mapping of tags for the IAM role. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_user_types.go
+++ b/apis/iam/v1beta1/zz_user_types.go
@@ -44,7 +44,7 @@ type UserParameters struct {
 	// +kubebuilder:validation:Optional
 	PermissionsBoundary *string `json:"permissionsBoundary,omitempty" tf:"permissions_boundary,omitempty"`
 
-	// Key-value map of tags for the IAM user. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/iam/v1beta1/zz_virtualmfadevice_types.go
+++ b/apis/iam/v1beta1/zz_virtualmfadevice_types.go
@@ -36,7 +36,7 @@ type VirtualMfaDeviceParameters struct {
 	// +kubebuilder:validation:Optional
 	Path *string `json:"path,omitempty" tf:"path,omitempty"`
 
-	// Map of resource tags for the virtual mfa device. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/kafka/v1beta1/zz_cluster_types.go
+++ b/apis/kafka/v1beta1/zz_cluster_types.go
@@ -209,7 +209,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/kinesis/v1beta1/zz_stream_types.go
+++ b/apis/kinesis/v1beta1/zz_stream_types.go
@@ -80,7 +80,7 @@ type StreamParameters struct {
 	// +kubebuilder:validation:Optional
 	StreamModeDetails []StreamModeDetailsParameters `json:"streamModeDetails,omitempty" tf:"stream_mode_details,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/kinesisanalytics/v1beta1/zz_application_types.go
+++ b/apis/kinesisanalytics/v1beta1/zz_application_types.go
@@ -93,7 +93,7 @@ type ApplicationParameters struct {
 	// +kubebuilder:validation:Optional
 	StartApplication *bool `json:"startApplication,omitempty" tf:"start_application,omitempty"`
 
-	// Key-value map of tags for the Kinesis Analytics Application. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/kinesisanalyticsv2/v1beta1/zz_application_types.go
+++ b/apis/kinesisanalyticsv2/v1beta1/zz_application_types.go
@@ -146,7 +146,7 @@ type ApplicationParameters struct {
 	// +kubebuilder:validation:Optional
 	StartApplication *bool `json:"startApplication,omitempty" tf:"start_application,omitempty"`
 
-	// A map of tags to assign to the application. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/kinesisvideo/v1beta1/zz_stream_types.go
+++ b/apis/kinesisvideo/v1beta1/zz_stream_types.go
@@ -68,7 +68,7 @@ type StreamParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/kms/v1beta1/zz_externalkey_types.go
+++ b/apis/kms/v1beta1/zz_externalkey_types.go
@@ -69,7 +69,7 @@ type ExternalKeyParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A key-value map of tags to assign to the key. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/kms/v1beta1/zz_key_types.go
+++ b/apis/kms/v1beta1/zz_key_types.go
@@ -77,7 +77,7 @@ type KeyParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the object. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/lambda/v1beta1/zz_function_types.go
+++ b/apis/lambda/v1beta1/zz_function_types.go
@@ -226,7 +226,7 @@ type FunctionParameters struct {
 	// +kubebuilder:validation:Optional
 	SourceCodeHash *string `json:"sourceCodeHash,omitempty" tf:"source_code_hash,omitempty"`
 
-	// Map of tags to assign to the object. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/licensemanager/v1beta1/zz_licenseconfiguration_types.go
+++ b/apis/licensemanager/v1beta1/zz_licenseconfiguration_types.go
@@ -59,7 +59,7 @@ type LicenseConfigurationParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/mq/v1beta1/zz_broker_types.go
+++ b/apis/mq/v1beta1/zz_broker_types.go
@@ -114,7 +114,7 @@ type BrokerParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// Map of tags to assign to the broker. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/mq/v1beta1/zz_configuration_types.go
+++ b/apis/mq/v1beta1/zz_configuration_types.go
@@ -59,7 +59,7 @@ type ConfigurationParameters_2 struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/neptune/v1beta1/zz_cluster_types.go
+++ b/apis/neptune/v1beta1/zz_cluster_types.go
@@ -187,7 +187,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageEncrypted *bool `json:"storageEncrypted,omitempty" tf:"storage_encrypted,omitempty"`
 
-	// A map of tags to assign to the Neptune cluster. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/neptune/v1beta1/zz_clusterendpoint_types.go
+++ b/apis/neptune/v1beta1/zz_clusterendpoint_types.go
@@ -60,7 +60,7 @@ type ClusterEndpointParameters struct {
 	// +kubebuilder:validation:Optional
 	StaticMembers []*string `json:"staticMembers,omitempty" tf:"static_members,omitempty"`
 
-	// A map of tags to assign to the Neptune cluster. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/neptune/v1beta1/zz_clusterinstance_types.go
+++ b/apis/neptune/v1beta1/zz_clusterinstance_types.go
@@ -135,7 +135,7 @@ type ClusterInstanceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/neptune/v1beta1/zz_clusterparametergroup_types.go
+++ b/apis/neptune/v1beta1/zz_clusterparametergroup_types.go
@@ -44,7 +44,7 @@ type ClusterParameterGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/neptune/v1beta1/zz_eventsubscription_types.go
+++ b/apis/neptune/v1beta1/zz_eventsubscription_types.go
@@ -65,7 +65,7 @@ type EventSubscriptionParameters struct {
 	// +kubebuilder:validation:Optional
 	SourceType *string `json:"sourceType,omitempty" tf:"source_type,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/neptune/v1beta1/zz_parametergroup_types.go
+++ b/apis/neptune/v1beta1/zz_parametergroup_types.go
@@ -62,7 +62,7 @@ type ParameterGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/neptune/v1beta1/zz_subnetgroup_types.go
+++ b/apis/neptune/v1beta1/zz_subnetgroup_types.go
@@ -51,7 +51,7 @@ type SubnetGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/ram/v1beta1/zz_resourceshare_types.go
+++ b/apis/ram/v1beta1/zz_resourceshare_types.go
@@ -40,7 +40,7 @@ type ResourceShareParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource share. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_cluster_types.go
+++ b/apis/rds/v1beta1/zz_cluster_types.go
@@ -229,7 +229,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageType *string `json:"storageType,omitempty" tf:"storage_type,omitempty"`
 
-	// A map of tags to assign to the DB cluster. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/rds/v1beta1/zz_clusterendpoint_types.go
+++ b/apis/rds/v1beta1/zz_clusterendpoint_types.go
@@ -61,7 +61,7 @@ type ClusterEndpointParameters struct {
 	// +kubebuilder:validation:Optional
 	StaticMembers []*string `json:"staticMembers,omitempty" tf:"static_members,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_clusterinstance_types.go
+++ b/apis/rds/v1beta1/zz_clusterinstance_types.go
@@ -182,7 +182,7 @@ type ClusterInstanceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the instance. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_clusterparametergroup_types.go
+++ b/apis/rds/v1beta1/zz_clusterparametergroup_types.go
@@ -64,7 +64,7 @@ type ClusterParameterGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_instance_types.go
+++ b/apis/rds/v1beta1/zz_instance_types.go
@@ -353,7 +353,7 @@ type InstanceParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageType *string `json:"storageType,omitempty" tf:"storage_type,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/rds/v1beta1/zz_optiongroup_types.go
+++ b/apis/rds/v1beta1/zz_optiongroup_types.go
@@ -48,7 +48,7 @@ type OptionGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_parametergroup_types.go
+++ b/apis/rds/v1beta1/zz_parametergroup_types.go
@@ -44,7 +44,7 @@ type ParameterGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_proxy_types.go
+++ b/apis/rds/v1beta1/zz_proxy_types.go
@@ -105,7 +105,7 @@ type ProxyParameters struct {
 	// +kubebuilder:validation:Optional
 	RoleArnSelector *v1.Selector `json:"roleArnSelector,omitempty" tf:"-"`
 
-	// A mapping of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/rds/v1beta1/zz_proxyendpoint_types.go
+++ b/apis/rds/v1beta1/zz_proxyendpoint_types.go
@@ -53,7 +53,7 @@ type ProxyEndpointParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A mapping of tags to assign to the resource.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/rds/v1beta1/zz_securitygroup_types.go
+++ b/apis/rds/v1beta1/zz_securitygroup_types.go
@@ -63,7 +63,7 @@ type SecurityGroupParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_snapshot_types.go
+++ b/apis/rds/v1beta1/zz_snapshot_types.go
@@ -91,7 +91,7 @@ type SnapshotParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/rds/v1beta1/zz_subnetgroup_types.go
+++ b/apis/rds/v1beta1/zz_subnetgroup_types.go
@@ -51,7 +51,7 @@ type SubnetGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	SubnetIds []*string `json:"subnetIds,omitempty" tf:"subnet_ids,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/redshift/v1beta1/zz_cluster_types.go
+++ b/apis/redshift/v1beta1/zz_cluster_types.go
@@ -209,7 +209,7 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	SnapshotIdentifier *string `json:"snapshotIdentifier,omitempty" tf:"snapshot_identifier,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/resourcegroups/v1beta1/zz_group_types.go
+++ b/apis/resourcegroups/v1beta1/zz_group_types.go
@@ -39,7 +39,7 @@ type GroupParameters struct {
 	// +kubebuilder:validation:Required
 	ResourceQuery []ResourceQueryParameters `json:"resourceQuery" tf:"resource_query,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/route53/v1beta1/zz_healthcheck_types.go
+++ b/apis/route53/v1beta1/zz_healthcheck_types.go
@@ -118,7 +118,7 @@ type HealthCheckParameters struct {
 	// +kubebuilder:validation:Optional
 	SearchString *string `json:"searchString,omitempty" tf:"search_string,omitempty"`
 
-	// A map of tags to assign to the health check. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/route53/v1beta1/zz_zone_types.go
+++ b/apis/route53/v1beta1/zz_zone_types.go
@@ -77,7 +77,7 @@ type ZoneParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the zone. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/route53resolver/v1beta1/zz_endpoint_types.go
+++ b/apis/route53resolver/v1beta1/zz_endpoint_types.go
@@ -70,7 +70,7 @@ type EndpointParameters struct {
 	// +kubebuilder:validation:Optional
 	SecurityGroupIds []*string `json:"securityGroupIds,omitempty" tf:"security_group_ids,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/route53resolver/v1beta1/zz_rule_types.go
+++ b/apis/route53resolver/v1beta1/zz_rule_types.go
@@ -66,7 +66,7 @@ type RuleParameters struct {
 	// +kubebuilder:validation:Required
 	RuleType *string `json:"ruleType" tf:"rule_type,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/s3/v1beta1/zz_bucket_types.go
+++ b/apis/s3/v1beta1/zz_bucket_types.go
@@ -126,7 +126,7 @@ type BucketParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the bucket. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/s3/v1beta1/zz_bucketanalyticsconfiguration_types.go
+++ b/apis/s3/v1beta1/zz_bucketanalyticsconfiguration_types.go
@@ -22,7 +22,7 @@ type BucketAnalyticsConfigurationFilterParameters struct {
 	// +kubebuilder:validation:Optional
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
-	// Set of object tags for filtering.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/s3/v1beta1/zz_bucketintelligenttieringconfiguration_types.go
+++ b/apis/s3/v1beta1/zz_bucketintelligenttieringconfiguration_types.go
@@ -22,7 +22,7 @@ type BucketIntelligentTieringConfigurationFilterParameters struct {
 	// +kubebuilder:validation:Optional
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
-	// All of these tags must exist in the object's tag set in order for the configuration to apply.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/s3/v1beta1/zz_bucketmetric_types.go
+++ b/apis/s3/v1beta1/zz_bucketmetric_types.go
@@ -22,7 +22,7 @@ type BucketMetricFilterParameters struct {
 	// +kubebuilder:validation:Optional
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
-	// Object tags for filtering (up to 10).
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/s3/v1beta1/zz_bucketobject_types.go
+++ b/apis/s3/v1beta1/zz_bucketobject_types.go
@@ -139,7 +139,7 @@ type BucketObjectParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageClass *string `json:"storageClass,omitempty" tf:"storage_class,omitempty"`
 
-	// Map of tags to assign to the object. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/s3/v1beta1/zz_object_types.go
+++ b/apis/s3/v1beta1/zz_object_types.go
@@ -139,7 +139,7 @@ type ObjectParameters struct {
 	// +kubebuilder:validation:Optional
 	StorageClass *string `json:"storageClass,omitempty" tf:"storage_class,omitempty"`
 
-	// Map of tags to assign to the object. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/secretsmanager/v1beta1/zz_secret_types.go
+++ b/apis/secretsmanager/v1beta1/zz_secret_types.go
@@ -114,7 +114,7 @@ type SecretParameters struct {
 	// +kubebuilder:validation:Optional
 	Replica []ReplicaParameters `json:"replica,omitempty" tf:"replica,omitempty"`
 
-	// Key-value map of user-defined tags that are attached to the secret. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/servicediscovery/v1beta1/zz_httpnamespace_types.go
+++ b/apis/servicediscovery/v1beta1/zz_httpnamespace_types.go
@@ -40,7 +40,7 @@ type HTTPNamespaceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the namespace. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/servicediscovery/v1beta1/zz_privatednsnamespace_types.go
+++ b/apis/servicediscovery/v1beta1/zz_privatednsnamespace_types.go
@@ -43,7 +43,7 @@ type PrivateDNSNamespaceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the namespace. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/servicediscovery/v1beta1/zz_publicdnsnamespace_types.go
+++ b/apis/servicediscovery/v1beta1/zz_publicdnsnamespace_types.go
@@ -43,7 +43,7 @@ type PublicDNSNamespaceParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// A map of tags to assign to the namespace. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/sfn/v1beta1/zz_activity_types.go
+++ b/apis/sfn/v1beta1/zz_activity_types.go
@@ -32,7 +32,7 @@ type ActivityParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/sfn/v1beta1/zz_statemachine_types.go
+++ b/apis/sfn/v1beta1/zz_statemachine_types.go
@@ -77,7 +77,7 @@ type StateMachineParameters struct {
 	// +kubebuilder:validation:Optional
 	RoleArnSelector *v1.Selector `json:"roleArnSelector,omitempty" tf:"-"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/signer/v1beta1/zz_signingprofile_types.go
+++ b/apis/signer/v1beta1/zz_signingprofile_types.go
@@ -77,7 +77,7 @@ type SigningProfileParameters struct {
 	// +kubebuilder:validation:Optional
 	SignatureValidityPeriod []SignatureValidityPeriodParameters `json:"signatureValidityPeriod,omitempty" tf:"signature_validity_period,omitempty"`
 
-	// A list of tags associated with the signing profile. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/sns/v1beta1/zz_topic_types.go
+++ b/apis/sns/v1beta1/zz_topic_types.go
@@ -219,7 +219,7 @@ type TopicParameters struct {
 	// +kubebuilder:validation:Optional
 	SqsSuccessFeedbackSampleRate *float64 `json:"sqsSuccessFeedbackSampleRate,omitempty" tf:"sqs_success_feedback_sample_rate,omitempty"`
 
-	// Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/apis/sqs/v1beta1/zz_queue_types.go
+++ b/apis/sqs/v1beta1/zz_queue_types.go
@@ -95,7 +95,7 @@ type QueueParameters struct {
 	// +kubebuilder:validation:Optional
 	SqsManagedSseEnabled *bool `json:"sqsManagedSseEnabled,omitempty" tf:"sqs_managed_sse_enabled,omitempty"`
 
-	// A map of tags to assign to the queue. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/transfer/v1beta1/zz_server_types.go
+++ b/apis/transfer/v1beta1/zz_server_types.go
@@ -158,7 +158,7 @@ type ServerParameters struct {
 	// +kubebuilder:validation:Optional
 	SecurityPolicyName *string `json:"securityPolicyName,omitempty" tf:"security_policy_name,omitempty"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 

--- a/apis/transfer/v1beta1/zz_user_types.go
+++ b/apis/transfer/v1beta1/zz_user_types.go
@@ -110,7 +110,7 @@ type UserParameters struct {
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 
-	// A map of tags to assign to the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	// Key-value map of resource tags.
 	// +kubebuilder:validation:Optional
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -165,3 +165,16 @@ func AddExternalTagsField() config.ResourceOption {
 		}
 	}
 }
+
+// DocumentationForTags overrides the API documentation of the tags fields since
+// it contains Terraform-specific feature call out.
+func DocumentationForTags() config.ResourceOption {
+	return func(r *config.Resource) {
+		if r.MetaResource == nil {
+			return
+		}
+		if _, ok := r.MetaResource.ArgumentDocs["tags"]; ok {
+			r.MetaResource.ArgumentDocs["tags"] = "- (Optional) Key-value map of resource tags."
+		}
+	}
+}

--- a/config/provider.go
+++ b/config/provider.go
@@ -130,6 +130,7 @@ func GetProvider() *config.Provider {
 			AddExternalTagsField(),
 			ExternalNameConfigurations(),
 			NamePrefixRemoval(),
+			DocumentationForTags(),
 		),
 	)
 

--- a/package/crds/acm.aws.upbound.io_certificates.yaml
+++ b/package/crds/acm.aws.upbound.io_certificates.yaml
@@ -120,9 +120,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   validationMethod:
                     description: Which method to use for validation.

--- a/package/crds/acmpca.aws.upbound.io_certificateauthorities.yaml
+++ b/package/crds/acmpca.aws.upbound.io_certificateauthorities.yaml
@@ -233,10 +233,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Specifies a key-value map of user-defined tags that
-                      are attached to the certificate authority. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   type:
                     description: 'The type of the certificate authority. Defaults

--- a/package/crds/amp.aws.upbound.io_workspaces.yaml
+++ b/package/crds/amp.aws.upbound.io_workspaces.yaml
@@ -75,9 +75,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/apigateway.aws.upbound.io_apikeys.yaml
+++ b/package/crds/apigateway.aws.upbound.io_apikeys.yaml
@@ -81,9 +81,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   valueSecretRef:
                     description: The value of the API key. If not specified, it will

--- a/package/crds/apigateway.aws.upbound.io_clientcertificates.yaml
+++ b/package/crds/apigateway.aws.upbound.io_clientcertificates.yaml
@@ -74,9 +74,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/apigateway.aws.upbound.io_domainnames.yaml
+++ b/package/crds/apigateway.aws.upbound.io_domainnames.yaml
@@ -334,9 +334,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - domainName

--- a/package/crds/apigateway.aws.upbound.io_restapis.yaml
+++ b/package/crds/apigateway.aws.upbound.io_restapis.yaml
@@ -174,9 +174,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/apigateway.aws.upbound.io_stages.yaml
+++ b/package/crds/apigateway.aws.upbound.io_stages.yaml
@@ -292,9 +292,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   variables:
                     additionalProperties:

--- a/package/crds/apigateway.aws.upbound.io_usageplans.yaml
+++ b/package/crds/apigateway.aws.upbound.io_usageplans.yaml
@@ -293,9 +293,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   throttleSettings:
                     description: The throttling limits of the usage plan.

--- a/package/crds/apigateway.aws.upbound.io_vpclinks.yaml
+++ b/package/crds/apigateway.aws.upbound.io_vpclinks.yaml
@@ -77,9 +77,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   targetArnRefs:
                     description: References to LB in elbv2 to populate targetArns.

--- a/package/crds/apigatewayv2.aws.upbound.io_apis.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_apis.yaml
@@ -151,9 +151,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the API. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   target:
                     description: Part of quick create. Quick create produces an API

--- a/package/crds/apigatewayv2.aws.upbound.io_domainnames.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_domainnames.yaml
@@ -200,9 +200,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the domain name. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - domainNameConfiguration

--- a/package/crds/apigatewayv2.aws.upbound.io_stages.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_stages.yaml
@@ -325,9 +325,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the stage. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/apigatewayv2.aws.upbound.io_vpclinks.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_vpclinks.yaml
@@ -239,9 +239,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the VPC Link. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/athena.aws.upbound.io_datacatalogs.yaml
+++ b/package/crds/athena.aws.upbound.io_datacatalogs.yaml
@@ -81,9 +81,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   type:
                     description: 'The type of data catalog: LAMBDA for a federated

--- a/package/crds/athena.aws.upbound.io_workgroups.yaml
+++ b/package/crds/athena.aws.upbound.io_workgroups.yaml
@@ -265,10 +265,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags for the workgroup.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/autoscaling.aws.upbound.io_autoscalinggroups.yaml
+++ b/package/crds/autoscaling.aws.upbound.io_autoscalinggroups.yaml
@@ -884,8 +884,7 @@ spec:
                       type: object
                     type: array
                   tags:
-                    description: Set of maps containing resource tags. Conflicts with
-                      tag. See Tags below for more details.
+                    description: Key-value map of resource tags.
                     items:
                       additionalProperties:
                         type: string

--- a/package/crds/backup.aws.upbound.io_frameworks.yaml
+++ b/package/crds/backup.aws.upbound.io_frameworks.yaml
@@ -119,11 +119,7 @@ spec:
                               tags:
                                 additionalProperties:
                                   type: string
-                                description: Metadata that you can assign to help
-                                  organize the frameworks you create. If configured
-                                  with a provider default_tags configuration block
-                                  present, tags with matching keys will overwrite
-                                  those defined at the provider-level.
+                                description: Key-value map of resource tags.
                                 type: object
                             type: object
                           type: array
@@ -147,10 +143,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Metadata that you can assign to help organize the
-                      frameworks you create. If configured with a provider default_tags
-                      configuration block present, tags with matching keys will overwrite
-                      those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - control

--- a/package/crds/backup.aws.upbound.io_plans.yaml
+++ b/package/crds/backup.aws.upbound.io_plans.yaml
@@ -261,10 +261,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Metadata that you can assign to help organize the
-                      plans you create. If configured with a provider default_tags
-                      configuration block present, tags with matching keys will overwrite
-                      those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/backup.aws.upbound.io_reportplans.yaml
+++ b/package/crds/backup.aws.upbound.io_reportplans.yaml
@@ -134,10 +134,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Metadata that you can assign to help organize the
-                      report plans you create. If configured with a provider default_tags
-                      configuration block present, tags with matching keys will overwrite
-                      those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/backup.aws.upbound.io_vaults.yaml
+++ b/package/crds/backup.aws.upbound.io_vaults.yaml
@@ -148,10 +148,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Metadata that you can assign to help organize the
-                      resources that you create. If configured with a provider default_tags
-                      configuration block present, tags with matching keys will overwrite
-                      those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/cloudfront.aws.upbound.io_distributions.yaml
+++ b/package/crds/cloudfront.aws.upbound.io_distributions.yaml
@@ -984,9 +984,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   viewerCertificate:
                     description: The SSL configuration for this distribution (maximum

--- a/package/crds/cloudwatch.aws.upbound.io_compositealarms.yaml
+++ b/package/crds/cloudwatch.aws.upbound.io_compositealarms.yaml
@@ -258,10 +258,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to associate with the alarm. Up to
-                      50 tags are allowed. If configured with a provider default_tags
-                      configuration block present, tags with matching keys will overwrite
-                      those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - alarmRule

--- a/package/crds/cloudwatch.aws.upbound.io_metricalarms.yaml
+++ b/package/crds/cloudwatch.aws.upbound.io_metricalarms.yaml
@@ -233,9 +233,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   threshold:
                     description: The value against which the specified statistic is

--- a/package/crds/cloudwatch.aws.upbound.io_metricstreams.yaml
+++ b/package/crds/cloudwatch.aws.upbound.io_metricstreams.yaml
@@ -265,9 +265,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/cloudwatchlogs.aws.upbound.io_groups.yaml
+++ b/package/crds/cloudwatchlogs.aws.upbound.io_groups.yaml
@@ -159,9 +159,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/codecommit.aws.upbound.io_repositories.yaml
+++ b/package/crds/codecommit.aws.upbound.io_repositories.yaml
@@ -79,9 +79,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/codepipeline.aws.upbound.io_codepipelines.yaml
+++ b/package/crds/codepipeline.aws.upbound.io_codepipelines.yaml
@@ -351,9 +351,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - artifactStore

--- a/package/crds/codepipeline.aws.upbound.io_webhooks.yaml
+++ b/package/crds/codepipeline.aws.upbound.io_webhooks.yaml
@@ -122,9 +122,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   targetAction:
                     description: The name of the action in a pipeline you want to

--- a/package/crds/codestarconnections.aws.upbound.io_connections.yaml
+++ b/package/crds/codestarconnections.aws.upbound.io_connections.yaml
@@ -86,10 +86,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of key-value resource tags to associate with
-                      the resource. If configured with a provider default_tags configuration
-                      block present, tags with matching keys will overwrite those
-                      defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/codestarnotifications.aws.upbound.io_notificationrules.yaml
+++ b/package/crds/codestarnotifications.aws.upbound.io_notificationrules.yaml
@@ -167,9 +167,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   target:
                     description: Configuration blocks containing notification target

--- a/package/crds/cognitoidentity.aws.upbound.io_pools.yaml
+++ b/package/crds/cognitoidentity.aws.upbound.io_pools.yaml
@@ -278,10 +278,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the Identity Pool. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - identityPoolName

--- a/package/crds/cognitoidp.aws.upbound.io_userpools.yaml
+++ b/package/crds/cognitoidp.aws.upbound.io_userpools.yaml
@@ -523,9 +523,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the User Pool. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   userPoolAddOns:
                     description: Configuration block for user pool add-ons to enable

--- a/package/crds/dax.aws.upbound.io_clusters.yaml
+++ b/package/crds/dax.aws.upbound.io_clusters.yaml
@@ -277,9 +277,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - nodeType

--- a/package/crds/deploy.aws.upbound.io_apps.yaml
+++ b/package/crds/deploy.aws.upbound.io_apps.yaml
@@ -74,9 +74,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/deploy.aws.upbound.io_deploymentgroups.yaml
+++ b/package/crds/deploy.aws.upbound.io_deploymentgroups.yaml
@@ -839,9 +839,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   triggerConfiguration:
                     description: Configuration block(s) of the triggers for the deployment

--- a/package/crds/docdb.aws.upbound.io_clusterinstances.yaml
+++ b/package/crds/docdb.aws.upbound.io_clusterinstances.yaml
@@ -184,9 +184,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the instance. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - instanceClass

--- a/package/crds/docdb.aws.upbound.io_clusters.yaml
+++ b/package/crds/docdb.aws.upbound.io_clusters.yaml
@@ -247,9 +247,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the DB cluster. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcSecurityGroupIdRefs:
                     description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.

--- a/package/crds/docdb.aws.upbound.io_subnetgroups.yaml
+++ b/package/crds/docdb.aws.upbound.io_subnetgroups.yaml
@@ -156,9 +156,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/dynamodb.aws.upbound.io_tables.yaml
+++ b/package/crds/dynamodb.aws.upbound.io_tables.yaml
@@ -257,10 +257,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to populate on the created table. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   ttl:
                     description: 'Defines ttl, has two properties, and can only be

--- a/package/crds/ec2.aws.upbound.io_defaultroutetables.yaml
+++ b/package/crds/ec2.aws.upbound.io_defaultroutetables.yaml
@@ -357,9 +357,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ec2.aws.upbound.io_ebssnapshots.yaml
+++ b/package/crds/ec2.aws.upbound.io_ebssnapshots.yaml
@@ -86,9 +86,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the snapshot. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   temporaryRestoreDays:
                     description: Specifies the number of days for which to temporarily

--- a/package/crds/ec2.aws.upbound.io_ebsvolumes.yaml
+++ b/package/crds/ec2.aws.upbound.io_ebsvolumes.yaml
@@ -171,9 +171,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   throughput:
                     description: The throughput that the volume supports, in MiB/s.

--- a/package/crds/ec2.aws.upbound.io_egressonlyinternetgateways.yaml
+++ b/package/crds/ec2.aws.upbound.io_egressonlyinternetgateways.yaml
@@ -72,9 +72,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcId:
                     description: The VPC ID to create in.

--- a/package/crds/ec2.aws.upbound.io_eips.yaml
+++ b/package/crds/ec2.aws.upbound.io_eips.yaml
@@ -245,10 +245,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. Tags can only
-                      be applied to EIPs in a VPC. If configured with a provider default_tags
-                      configuration block present, tags with matching keys will overwrite
-                      those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpc:
                     description: Boolean if the EIP is in a VPC or not.

--- a/package/crds/ec2.aws.upbound.io_flowlogs.yaml
+++ b/package/crds/ec2.aws.upbound.io_flowlogs.yaml
@@ -343,9 +343,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   trafficType:
                     description: 'The type of traffic to capture. Valid values: ACCEPT,REJECT,

--- a/package/crds/ec2.aws.upbound.io_instances.yaml
+++ b/package/crds/ec2.aws.upbound.io_instances.yaml
@@ -751,11 +751,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. Note that
-                      these tags apply to the instance and not block storage devices.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   tenancy:
                     description: Tenancy of the instance (if the instance is running

--- a/package/crds/ec2.aws.upbound.io_internetgateways.yaml
+++ b/package/crds/ec2.aws.upbound.io_internetgateways.yaml
@@ -71,9 +71,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcId:
                     description: The VPC ID to create in.  See the aws_internet_gateway_attachment

--- a/package/crds/ec2.aws.upbound.io_keypairs.yaml
+++ b/package/crds/ec2.aws.upbound.io_keypairs.yaml
@@ -75,9 +75,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - publicKey

--- a/package/crds/ec2.aws.upbound.io_launchtemplates.yaml
+++ b/package/crds/ec2.aws.upbound.io_launchtemplates.yaml
@@ -1319,10 +1319,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the launch template. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   updateDefaultVersion:
                     description: Whether to update Default Version each update. Conflicts

--- a/package/crds/ec2.aws.upbound.io_managedprefixlists.yaml
+++ b/package/crds/ec2.aws.upbound.io_managedprefixlists.yaml
@@ -176,9 +176,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to this resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - addressFamily

--- a/package/crds/ec2.aws.upbound.io_natgateways.yaml
+++ b/package/crds/ec2.aws.upbound.io_natgateways.yaml
@@ -229,9 +229,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ec2.aws.upbound.io_networkacls.yaml
+++ b/package/crds/ec2.aws.upbound.io_networkacls.yaml
@@ -153,9 +153,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcId:
                     description: The ID of the associated VPC.

--- a/package/crds/ec2.aws.upbound.io_networkinterfaces.yaml
+++ b/package/crds/ec2.aws.upbound.io_networkinterfaces.yaml
@@ -304,9 +304,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ec2.aws.upbound.io_placementgroups.yaml
+++ b/package/crds/ec2.aws.upbound.io_placementgroups.yaml
@@ -80,9 +80,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ec2.aws.upbound.io_routetables.yaml
+++ b/package/crds/ec2.aws.upbound.io_routetables.yaml
@@ -71,9 +71,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcId:
                     description: The VPC ID.

--- a/package/crds/ec2.aws.upbound.io_securitygroups.yaml
+++ b/package/crds/ec2.aws.upbound.io_securitygroups.yaml
@@ -88,9 +88,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcId:
                     description: VPC ID.

--- a/package/crds/ec2.aws.upbound.io_spotinstancerequests.yaml
+++ b/package/crds/ec2.aws.upbound.io_spotinstancerequests.yaml
@@ -131,11 +131,7 @@ spec:
                         tags:
                           additionalProperties:
                             type: string
-                          description: A map of tags to assign to the Spot Instance
-                            Request. These tags are not automatically applied to the
-                            launched Instance. If configured with a provider default_tags
-                            configuration block present, tags with matching keys will
-                            overwrite those defined at the provider-level.
+                          description: Key-value map of resource tags.
                           type: object
                         throughput:
                           type: number
@@ -229,11 +225,7 @@ spec:
                         httpTokens:
                           type: string
                         instanceMetadataTags:
-                          description: A map of tags to assign to the Spot Instance
-                            Request. These tags are not automatically applied to the
-                            launched Instance. If configured with a provider default_tags
-                            configuration block present, tags with matching keys will
-                            overwrite those defined at the provider-level.
+                          description: Key-value map of resource tags.
                           type: string
                       type: object
                     type: array
@@ -282,11 +274,7 @@ spec:
                         tags:
                           additionalProperties:
                             type: string
-                          description: A map of tags to assign to the Spot Instance
-                            Request. These tags are not automatically applied to the
-                            launched Instance. If configured with a provider default_tags
-                            configuration block present, tags with matching keys will
-                            overwrite those defined at the provider-level.
+                          description: Key-value map of resource tags.
                           type: object
                         throughput:
                           type: number
@@ -392,11 +380,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the Spot Instance Request.
-                      These tags are not automatically applied to the launched Instance.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   tenancy:
                     type: string
@@ -421,11 +405,7 @@ spec:
                   volumeTags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the Spot Instance Request.
-                      These tags are not automatically applied to the launched Instance.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcSecurityGroupIdRefs:
                     description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.

--- a/package/crds/ec2.aws.upbound.io_subnets.yaml
+++ b/package/crds/ec2.aws.upbound.io_subnets.yaml
@@ -134,9 +134,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcId:
                     description: The VPC ID.

--- a/package/crds/ec2.aws.upbound.io_transitgatewaymulticastdomains.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewaymulticastdomains.yaml
@@ -88,10 +88,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value tags for the EC2 Transit Gateway Multicast
-                      Domain. If configured with a provider default_tags configuration
-                      block present, tags with matching keys will overwrite those
-                      defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   transitGatewayId:
                     description: EC2 Transit Gateway identifier. The EC2 Transit Gateway

--- a/package/crds/ec2.aws.upbound.io_transitgatewaypeeringattachments.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewaypeeringattachments.yaml
@@ -157,10 +157,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value tags for the EC2 Transit Gateway Peering
-                      Attachment. If configured with a provider default_tags configuration
-                      block present, tags with matching keys will overwrite those
-                      defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   transitGatewayId:
                     description: Identifier of EC2 Transit Gateway.

--- a/package/crds/ec2.aws.upbound.io_transitgatewayroutetables.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayroutetables.yaml
@@ -72,10 +72,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value tags for the EC2 Transit Gateway Route
-                      Table. If configured with a provider default_tags configuration
-                      block present, tags with matching keys will overwrite those
-                      defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   transitGatewayId:
                     description: Identifier of EC2 Transit Gateway.

--- a/package/crds/ec2.aws.upbound.io_transitgateways.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgateways.yaml
@@ -100,9 +100,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value tags for the EC2 Transit Gateway. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   transitGatewayCidrBlocks:
                     description: One or more IPv4 or IPv6 CIDR blocks for the transit

--- a/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachmentaccepters.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachmentaccepters.yaml
@@ -72,10 +72,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value tags for the EC2 Transit Gateway VPC Attachment.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   transitGatewayAttachmentId:
                     description: The ID of the EC2 Transit Gateway Attachment to manage.

--- a/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachments.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachments.yaml
@@ -168,10 +168,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value tags for the EC2 Transit Gateway VPC Attachment.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   transitGatewayDefaultRouteTableAssociation:
                     description: 'Boolean whether the VPC Attachment should be associated

--- a/package/crds/ec2.aws.upbound.io_vpcdhcpoptions.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcdhcpoptions.yaml
@@ -99,9 +99,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ec2.aws.upbound.io_vpcendpoints.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcendpoints.yaml
@@ -167,9 +167,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcEndpointType:
                     description: The VPC endpoint type, Gateway, GatewayLoadBalancer,

--- a/package/crds/ec2.aws.upbound.io_vpcendpointservices.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcendpointservices.yaml
@@ -91,9 +91,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - acceptanceRequired

--- a/package/crds/ec2.aws.upbound.io_vpcpeeringconnections.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcpeeringconnections.yaml
@@ -162,9 +162,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcId:
                     description: The ID of the requester VPC.

--- a/package/crds/ec2.aws.upbound.io_vpcs.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcs.yaml
@@ -141,9 +141,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ecr.aws.upbound.io_repositories.yaml
+++ b/package/crds/ecr.aws.upbound.io_repositories.yaml
@@ -182,9 +182,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ecs.aws.upbound.io_capacityproviders.yaml
+++ b/package/crds/ecs.aws.upbound.io_capacityproviders.yaml
@@ -194,9 +194,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - autoScalingGroupProvider

--- a/package/crds/ecs.aws.upbound.io_clusters.yaml
+++ b/package/crds/ecs.aws.upbound.io_clusters.yaml
@@ -166,9 +166,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ecs.aws.upbound.io_services.yaml
+++ b/package/crds/ecs.aws.upbound.io_services.yaml
@@ -632,9 +632,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   taskDefinition:
                     description: Family and revision (family:revision) or full ARN

--- a/package/crds/ecs.aws.upbound.io_taskdefinitions.yaml
+++ b/package/crds/ecs.aws.upbound.io_taskdefinitions.yaml
@@ -283,9 +283,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   taskRoleArn:
                     description: ARN of IAM role that allows your Amazon ECS container

--- a/package/crds/efs.aws.upbound.io_accesspoints.yaml
+++ b/package/crds/efs.aws.upbound.io_accesspoints.yaml
@@ -208,9 +208,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value mapping of resource tags. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/efs.aws.upbound.io_filesystems.yaml
+++ b/package/crds/efs.aws.upbound.io_filesystems.yaml
@@ -188,9 +188,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the file system. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   throughputMode:
                     description: 'Throughput mode for the file system. Defaults to

--- a/package/crds/eks.aws.upbound.io_addons.yaml
+++ b/package/crds/eks.aws.upbound.io_addons.yaml
@@ -243,9 +243,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/eks.aws.upbound.io_clusters.yaml
+++ b/package/crds/eks.aws.upbound.io_clusters.yaml
@@ -218,9 +218,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   version:
                     description: –  Desired Kubernetes master version. If you do not

--- a/package/crds/eks.aws.upbound.io_fargateprofiles.yaml
+++ b/package/crds/eks.aws.upbound.io_fargateprofiles.yaml
@@ -328,9 +328,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/eks.aws.upbound.io_identityproviderconfigs.yaml
+++ b/package/crds/eks.aws.upbound.io_identityproviderconfigs.yaml
@@ -186,9 +186,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - oidc

--- a/package/crds/eks.aws.upbound.io_nodegroups.yaml
+++ b/package/crds/eks.aws.upbound.io_nodegroups.yaml
@@ -495,9 +495,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   taint:
                     description: The Kubernetes taints to be applied to the nodes

--- a/package/crds/elasticache.aws.upbound.io_clusters.yaml
+++ b/package/crds/elasticache.aws.upbound.io_clusters.yaml
@@ -376,9 +376,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/elasticache.aws.upbound.io_parametergroups.yaml
+++ b/package/crds/elasticache.aws.upbound.io_parametergroups.yaml
@@ -95,9 +95,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value mapping of resource tags. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - family

--- a/package/crds/elasticache.aws.upbound.io_replicationgroups.yaml
+++ b/package/crds/elasticache.aws.upbound.io_replicationgroups.yaml
@@ -540,12 +540,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. Adding tags
-                      to this resource will add or overwrite any existing tags on
-                      the clusters in the replication group and not to the group itself.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   transitEncryptionEnabled:
                     description: Whether to enable encryption in transit.

--- a/package/crds/elasticache.aws.upbound.io_subnetgroups.yaml
+++ b/package/crds/elasticache.aws.upbound.io_subnetgroups.yaml
@@ -156,9 +156,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/elasticache.aws.upbound.io_users.yaml
+++ b/package/crds/elasticache.aws.upbound.io_users.yaml
@@ -106,8 +106,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A list of tags to be added to this resource. A tag
-                      is a key-value pair.
+                    description: Key-value map of resource tags.
                     type: object
                   userName:
                     description: The username of the user.

--- a/package/crds/elb.aws.upbound.io_elbs.yaml
+++ b/package/crds/elb.aws.upbound.io_elbs.yaml
@@ -358,9 +358,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - listener

--- a/package/crds/elbv2.aws.upbound.io_lblisteners.yaml
+++ b/package/crds/elbv2.aws.upbound.io_lblisteners.yaml
@@ -576,9 +576,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - defaultAction

--- a/package/crds/elbv2.aws.upbound.io_lbs.yaml
+++ b/package/crds/elbv2.aws.upbound.io_lbs.yaml
@@ -486,9 +486,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/elbv2.aws.upbound.io_lbtargetgroups.yaml
+++ b/package/crds/elbv2.aws.upbound.io_lbtargetgroups.yaml
@@ -217,9 +217,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   targetType:
                     description: (May be required, Forces new resource) Type of target

--- a/package/crds/firehose.aws.upbound.io_deliverystreams.yaml
+++ b/package/crds/firehose.aws.upbound.io_deliverystreams.yaml
@@ -2314,9 +2314,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   versionId:
                     description: Specifies the table version for the output data schema.

--- a/package/crds/gamelift.aws.upbound.io_aliases.yaml
+++ b/package/crds/gamelift.aws.upbound.io_aliases.yaml
@@ -97,9 +97,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/gamelift.aws.upbound.io_builds.yaml
+++ b/package/crds/gamelift.aws.upbound.io_builds.yaml
@@ -328,9 +328,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   version:
                     description: Version that is associated with this build.

--- a/package/crds/gamelift.aws.upbound.io_fleet.yaml
+++ b/package/crds/gamelift.aws.upbound.io_fleet.yaml
@@ -350,9 +350,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - ec2InstanceType

--- a/package/crds/gamelift.aws.upbound.io_gamesessionqueues.yaml
+++ b/package/crds/gamelift.aws.upbound.io_gamesessionqueues.yaml
@@ -96,9 +96,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   timeoutInSeconds:
                     description: Maximum time a game session request can remain in

--- a/package/crds/gamelift.aws.upbound.io_scripts.yaml
+++ b/package/crds/gamelift.aws.upbound.io_scripts.yaml
@@ -324,9 +324,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   version:
                     description: Version that is associated with this script.

--- a/package/crds/globalaccelerator.aws.upbound.io_accelerators.yaml
+++ b/package/crds/globalaccelerator.aws.upbound.io_accelerators.yaml
@@ -102,9 +102,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/glue.aws.upbound.io_jobs.yaml
+++ b/package/crds/glue.aws.upbound.io_jobs.yaml
@@ -235,9 +235,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   timeout:
                     description: –  The job timeout in minutes. The default is 2880

--- a/package/crds/glue.aws.upbound.io_registries.yaml
+++ b/package/crds/glue.aws.upbound.io_registries.yaml
@@ -74,9 +74,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/glue.aws.upbound.io_triggers.yaml
+++ b/package/crds/glue.aws.upbound.io_triggers.yaml
@@ -344,9 +344,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   type:
                     description: –  The type of trigger. Valid values are CONDITIONAL,

--- a/package/crds/glue.aws.upbound.io_workflows.yaml
+++ b/package/crds/glue.aws.upbound.io_workflows.yaml
@@ -86,9 +86,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/grafana.aws.upbound.io_workspaces.yaml
+++ b/package/crds/grafana.aws.upbound.io_workspaces.yaml
@@ -199,9 +199,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value mapping of resource tags. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - accountAccessType

--- a/package/crds/iam.aws.upbound.io_instanceprofiles.yaml
+++ b/package/crds/iam.aws.upbound.io_instanceprofiles.yaml
@@ -152,10 +152,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of resource tags for the IAM Instance Profile.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 type: object
               providerConfigRef:

--- a/package/crds/iam.aws.upbound.io_openidconnectproviders.yaml
+++ b/package/crds/iam.aws.upbound.io_openidconnectproviders.yaml
@@ -76,10 +76,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of resource tags for the IAM OIDC provider. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   thumbprintList:
                     description: A list of server certificate thumbprints for the

--- a/package/crds/iam.aws.upbound.io_policies.yaml
+++ b/package/crds/iam.aws.upbound.io_policies.yaml
@@ -76,9 +76,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of resource tags for the IAM Policy. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - policy

--- a/package/crds/iam.aws.upbound.io_roles.yaml
+++ b/package/crds/iam.aws.upbound.io_roles.yaml
@@ -90,9 +90,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value mapping of tags for the IAM role. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - assumeRolePolicy

--- a/package/crds/iam.aws.upbound.io_samlproviders.yaml
+++ b/package/crds/iam.aws.upbound.io_samlproviders.yaml
@@ -71,10 +71,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of resource tags for the IAM SAML provider. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - samlMetadataDocument

--- a/package/crds/iam.aws.upbound.io_servercertificates.yaml
+++ b/package/crds/iam.aws.upbound.io_servercertificates.yaml
@@ -96,10 +96,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of resource tags for the server certificate.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - certificateBody

--- a/package/crds/iam.aws.upbound.io_servicelinkedroles.yaml
+++ b/package/crds/iam.aws.upbound.io_servicelinkedroles.yaml
@@ -81,9 +81,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value mapping of tags for the IAM role. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - awsServiceName

--- a/package/crds/iam.aws.upbound.io_users.yaml
+++ b/package/crds/iam.aws.upbound.io_users.yaml
@@ -82,9 +82,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of tags for the IAM user. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 type: object
               providerConfigRef:

--- a/package/crds/iam.aws.upbound.io_virtualmfadevices.yaml
+++ b/package/crds/iam.aws.upbound.io_virtualmfadevices.yaml
@@ -70,10 +70,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of resource tags for the virtual mfa device.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   virtualMfaDeviceName:
                     description: The name of the virtual MFA device. Use with path

--- a/package/crds/kafka.aws.upbound.io_clusters.yaml
+++ b/package/crds/kafka.aws.upbound.io_clusters.yaml
@@ -867,9 +867,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - brokerNodeGroupInfo

--- a/package/crds/kinesis.aws.upbound.io_streams.yaml
+++ b/package/crds/kinesis.aws.upbound.io_streams.yaml
@@ -192,9 +192,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/kinesisanalytics.aws.upbound.io_applications.yaml
+++ b/package/crds/kinesisanalytics.aws.upbound.io_applications.yaml
@@ -865,10 +865,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of tags for the Kinesis Analytics Application.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/kinesisanalyticsv2.aws.upbound.io_applications.yaml
+++ b/package/crds/kinesisanalyticsv2.aws.upbound.io_applications.yaml
@@ -1383,9 +1383,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the application. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/kinesisvideo.aws.upbound.io_streams.yaml
+++ b/package/crds/kinesisvideo.aws.upbound.io_streams.yaml
@@ -171,9 +171,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/kms.aws.upbound.io_externalkeys.yaml
+++ b/package/crds/kms.aws.upbound.io_externalkeys.yaml
@@ -120,10 +120,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A key-value map of tags to assign to the key. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   validTo:
                     description: 'Time at which the imported key material expires.

--- a/package/crds/kms.aws.upbound.io_keys.yaml
+++ b/package/crds/kms.aws.upbound.io_keys.yaml
@@ -122,9 +122,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the object. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/lambda.aws.upbound.io_functions.yaml
+++ b/package/crds/lambda.aws.upbound.io_functions.yaml
@@ -534,9 +534,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the object. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   timeout:
                     description: Amount of time your Lambda Function has to run in

--- a/package/crds/licensemanager.aws.upbound.io_licenseconfigurations.yaml
+++ b/package/crds/licensemanager.aws.upbound.io_licenseconfigurations.yaml
@@ -92,9 +92,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - licenseCountingType

--- a/package/crds/mq.aws.upbound.io_brokers.yaml
+++ b/package/crds/mq.aws.upbound.io_brokers.yaml
@@ -419,9 +419,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the broker. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   user:
                     description: Configuration block for broker users. For engine_type

--- a/package/crds/mq.aws.upbound.io_configurations.yaml
+++ b/package/crds/mq.aws.upbound.io_configurations.yaml
@@ -93,9 +93,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - data

--- a/package/crds/neptune.aws.upbound.io_clusterendpoints.yaml
+++ b/package/crds/neptune.aws.upbound.io_clusterendpoints.yaml
@@ -166,10 +166,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the Neptune cluster. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - endpointType

--- a/package/crds/neptune.aws.upbound.io_clusterinstances.yaml
+++ b/package/crds/neptune.aws.upbound.io_clusterinstances.yaml
@@ -348,9 +348,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the instance. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - instanceClass

--- a/package/crds/neptune.aws.upbound.io_clusterparametergroups.yaml
+++ b/package/crds/neptune.aws.upbound.io_clusterparametergroups.yaml
@@ -97,9 +97,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - family

--- a/package/crds/neptune.aws.upbound.io_clusters.yaml
+++ b/package/crds/neptune.aws.upbound.io_clusters.yaml
@@ -613,10 +613,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the Neptune cluster. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcSecurityGroupIdRefs:
                     description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.

--- a/package/crds/neptune.aws.upbound.io_eventsubscriptions.yaml
+++ b/package/crds/neptune.aws.upbound.io_eventsubscriptions.yaml
@@ -172,9 +172,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/neptune.aws.upbound.io_parametergroups.yaml
+++ b/package/crds/neptune.aws.upbound.io_parametergroups.yaml
@@ -97,9 +97,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - family

--- a/package/crds/neptune.aws.upbound.io_subnetgroups.yaml
+++ b/package/crds/neptune.aws.upbound.io_subnetgroups.yaml
@@ -156,9 +156,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/ram.aws.upbound.io_resourceshares.yaml
+++ b/package/crds/ram.aws.upbound.io_resourceshares.yaml
@@ -78,10 +78,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource share. If
-                      configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/rds.aws.upbound.io_clusterendpoints.yaml
+++ b/package/crds/rds.aws.upbound.io_clusterendpoints.yaml
@@ -164,9 +164,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - customEndpointType

--- a/package/crds/rds.aws.upbound.io_clusterinstances.yaml
+++ b/package/crds/rds.aws.upbound.io_clusterinstances.yaml
@@ -458,9 +458,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the instance. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - instanceClass

--- a/package/crds/rds.aws.upbound.io_clusterparametergroups.yaml
+++ b/package/crds/rds.aws.upbound.io_clusterparametergroups.yaml
@@ -100,9 +100,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - family

--- a/package/crds/rds.aws.upbound.io_clusters.yaml
+++ b/package/crds/rds.aws.upbound.io_clusters.yaml
@@ -691,9 +691,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the DB cluster. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcSecurityGroupIdRefs:
                     description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.

--- a/package/crds/rds.aws.upbound.io_instances.yaml
+++ b/package/crds/rds.aws.upbound.io_instances.yaml
@@ -631,9 +631,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   timezone:
                     description: Time zone of the DB instance. timezone is currently

--- a/package/crds/rds.aws.upbound.io_optiongroups.yaml
+++ b/package/crds/rds.aws.upbound.io_optiongroups.yaml
@@ -128,9 +128,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - engineName

--- a/package/crds/rds.aws.upbound.io_parametergroups.yaml
+++ b/package/crds/rds.aws.upbound.io_parametergroups.yaml
@@ -100,9 +100,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - family

--- a/package/crds/rds.aws.upbound.io_proxies.yaml
+++ b/package/crds/rds.aws.upbound.io_proxies.yaml
@@ -287,9 +287,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A mapping of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcSecurityGroupIdRefs:
                     description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.

--- a/package/crds/rds.aws.upbound.io_proxyendpoints.yaml
+++ b/package/crds/rds.aws.upbound.io_proxyendpoints.yaml
@@ -148,7 +148,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A mapping of tags to assign to the resource.
+                    description: Key-value map of resource tags.
                     type: object
                   targetRole:
                     description: Indicates whether the DB proxy endpoint can be used

--- a/package/crds/rds.aws.upbound.io_securitygroups.yaml
+++ b/package/crds/rds.aws.upbound.io_securitygroups.yaml
@@ -93,9 +93,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - ingress

--- a/package/crds/rds.aws.upbound.io_snapshots.yaml
+++ b/package/crds/rds.aws.upbound.io_snapshots.yaml
@@ -148,9 +148,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/rds.aws.upbound.io_subnetgroups.yaml
+++ b/package/crds/rds.aws.upbound.io_subnetgroups.yaml
@@ -156,9 +156,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/redshift.aws.upbound.io_clusters.yaml
+++ b/package/crds/redshift.aws.upbound.io_clusters.yaml
@@ -421,9 +421,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpcSecurityGroupIdRefs:
                     description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.

--- a/package/crds/resourcegroups.aws.upbound.io_groups.yaml
+++ b/package/crds/resourcegroups.aws.upbound.io_groups.yaml
@@ -89,9 +89,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/route53.aws.upbound.io_healthchecks.yaml
+++ b/package/crds/route53.aws.upbound.io_healthchecks.yaml
@@ -237,9 +237,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the health check. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   type:
                     description: The protocol to use when performing health checks.

--- a/package/crds/route53.aws.upbound.io_zones.yaml
+++ b/package/crds/route53.aws.upbound.io_zones.yaml
@@ -157,9 +157,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the zone. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/route53resolver.aws.upbound.io_endpoints.yaml
+++ b/package/crds/route53resolver.aws.upbound.io_endpoints.yaml
@@ -256,9 +256,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - direction

--- a/package/crds/route53resolver.aws.upbound.io_rules.yaml
+++ b/package/crds/route53resolver.aws.upbound.io_rules.yaml
@@ -164,9 +164,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   targetIp:
                     description: Configuration block(s) indicating the IPs that you

--- a/package/crds/s3.aws.upbound.io_bucketanalyticsconfigurations.yaml
+++ b/package/crds/s3.aws.upbound.io_bucketanalyticsconfigurations.yaml
@@ -153,7 +153,7 @@ spec:
                         tags:
                           additionalProperties:
                             type: string
-                          description: Set of object tags for filtering.
+                          description: Key-value map of resource tags.
                           type: object
                       type: object
                     type: array

--- a/package/crds/s3.aws.upbound.io_bucketintelligenttieringconfigurations.yaml
+++ b/package/crds/s3.aws.upbound.io_bucketintelligenttieringconfigurations.yaml
@@ -154,8 +154,7 @@ spec:
                         tags:
                           additionalProperties:
                             type: string
-                          description: All of these tags must exist in the object's
-                            tag set in order for the configuration to apply.
+                          description: Key-value map of resource tags.
                           type: object
                       type: object
                     type: array

--- a/package/crds/s3.aws.upbound.io_bucketmetrics.yaml
+++ b/package/crds/s3.aws.upbound.io_bucketmetrics.yaml
@@ -151,7 +151,7 @@ spec:
                         tags:
                           additionalProperties:
                             type: string
-                          description: Object tags for filtering (up to 10).
+                          description: Key-value map of resource tags.
                           type: object
                       type: object
                     type: array

--- a/package/crds/s3.aws.upbound.io_bucketobjects.yaml
+++ b/package/crds/s3.aws.upbound.io_bucketobjects.yaml
@@ -320,9 +320,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the object. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   websiteRedirect:
                     description: Target URL for website redirect.

--- a/package/crds/s3.aws.upbound.io_buckets.yaml
+++ b/package/crds/s3.aws.upbound.io_buckets.yaml
@@ -84,9 +84,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the bucket. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/s3.aws.upbound.io_objects.yaml
+++ b/package/crds/s3.aws.upbound.io_objects.yaml
@@ -322,9 +322,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Map of tags to assign to the object. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   websiteRedirect:
                     description: Target URL for website redirect.

--- a/package/crds/secretsmanager.aws.upbound.io_secrets.yaml
+++ b/package/crds/secretsmanager.aws.upbound.io_secrets.yaml
@@ -191,10 +191,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of user-defined tags that are attached
-                      to the secret. If configured with a provider default_tags configuration
-                      block present, tags with matching keys will overwrite those
-                      defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/servicediscovery.aws.upbound.io_httpnamespaces.yaml
+++ b/package/crds/servicediscovery.aws.upbound.io_httpnamespaces.yaml
@@ -78,9 +78,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the namespace. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/servicediscovery.aws.upbound.io_privatednsnamespaces.yaml
+++ b/package/crds/servicediscovery.aws.upbound.io_privatednsnamespaces.yaml
@@ -78,9 +78,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the namespace. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   vpc:
                     description: The ID of VPC that you want to associate the namespace

--- a/package/crds/servicediscovery.aws.upbound.io_publicdnsnamespaces.yaml
+++ b/package/crds/servicediscovery.aws.upbound.io_publicdnsnamespaces.yaml
@@ -78,9 +78,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the namespace. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - name

--- a/package/crds/sfn.aws.upbound.io_activities.yaml
+++ b/package/crds/sfn.aws.upbound.io_activities.yaml
@@ -71,9 +71,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/sfn.aws.upbound.io_statemachines.yaml
+++ b/package/crds/sfn.aws.upbound.io_statemachines.yaml
@@ -175,9 +175,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   tracingConfiguration:
                     description: Selects whether AWS X-Ray tracing is enabled.

--- a/package/crds/signer.aws.upbound.io_signingprofiles.yaml
+++ b/package/crds/signer.aws.upbound.io_signingprofiles.yaml
@@ -88,10 +88,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A list of tags associated with the signing profile.
-                      If configured with a provider default_tags configuration block
-                      present, tags with matching keys will overwrite those defined
-                      at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - platformId

--- a/package/crds/sns.aws.upbound.io_topics.yaml
+++ b/package/crds/sns.aws.upbound.io_topics.yaml
@@ -873,9 +873,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: Key-value map of resource tags. If configured with
-                      a provider default_tags configuration block present, tags with
-                      matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region

--- a/package/crds/sqs.aws.upbound.io_queues.yaml
+++ b/package/crds/sqs.aws.upbound.io_queues.yaml
@@ -146,9 +146,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the queue. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   visibilityTimeoutSeconds:
                     description: The visibility timeout for the queue. An integer

--- a/package/crds/transfer.aws.upbound.io_servers.yaml
+++ b/package/crds/transfer.aws.upbound.io_servers.yaml
@@ -387,9 +387,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                   url:
                     description: '- URL of the service endpoint used to authenticate

--- a/package/crds/transfer.aws.upbound.io_users.yaml
+++ b/package/crds/transfer.aws.upbound.io_users.yaml
@@ -289,9 +289,7 @@ spec:
                   tags:
                     additionalProperties:
                       type: string
-                    description: A map of tags to assign to the resource. If configured
-                      with a provider default_tags configuration block present, tags
-                      with matching keys will overwrite those defined at the provider-level.
+                    description: Key-value map of resource tags.
                     type: object
                 required:
                 - region


### PR DESCRIPTION
### Description of your changes

Removes the callout of Terraform's provider-wide tagging which is not available in Crossplane. Discussed in https://crossplane.slack.com/archives/CEG3T90A1/p1667302198264609

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
