### PR TITLE
Consume upjet commit 6de200a3a8b0ac77c5f9d122f93db26aacd61960

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/pkg/errors v0.9.1
-	github.com/upbound/upjet v0.8.0-rc.0.0.20221024111721-c82119f5ef34
+	github.com/upbound/upjet v0.8.0-rc.0.0.20221111123128-6de200a3a8b0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
@@ -157,5 +157,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/upbound/upjet => github.com/ulucinar/upbound-upjet v0.0.0-20221111092000-df1b435adc54

--- a/go.sum
+++ b/go.sum
@@ -686,8 +686,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/ulucinar/upbound-upjet v0.0.0-20221111092000-df1b435adc54 h1:DPmg48wohmFoXFGS3p8EuFIghUsojSnbuoUhfSxH9B0=
-github.com/ulucinar/upbound-upjet v0.0.0-20221111092000-df1b435adc54/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
+github.com/upbound/upjet v0.8.0-rc.0.0.20221111123128-6de200a3a8b0 h1:bYRc+p0Glihl+G+/3paLq9H/LiWUcEOqKZddQmyNrN0=
+github.com/upbound/upjet v0.8.0-rc.0.0.20221111123128-6de200a3a8b0/go.mod h1:QyDjh8h49niORvHLHZE8ZS4fiCa6Dkcsw3aBJBfK3I8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Removes the `replace` statement in go.mod and consumes Upjet's current main HEAD(`6de200a3a8b0ac77c5f9d122f93db26aacd61960`).

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually with `make reviewable`