### PR TITLE
Add configuration for gorups elasticbeanstalk(2), imagebuilder(1)

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -309,10 +309,12 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 
 	// elasticbeanstalk
 	//
-	// Elastic Beanstalk Applications can be imported using the name
-	"aws_elastic_beanstalk_application": config.NameAsIdentifier,
 	// No import
 	"aws_elastic_beanstalk_configuration_template": config.NameAsIdentifier,
+	// Elastic Beanstalk Applications can be imported using the name
+	"aws_elastic_beanstalk_application": config.NameAsIdentifier,
+	// Elastic Beanstalk Environments can be imported using the id
+	"aws_elastic_beanstalk_environment": config.IdentifierFromProvider,
 
 	// elasticsearch
 	//
@@ -630,6 +632,10 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	// aws_imagebuilder_infrastructure_configuration can be imported using the Amazon Resource Name (ARN)
 	// Example: arn:aws:imagebuilder:us-east-1:123456789012:infrastructure-configuration/example
 	"aws_imagebuilder_infrastructure_configuration": config.TemplatedStringAsIdentifier("name", "arn:aws:imagebuilder:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:infrastructure-configuration/{{ .external_name }}"),
+	// aws_imagebuilder_components resources can be imported by using the Amazon Resource Name (ARN)
+	// Example: arn:aws:imagebuilder:us-east-1:123456789012:component/example/1.0.0/1
+	// TODO: Normalize external_name while testing
+	"aws_imagebuilder_component": config.IdentifierFromProvider,
 
 	// inspector
 	//


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add configuration of 2 resource in the `elasticbeanstalk` group:
- [ ] [aws_elastic_beanstalk_application_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_application)
- [ ] [aws_elastic_beanstalk_environment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_environment)

Add configuration of 1 resource in the `imagebuilder` group:
- [ ] [aws_imagebuilder_component](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/imagebuilder_component)
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #400 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
