### PR TITLE
Remove updoc Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,23 +80,6 @@ XPKGS = provider-aws
 xpkg.build.provider-aws: do.build.images
 
 # ====================================================================================
-# Setup Upbound Docs
-
-updoc-upload:
-	@$(INFO) uploading docs for v$(VERSION_MAJOR).$(VERSION_MINOR)
-	@go run github.com/upbound/official-providers/updoc/cmd upload \
-        --docs-dir=$(ROOT_DIR)/docs \
-        --name=$(PROJECT_NAME) \
-        --version=v$(VERSION_MAJOR).$(VERSION_MINOR) \
-        --bucket-name=$(BUCKET_NAME) \
-        --cdn-domain=$(CDN_DOMAIN) || $(FAIL)
-	@$(OK) uploaded docs for v$(VERSION_MAJOR).$(VERSION_MINOR)
-
-ifneq ($(filter release-%,$(BRANCH_NAME)),)
-publish.artifacts: updoc-upload
-endif
-
-# ====================================================================================
 # Targets
 
 # run `make help` to see the targets and options


### PR DESCRIPTION


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Drops the updoc Makefile target so that it is not triggered during artifact publish.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Verified updoc is currently triggered on main:
```
🤖 (provider-aws) GO=go1.19 BRANCH_NAME=release-0.19 make -n publish.artifacts
make -C /home/dan/code/github.com/upbound/provider-aws/cluster/images/provider-aws IMAGE_PLATFORMS=linux/amd64,linux/arm64 IMAGE=xpkg.upbound.io/upbound/provider-aws:v0.19.0 img.publish
echo `date +%H:%M:%S` [ .. ] Pushing package xpkg.upbound.io/upbound/provider-aws:v0.19.0
/home/dan/code/github.com/upbound/provider-aws/.cache/tools/linux_x86_64/up-v0.14.0 xpkg push --package /home/dan/code/github.com/upbound/provider-aws/_output/xpkg/linux_amd64/provider-aws-v0.19.0.xpkg  --package /home/dan/code/github.com/upbound/provider-aws/_output/xpkg/linux_arm64/provider-aws-v0.19.0.xpkg  xpkg.upbound.io/upbound/provider-aws:v0.19.0 || (echo `date +%H:%M:%S` [FAIL] && false)
echo `date +%H:%M:%S` [ OK ] Pushed package xpkg.upbound.io/upbound/provider-aws:v0.19.0
echo `date +%H:%M:%S` [ .. ] uploading docs for v0.19
go run github.com/upbound/official-providers/updoc/cmd upload \
        --docs-dir=/home/dan/code/github.com/upbound/provider-aws/docs \
        --name=provider-aws \
        --version=v0.19 \
        --bucket-name= \
        --cdn-domain= || (echo `date +%H:%M:%S` [FAIL] && false)
echo `date +%H:%M:%S` [ OK ] uploaded docs for v0.19
:
```

But not on this PR branch:
```
🤖 (provider-aws) GO=go1.19 BRANCH_NAME=release-0.19 make -n publish.artifacts
make -C /home/dan/code/github.com/upbound/provider-aws/cluster/images/provider-aws IMAGE_PLATFORMS=linux/amd64,linux/arm64 IMAGE=xpkg.upbound.io/upbound/provider-aws:v0.19.0-1.g7ab47742 img.publish
echo `date +%H:%M:%S` [ .. ] Pushing package xpkg.upbound.io/upbound/provider-aws:v0.19.0-1.g7ab47742
/home/dan/code/github.com/upbound/provider-aws/.cache/tools/linux_x86_64/up-v0.14.0 xpkg push --package /home/dan/code/github.com/upbound/provider-aws/_output/xpkg/linux_amd64/provider-aws-v0.19.0-1.g7ab47742.xpkg  --package /home/dan/code/github.com/upbound/provider-aws/_output/xpkg/linux_arm64/provider-aws-v0.19.0-1.g7ab47742.xpkg  xpkg.upbound.io/upbound/provider-aws:v0.19.0-1.g7ab47742 || (echo `date +%H:%M:%S` [FAIL] && false)
echo `date +%H:%M:%S` [ OK ] Pushed package xpkg.upbound.io/upbound/provider-aws:v0.19.0-1.g7ab47742
:
```