### PR TITLE
Make not-generated Terraform resources CSV available as a Github workflow artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,19 @@ jobs:
         run: make vendor vendor.check
 
       - name: Check Diff
-        run: make check-diff
+        run: |
+          mkdir _output
+          make check-diff
+        env:
+          # check-diff depends on the generate Make target, and we would like
+          # to save a skipped resource list
+          SKIPPED_RESOURCES_CSV: ../_output/skipped_resources.csv
+
+      - name: Publish skipped resources CSV to Github
+        uses: actions/upload-artifact@v3
+        with:
+          name: skipped_resources
+          path: _output/skipped_resources.csv
 
   unit-tests:
     runs-on: ubuntu-22.04
@@ -236,7 +248,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Publish Artifacts to GitHub
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: output
           path: _output/**

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -1,6 +1,16 @@
-/*
-Copyright 2021 Upbound Inc.
-*/
+// Copyright 2022 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 
@@ -11,24 +21,28 @@ import (
 	"strings"
 
 	"github.com/upbound/upjet/pkg/pipeline"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/upbound/provider-aws/config"
 )
 
 func main() {
-	if len(os.Args) < 2 || os.Args[1] == "" {
-		panic("root directory is required to be given as argument")
-	}
-	rootDir := os.Args[1]
-	absRootDir, err := filepath.Abs(rootDir)
+	var (
+		app                 = kingpin.New("generator", "Run Upjet code generation pipelines for provider-aws").DefaultEnvars()
+		repoRoot            = app.Arg("repo-root", "Root directory for the provider repository").Required().String()
+		skippedResourcesCSV = app.Flag("skipped-resources-csv", "File path where a list of skipped (not-generated) Terraform resource names will be stored as a CSV").Envar("SKIPPED_RESOURCES_CSV").String()
+	)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	absRootDir, err := filepath.Abs(*repoRoot)
 	if err != nil {
-		panic(fmt.Sprintf("cannot calculate the absolute path with %s", rootDir))
+		panic(fmt.Sprintf("cannot calculate the absolute path with %s", *repoRoot))
 	}
 	p := config.GetProvider()
 	pipeline.Run(p, absRootDir)
-	if fp := os.Getenv("SKIPPED_RESOURCES_CSV"); len(fp) != 0 {
-		if err := os.WriteFile(fp, []byte(strings.Join(p.GetSkippedResourceNames(), ";")), 0o600); err != nil {
-			panic(fmt.Sprintf("cannot write skipped resources CSV to file %s: %s", fp, err.Error()))
+	if len(*skippedResourcesCSV) != 0 {
+		if err := os.WriteFile(*skippedResourcesCSV, []byte(strings.Join(p.GetSkippedResourceNames(), "\n")), 0o600); err != nil {
+			panic(fmt.Sprintf("cannot write skipped resources CSV to file %s: %s", *skippedResourcesCSV, err.Error()))
 		}
 	}
 }

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/upbound/upjet/pkg/pipeline"
 
@@ -23,5 +24,11 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("cannot calculate the absolute path with %s", rootDir))
 	}
-	pipeline.Run(config.GetProvider(), absRootDir)
+	p := config.GetProvider()
+	pipeline.Run(p, absRootDir)
+	if fp := os.Getenv("SKIPPED_RESOURCES_CSV"); len(fp) != 0 {
+		if err := os.WriteFile(fp, []byte(strings.Join(p.GetSkippedResourceNames(), ";")), 0o600); err != nil {
+			panic(fmt.Sprintf("cannot write skipped resources CSV to file %s: %s", fp, err.Error()))
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -157,3 +157,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/upbound/upjet => github.com/ulucinar/upbound-upjet v0.0.0-20221111092000-df1b435adc54

--- a/go.sum
+++ b/go.sum
@@ -686,8 +686,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/upbound/upjet v0.8.0-rc.0.0.20221024111721-c82119f5ef34 h1:TXehSax5YEurPY8vMnRx7n8xIHENGAiOhISxxqthcX0=
-github.com/upbound/upjet v0.8.0-rc.0.0.20221024111721-c82119f5ef34/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
+github.com/ulucinar/upbound-upjet v0.0.0-20221111092000-df1b435adc54 h1:DPmg48wohmFoXFGS3p8EuFIghUsojSnbuoUhfSxH9B0=
+github.com/ulucinar/upbound-upjet v0.0.0-20221111092000-df1b435adc54/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a change where a CSV file of Terraform resource names which are available in the Terraform provider's schema but not generated as managed resources is produced and made available as a Github workflow artifact.

Currently, the artifact is generated when the `generate` make target is run as a dependency (of `check-diff`). This is a little bit implicit and as an alternative we can generate the CSV on its own step. But I did not want to add to our build times (by running `make generate` a second time or computing the diff from the JSON schema and the generated files), and thus preferred to generate the CSV in the `Check Diff` step. 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with the following workflow run:
https://github.com/upbound/provider-aws/actions/runs/3438916965