### PR TITLE
Remove UXP requirement notice

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,7 +32,7 @@ up uxp install
 Find more information in the [Upbound UXP
 documentation](https://docs.upbound.io/uxp/).
 
-_The Upbound AWS official provider may also be used with upstream [Crossplane](https://crossplane.io/docs/v1.9/getting-started/install-configure.html)._
+_The Upbound AWS official provider may also be used with upstream [Crossplane](https://crossplane.io/docs/master/getting-started/install-configure.html)._
 
 ### Install the provider
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -21,10 +21,7 @@ documentation](https://docs.upbound.io/cli/).
 
 #### Upbound Universal Crossplane
 UXP is the Upbound official enterprise-grade distribution of Crossplane for
-self-hosted control planes. Only Upbound Universal Crossplane (UXP) supports
-official providers.
-
-Official providers aren't supported with open source Crossplane.
+self-hosted control planes. 
 
 Install UXP into your Kubernetes cluster using the Up command-line.
 
@@ -34,6 +31,8 @@ up uxp install
 
 Find more information in the [Upbound UXP
 documentation](https://docs.upbound.io/uxp/).
+
+_The Upbound AWS official provider may also be used with upstream [Crossplane](https://crossplane.io/docs/v1.9/getting-started/install-configure.html)._
 
 ### Install the provider
 
@@ -163,9 +162,6 @@ An IRSA configuration requires multiple components:
 * Create a `ControllerConfig` to associate the IAM role ARN.
 * Apply the `ControllerConfig` to the `Provider`.
 * Instruct the `ProviderConfig` to use `IRSA` credentials.
-
-_Note:_ `IRSA` authentication requires [Upbound Universal Crossplane
-(UXP)](https://docs.upbound.io/uxp) installed in the EKS cluster.
 
 <!-- Disable heading acronym rule to ignore "OIDC" -->
 <!-- vale Microsoft.HeadingAcronyms = NO -->


### PR DESCRIPTION
Signed-off-by: Jean du Plessis <jean@upbound.io>

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Removes the invalid instruction that UXP is required to run Upbound AWS official provider.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n/a
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
