### PR TITLE
Amend SecurityGroupRule late init fix

### DIFF
--- a/apis/ec2/v1beta1/zz_generated_terraformed.go
+++ b/apis/ec2/v1beta1/zz_generated_terraformed.go
@@ -4752,6 +4752,8 @@ func (tr *SecurityGroupRule) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("CidrBlocks"))
+	opts = append(opts, resource.WithNameFilter("IPv6CidrBlocks"))
 	opts = append(opts, resource.WithNameFilter("Self"))
 	opts = append(opts, resource.WithNameFilter("SourceSecurityGroupID"))
 

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -196,7 +196,10 @@ func Configure(p *config.Provider) {
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{
-				"self", "source_security_group_id",
+				"cidr_blocks",
+				"ipv6_cidr_blocks",
+				"self",
+				"source_security_group_id",
 			},
 		}
 	})

--- a/examples/ec2/securitygrouprule-self-true.yaml
+++ b/examples/ec2/securitygrouprule-self-true.yaml
@@ -1,6 +1,8 @@
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: VPC
 metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/securitygrouprule
   name: sample-vpc
 spec:
   forProvider:
@@ -14,6 +16,8 @@ spec:
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: SecurityGroup
 metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/securitygrouprule
   labels:
     selector: here-i-am
   name: test-vpc
@@ -29,6 +33,8 @@ spec:
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: SecurityGroupRule
 metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/securitygrouprule
   name: test-vpc-securitygroup
 spec:
   deletionPolicy: Delete


### PR DESCRIPTION


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


### Description of your changes

* Extend LateInit field list following the tf documentation https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule#self
* Group examples with the special annotation

Signed-off-by: Yury Tsarev <yury@upbound.io>

Follow up to #229 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested


```
make run
k apply -f examples/ec2/securitygrouprule-self-true.yaml`
k get -f examples/ec2/securitygrouprule-self-true.yaml
NAME                                READY   SYNCED   EXTERNAL-NAME           AGE
vpc.ec2.aws.upbound.io/sample-vpc   True    True     vpc-0e32df8eeb7da09f8   9m39s

NAME                                        READY   SYNCED   EXTERNAL-NAME          AGE
securitygroup.ec2.aws.upbound.io/test-vpc   True    True     sg-0d07d08552c9afea9   9m39s

NAME                                                          READY   SYNCED   EXTERNAL-NAME       AGE
securitygrouprule.ec2.aws.upbound.io/test-vpc-securitygroup   True    True     sgrule-3476840432   9m39s
```

