### PR TITLE
Use UPTEST_CLOUD_CREDENTIALS Github repo secret to enable cross-account resource uptesting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,15 @@ CROSSPLANE_NAMESPACE = upbound-system
 
 # This target requires the following environment variables to be set:
 # - UPTEST_EXAMPLE_LIST, a comma-separated list of examples to test
-# - UPTEST_CLOUD_CREDENTIALS (optional), cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat ~/.aws/credentials)
+# - UPTEST_CLOUD_CREDENTIALS (optional), multiple sets of AWS IAM User credentials specified as key=value pairs.
+#   The support keys are currently `DEFAULT` and `PEER`. So, an example for the value of this env. variable is:
+#   DEFAULT='[default]
+#   aws_access_key_id = REDACTED
+#   aws_secret_access_key = REDACTED'
+#   PEER='[default]
+#   aws_access_key_id = REDACTED
+#   aws_secret_access_key = REDACTED'
+#   The associated `ProviderConfig`s will be named as `default` and `peer`.
 # - UPTEST_DATASOURCE_PATH (optional), see https://github.com/upbound/uptest#injecting-dynamic-values-and-datasource
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests

--- a/cluster/test/setup.sh
+++ b/cluster/test/setup.sh
@@ -4,11 +4,23 @@ set -aeuo pipefail
 echo "Running setup.sh"
 
 if [[ -n "${UPTEST_CLOUD_CREDENTIALS:-}" ]]; then
-  echo "Creating cloud credential secret..."
-  ${KUBECTL} -n upbound-system create secret generic provider-secret --from-literal=credentials="${UPTEST_CLOUD_CREDENTIALS}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
+  # UPTEST_CLOUD_CREDENTIALS may contain more than one cloud credentials that we expect to be provided
+  # in a single GitHub secret. We expect them provided as key=value pairs separated by newlines. Currently we expect
+  # two AWS IAM user credentials to be provided. For example:
+  # DEFAULT='[default]
+  # aws_access_key_id = REDACTED
+  # aws_secret_access_key = REDACTED'
+  # PEER='[default]
+  # aws_access_key_id = REDACTED
+  # aws_secret_access_key = REDACTED'
+  eval "${UPTEST_CLOUD_CREDENTIALS}"
 
-  echo "Creating a default provider config..."
-  cat <<EOF | ${KUBECTL} apply -f -
+  if [[ -n "${DEFAULT:-}" ]]; then
+    echo "Creating the default cloud credentials secret..."
+    ${KUBECTL} -n upbound-system create secret generic provider-secret --from-literal=credentials="${DEFAULT}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
+
+    echo "Creating a default provider config..."
+    cat <<EOF | ${KUBECTL} apply -f -
 apiVersion: aws.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
@@ -21,4 +33,25 @@ spec:
       namespace: upbound-system
       key: credentials
 EOF
+  fi
+
+  if [[ -n "${PEER:-}" ]]; then
+    echo "Creating the peer cloud credentials secret for cross-account testing..."
+    ${KUBECTL} -n upbound-system create secret generic provider-secret-peer --from-literal=credentials="${PEER}" --dry-run=client -o yaml | ${KUBECTL} apply -f -
+
+    echo "Creating a peer provider config for cross-account testing..."
+    cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: peer
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      name: provider-secret-peer
+      namespace: upbound-system
+      key: credentials
+EOF
+  fi
 fi


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a change that would allow us to utilize a second IAM user for cross-account resource uptesting when the repo is properly configured with a second credentials environment variable.

A second `ProviderConfig.aws` named `peer` is provisioned in a different AWS account than the `default` `ProviderConfig`'s account for cross-account testing.

NOTE: This PR introduces a breaking change in the expected syntax for the Github repo secret `UPTEST_CLOUD_CREDENTIALS`, and the corresponding env. variable `UPTEST_CLOUD_CREDENTIALS` when running uptest locally with the associated make targets. It now has the following syntax:
```
DEFAULT='[default]
aws_access_key_id = REDACTED
aws_secret_access_key = REDACTED'
PEER='[default]
aws_access_key_id = REDACTED
aws_secret_access_key = REDACTED'
```

So the value of the env. variable is expected to have the `DEFAULT` key to be used as the default set of credentials, and another optional key named `PEER`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.
- [x] Update the vault key for `UPTEST_CLOUD_CREDENTIALS`
- [x] Change the syntax of the `UPTEST_CLOUD_CREDENTIALS` secret Github repo secret and add the second IAM user access credentials with the `PEER` key.
- [x] Update the vault key for `UPTEST_DATASOURCE`
- [x]  Update the `UPTEST_DATASOURCE` Github repo secret so that it contains the ID of this second account.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
A second `ProviderConfig.aws` named `peer` is now available in the test runtime:

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/9376684/205914186-b563c488-be26-4f16-a2f9-9f53c2476dd0.png">
