### PR TITLE
Fixes and Tweaks with Uptest related targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ GO111MODULE = on
 KIND_VERSION = v0.15.0
 UP_VERSION = v0.14.0
 UP_CHANNEL = stable
-UPTEST_VERSION = v0.2.1
+UPTEST_VERSION = v0.3.0
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ CROSSPLANE_NAMESPACE = upbound-system
 # - UPTEST_DATASOURCE_PATH (optional), see https://github.com/upbound/uptest#injecting-dynamic-values-and-datasource
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e "${UPTEST_EXAMPLE_LIST}" --setup-script=cluster/test/setup.sh --default-conditions="Test" || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e "${UPTEST_EXAMPLE_LIST}" --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=cluster/test/setup.sh --default-conditions="Test" || $(FAIL)
 	@$(OK) running automated tests
 
 uptest-local:

--- a/cluster/test/setup.sh
+++ b/cluster/test/setup.sh
@@ -2,17 +2,13 @@
 set -aeuo pipefail
 
 echo "Running setup.sh"
-echo "Creating cloud credential secret..."
-${KUBECTL} -n upbound-system create secret generic provider-secret --from-literal=credentials="${UPTEST_CLOUD_CREDENTIALS}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
 
-echo "Waiting until provider is healthy..."
-${KUBECTL} wait provider.pkg --all --for condition=Healthy --timeout 5m
+if [[ -n "${UPTEST_CLOUD_CREDENTIALS:-}" ]]; then
+  echo "Creating cloud credential secret..."
+  ${KUBECTL} -n upbound-system create secret generic provider-secret --from-literal=credentials="${UPTEST_CLOUD_CREDENTIALS}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
 
-echo "Waiting for all pods to come online..."
-${KUBECTL} -n upbound-system wait --for=condition=Available deployment --all --timeout=5m
-
-echo "Creating a default provider config..."
-cat <<EOF | ${KUBECTL} apply -f -
+  echo "Creating a default provider config..."
+  cat <<EOF | ${KUBECTL} apply -f -
 apiVersion: aws.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
@@ -24,3 +20,5 @@ spec:
       name: provider-secret
       namespace: upbound-system
       key: credentials
+EOF
+fi


### PR DESCRIPTION
### Description of your changes

This PR fixes couple of issues with local dev flow with uptest:

- Configures `Test` as default condition
- Splits local deployment as a separate target so that `make uptest` could be called when provider is running externally with `make run` (i.e. previous workflow with `make uptest-local`)
- updates uptest version to latest to get a fix with data source parsing

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```bash
UPTEST_DATASOURCE_PATH=.work/uptest-datasource.yaml UPTEST_EXAMPLE_LIST=examples/codecommit/approvalruletemplateassociation.yaml make e2e
```

Also

```bash
# on terminal A
make run

# on terminal B
# get secret and provider config configured beforehand
UPTEST_EXAMPLE_LIST=examples/iam/user.yaml make uptest
```
