### PR TITLE
Updates in the Quickstart Guide

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -40,7 +40,9 @@ _Note:_ all commands use the current `kubeconfig` context and configuration.
 ### Bash script
 Run the following to download and install 
 ```shell
-curl -sL "https://raw.githubusercontent.com/upbound/provider-aws/main/docs/quickstart.sh" | sh
+curl -sLO "https://raw.githubusercontent.com/upbound/provider-aws/main/docs/quickstart.sh"
+chmod +x quickstart.sh
+./quickstart.sh
 ```
 
 ### Shell commands
@@ -69,7 +71,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws:v0.18.0
+  package: xpkg.upbound.io/upbound/provider-aws:v0.21.0
 EOF
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Installed --timeout=180s
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Healthy --timeout=180s

--- a/docs/quickstart.sh
+++ b/docs/quickstart.sh
@@ -18,7 +18,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws:v0.17.0
+  package: xpkg.upbound.io/upbound/provider-aws:v0.21.0
 EOF
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Installed --timeout=180s
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Healthy --timeout=180s


### PR DESCRIPTION
### Description of your changes

This PR updates the quickstart guide by:
- Updating provider version to the latest
- Fixing the _Bash script_ mode, which is otherwise not asking for input and creating empty creds. 

Initially identified in https://github.com/upbound/provider-aws/issues/186 but not fixing the issue there.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

By following the quickstart steps.
