### PR TITLE
fix kms alias name

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -1611,7 +1611,7 @@ func kmsAlias() config.ExternalName {
 	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
 		id, ok := tfstate["id"]
 		if !ok {
-			return "", errors.Errorf("id attribute missing from state file")
+			return "", errors.New("id attribute missing from state file")
 		}
 
 		idStr, ok := id.(string)

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -494,8 +494,8 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	//
 	// 1234abcd-12ab-34cd-56ef-1234567890ab
 	"aws_kms_key": config.IdentifierFromProvider,
-	// KMS aliases can be imported using the name
-	"aws_kms_alias": config.NameAsIdentifier,
+	// KMS aliases are imported using "alias/" + name
+	"aws_kms_alias": kmsAlias(),
 	// No import
 	"aws_kms_ciphertext": config.IdentifierFromProvider,
 	// KMS External Keys can be imported using the id
@@ -1594,6 +1594,34 @@ func iamUserGroupMembership() config.ExternalName {
 		}
 		return strings.Join(append([]string{u.(string)}, groups...), "/"), nil
 	}
+	return e
+}
+
+func kmsAlias() config.ExternalName {
+	e := config.NameAsIdentifier
+	e.SetIdentifierArgumentFn = func(base map[string]interface{}, externalName string) {
+		if _, ok := base["name"]; !ok {
+			if !strings.HasPrefix(externalName, "alias/") {
+				base["name"] = fmt.Sprintf("alias/%s", externalName)
+			} else {
+				base["name"] = externalName
+			}
+		}
+	}
+	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
+		id, ok := tfstate["id"]
+		if !ok {
+			return "", errors.Errorf("id attribute missing from state file")
+		}
+
+		idStr, ok := id.(string)
+		if !ok {
+			return "", errors.New("value of id needs to be string")
+		}
+
+		return strings.TrimPrefix(idStr, "alias/"), nil
+	}
+
 	return e
 }
 

--- a/examples/kms/alias.yaml
+++ b/examples/kms/alias.yaml
@@ -1,9 +1,7 @@
 apiVersion: kms.aws.upbound.io/v1beta1
 kind: Alias
 metadata:
-  name: example
-  annotations:
-    crossplane.io/external-name: alias/my-key-alias
+  name: sample-key-alias
 spec:
   forProvider:
     region: us-east-1


### PR DESCRIPTION
Signed-off-by: Steven Borrelli <steve@borrelli.org>



### Description of your changes

Update name/external-name handling on KMS alias. 

Fixes #24

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've tested locally using the following manifest to test importing external names of the format "name" and "alias/name":

```yaml
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Key
metadata:
  name: official-provider-google
spec:
  forProvider:
    region: us-west-2
    description: Key For Testing containeraws.gcp.upbound.io resources
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Alias
metadata:
  name: official-provider-google
#  annotations:
#    crossplane.io/external-name: "alias/official-provider-google"
spec:
  forProvider:
    region: us-west-2
    targetKeyIdRef:
      name: official-provider-google
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Key
metadata:
  name: test-import
spec:
  forProvider:
    region: us-west-2
    description: Key For Testing 
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Alias
metadata:
  name: test-import
  annotations:
    crossplane.io/external-name: "alias/test-import"
spec:
  forProvider:
    region: us-west-2
    targetKeyIdRef:
      name: test-import
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Key
metadata:
  name: test-import-2
spec:
  forProvider:
    region: us-west-2
    description: Key For Testing 
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Alias
metadata:
  name: test-import-2
  annotations:
    crossplane.io/external-name: "test-import-2"
spec:
  forProvider:
    region: us-west-2
    targetKeyIdRef:
      name: test-import-2
```

