### PR TITLE
Add manual-intervention annotation for necessary resources in EventBridge resources

### DIFF
--- a/examples/cloudwatchevents/target.yaml
+++ b/examples/cloudwatchevents/target.yaml
@@ -2,6 +2,8 @@ apiVersion: cloudwatchevents.aws.upbound.io/v1beta1
 kind: Target
 metadata:
   name: aws-login
+  annotations:
+    upjet.upbound.io/manual-intervention: "This resource needs arn of Topic."
 spec:
   forProvider:
     arn: "arn:aws:sns:${data.aws_region}:${data.aws_account_id}:topic"
@@ -22,6 +24,8 @@ metadata:
   labels:
     testing.upbound.io/example-name: login-rule
   name: login-rule
+  annotations:
+    upjet.upbound.io/manual-intervention: "This resource is necessary to create the root resource."
 spec:
   forProvider:
     description: Capture all EC2 scaling events
@@ -44,6 +48,8 @@ metadata:
   labels:
     testing.upbound.io/example-name: topic
   name: topic
+  annotations:
+    upjet.upbound.io/manual-intervention: "This resource is necessary to create the root resource."
 spec:
   forProvider:
     policy: |
@@ -68,6 +74,8 @@ metadata:
   labels:
     testing.upbound.io/example-name: target-bus
   name: target-bus
+  annotations:
+    upjet.upbound.io/manual-intervention: "This resource is necessary to create the root resource."
 spec:
   forProvider:
     region: us-west-1


### PR DESCRIPTION
Signed-off-by: Sergen Yalçın <yalcinsergen97@gmail.com>

### Description of your changes

This PR adds manual-intervention annotation for necessary resources in EventBridge resources.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Uptest

`aws_cloudwatch_event_api_destination`, `aws_cloudwatch_event_archive`, `aws_cloudwatch_event_bus`, `aws_cloudwatch_event_bus_policy`, `aws_cloudwatch_event_connection`, `aws_cloudwatch_event_permission`, `aws_cloudwatch_event_rule`, `aws_cloudwatch_event_target`: https://github.com/upbound/provider-aws/actions/runs/3684459356
