### PR TITLE
Add configuretion for elasticbeanstalk(2), imagebuilder(1)

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -314,6 +314,13 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	// Example: 123456789012:example
 	"aws_s3control_object_lambda_access_point_policy": config.TemplatedStringAsIdentifier("name", "{{ .parameters.account_id }}:{{ .external_name }}"),
 
+	// elasticbeanstalk
+	//
+	// Elastic Beanstalk Applications can be imported using the name
+	"aws_elastic_beanstalk_application_version": config.NameAsIdentifier,
+	// Elastic Beanstalk Environments can be imported using the id
+	"aws_elastic_beanstalk_environment": config.IdentifierFromProvider,
+
 	// elasticsearch
 	//
 	// Elasticsearch domains can be imported using the domain_name
@@ -777,4 +784,9 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	"aws_xray_group": config.IdentifierFromProvider,
 	// XRay Sampling Rules can be imported using the name
 	"aws_xray_sampling_rule": config.ParameterAsIdentifier("rule_name"),
+
+	// imagebuilder
+	//
+	// aws_imagebuilder_components resources can be imported by using the Amazon Resource Name (ARN)
+	"aws_imagebuilder_component": config.IdentifierFromProvider,
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add configuration of 2 resource in the `elasticbeanstalk` group:
- [x] [aws_elastic_beanstalk_application_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_application)
- [x] [aws_elastic_beanstalk_environment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_environment)

Add configuration of 1 resource in the `imagebuilder` group:
- [x] [aws_imagebuilder_component](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/imagebuilder_component)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #400 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
