### PR TITLE
waf: Configured 11 resources; wafregional: Configured 10 resources

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -653,4 +653,51 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	// No import
 	// TODO: For now API is not normalized. While testing resource we can check the actual ID and normalize the API.
 	"aws_inspector_resource_group": config.IdentifierFromProvider,
+	// waf
+	//
+	// WAF Byte Match Set can be imported using the id
+	"aws_waf_byte_match_set": config.IdentifierFromProvider,
+	// WAF Geo Match Set can be imported using their ID
+	"aws_waf_geo_match_set": config.IdentifierFromProvider,
+	// WAF IPSets can be imported using their ID
+	"aws_waf_ipset": config.IdentifierFromProvider,
+	// WAF Rated Based Rule can be imported using the id
+	"aws_waf_rate_based_rule": config.IdentifierFromProvider,
+	// WAF Regex Match Set can be imported using their ID
+	"aws_waf_regex_match_set": config.IdentifierFromProvider,
+	// AWS WAF Regex Pattern Set can be imported using their ID
+	"aws_waf_regex_pattern_set": config.IdentifierFromProvider,
+	// WAF rules can be imported using the id
+	"aws_waf_rule": config.IdentifierFromProvider,
+	// AWS WAF Size Constraint Set can be imported using their ID
+	"aws_waf_size_constraint_set": config.IdentifierFromProvider,
+	// AWS WAF SQL Injection Match Set can be imported using their ID
+	"aws_waf_sql_injection_match_set": config.IdentifierFromProvider,
+	// WAF Web ACL can be imported using the id
+	"aws_waf_web_acl": config.IdentifierFromProvider,
+	// WAF XSS Match Set can be imported using their ID
+	"aws_waf_xss_match_set": config.IdentifierFromProvider,
+
+	// wafregional
+	//
+	// WAF Regional Byte Match Set can be imported using the id
+	"aws_wafregional_byte_match_set": config.IdentifierFromProvider,
+	// WAF Regional Geo Match Set can be imported using the id
+	"aws_wafregional_geo_match_set": config.IdentifierFromProvider,
+	// WAF Regional IPSets can be imported using their ID
+	"aws_wafregional_ipset": config.IdentifierFromProvider,
+	// WAF Regional Rate Based Rule can be imported using the id
+	"aws_wafregional_rate_based_rule": config.IdentifierFromProvider,
+	// WAF Regional Regex Match Set can be imported using the id
+	"aws_wafregional_regex_match_set": config.IdentifierFromProvider,
+	// WAF Regional Regex Pattern Set can be imported using the id
+	"aws_wafregional_regex_pattern_set": config.IdentifierFromProvider,
+	// WAF Regional Rule can be imported using the id
+	"aws_wafregional_rule": config.IdentifierFromProvider,
+	// WAF Size Constraint Set can be imported using the id
+	"aws_wafregional_size_constraint_set": config.IdentifierFromProvider,
+	// WAF Regional Sql Injection Match Set can be imported using the id
+	"aws_wafregional_sql_injection_match_set": config.IdentifierFromProvider,
+	// WAF Regional Web ACL can be imported using the id
+	"aws_wafregional_web_acl": config.IdentifierFromProvider,
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Added configuration for 11 resources in the `waf` group:
- [x] [`aws_waf_byte_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_byte_match_set)
- [x] [`aws_waf_geo_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_geo_match_set)
- [x] [`aws_waf_ipset`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_ipset)
- [x] [`aws_waf_rate_based_rule`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_rate_based_rule)
- [x] [`aws_waf_regex_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_regex_match_set)
- [x] [`aws_waf_regex_pattern_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_regex_pattern_set)
- [x] [`aws_waf_rule`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_rule)
- [x] [`aws_waf_size_constraint_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_size_constraint_set)
- [x] [`aws_waf_sql_injection_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_sql_injection_match_set)
- [x] [`aws_waf_web_acl`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_web_acl)
- [x] [`aws_waf_xss_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_xss_match_set)

Added configuration for 10 resources in the `wafregional` group:
- [x] [`aws_wafregional_byte_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_byte_match_set)
- [x] [`aws_wafregional_geo_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_geo_match_set)
- [x] [`aws_wafregional_ipset`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_ipset)
- [x] [`aws_wafregional_rate_based_rule`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_rate_based_rule)
- [x] [`aws_wafregional_regex_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_regex_match_set)
- [x] [`aws_wafregional_regex_pattern_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_regex_pattern_set)
- [x] [`aws_wafregional_rule`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_rule)
- [x] [`aws_wafregional_size_constraint_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_size_constraint_set)
- [x] [`aws_wafregional_sql_injection_match_set`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_sql_injection_match_set)
- [x] [`aws_wafregional_web_acl`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_web_acl)

extracted from https://github.com/upbound/provider-aws/issues/53

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #36 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
