### PR TITLE
Configured transfer(2) group resources

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -829,4 +829,12 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	//
 	// SimpleDB Domains can be imported using the name
 	"aws_simpledb_domain": config.NameAsIdentifier,
+
+	// transfer
+	//
+	// Transfer SSH Public Key can be imported using the server_id and user_name and ssh_public_key_id separated by /
+	// Example: s-12345678/test-username/key-12345
+	"aws_transfer_ssh_key": config.IdentifierFromProvider,
+	// Transfer Workflows can be imported using the worflow_id
+	"aws_transfer_workflow": config.IdentifierFromProvider,
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add configuration of 2 resources in the `transfer` group:
- [x] [`aws_transfer_ssh_key`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_ssh_key)
- [x] [`aws_transfer_workflow`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_workflow)
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #41 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
