### PR TITLE
Remove already configured resources from externalnamenottested.go

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -14,12 +14,6 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 
 	// amp
 	//
-	// The prometheus alert manager definition can be imported using the workspace identifier
-	"aws_prometheus_alert_manager_definition": config.ParameterAsIdentifier("workspace_id"),
-	// The prometheus rule group namespace can be imported using the arn
-	"aws_prometheus_rule_group_namespace": config.IdentifierFromProvider,
-	// AMP Workspaces can be imported using the identifier
-	"aws_prometheus_workspace": config.IdentifierFromProvider,
 
 	// amplify
 	//
@@ -87,8 +81,6 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	"aws_autoscaling_policy": config.TemplatedStringAsIdentifier("name", "{{ .parameters.autoscaling_group_name }}/{{ .external_name }}"),
 	// AutoScaling ScheduledAction can be imported using the auto-scaling-group-name and scheduled-action-name: auto-scaling-group-name/scheduled-action-name
 	"aws_autoscaling_schedule": config.TemplatedStringAsIdentifier("scheduled_action_name", "{{ .parameters.autoscaling_group_name }}/{{ .external_name }}"),
-	// Launch configurations can be imported using the name
-	"aws_launch_configuration": config.NameAsIdentifier,
 
 	// autoscalingplans
 	//


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR removes some resources already configured in `config/externalname.go` but still exist in `config/externalnamenottested.go`

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The example manifests already exist for the respective resources, which imply they were previously validated.