### PR TITLE
Fix late init of SecurityGroupRule with `self: true`

### DIFF
--- a/apis/ec2/v1beta1/zz_generated_terraformed.go
+++ b/apis/ec2/v1beta1/zz_generated_terraformed.go
@@ -4234,6 +4234,8 @@ func (tr *SecurityGroupRule) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("Self"))
+	opts = append(opts, resource.WithNameFilter("SourceSecurityGroupID"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -194,6 +194,11 @@ func Configure(p *config.Provider) {
 		r.References["source_security_group_id"] = config.Reference{
 			Type: "SecurityGroup",
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{
+				"self", "source_security_group_id",
+			},
+		}
 	})
 
 	p.AddResourceConfigurator("aws_vpc_peering_connection", func(r *config.Resource) {

--- a/examples/ec2/securitygrouprule-self-true.yaml
+++ b/examples/ec2/securitygrouprule-self-true.yaml
@@ -1,0 +1,44 @@
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  name: sample-vpc
+spec:
+  forProvider:
+    cidrBlock: 172.16.0.0/16
+    region: us-east-1
+    tags:
+      Name: DemoVpc
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroup
+metadata:
+  labels:
+    selector: here-i-am
+  name: test-vpc
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    region: us-east-1
+    vpcIdRef:
+      name: sample-vpc
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroupRule
+metadata:
+  name: test-vpc-securitygroup
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    fromPort: 22
+    protocol: tcp
+    region: us-east-1
+    securityGroupIdSelector:
+      matchLabels:
+        selector: here-i-am
+    self: true
+    toPort: 22
+    type: ingress


### PR DESCRIPTION


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Add late init to `self` and `source_security_group_id`

Fixes #228

Signed-off-by: Yury Tsarev <yury@upbound.io>

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
k apply -f examples/ec2/securitygrouprule-self-true.yaml
```

```
k get managed
NAME                                        READY   SYNCED   EXTERNAL-NAME          AGE
securitygroup.ec2.aws.upbound.io/test-vpc   True    True     sg-00c2b14d55b3da787   10m

NAME                                READY   SYNCED   EXTERNAL-NAME           AGE
vpc.ec2.aws.upbound.io/sample-vpc   True    True     vpc-0f8da654a40cb68cb   10m

NAME                                                          READY   SYNCED   EXTERNAL-NAME       AGE
securitygrouprule.ec2.aws.upbound.io/test-vpc-securitygroup   True    True     sgrule-2687506433   10m
```

