### PR TITLE
Add missing SecurityGroup selectors to EFS MountTarget

### DIFF
--- a/apis/efs/v1beta1/zz_generated.deepcopy.go
+++ b/apis/efs/v1beta1/zz_generated.deepcopy.go
@@ -1054,6 +1054,18 @@ func (in *MountTargetParameters) DeepCopyInto(out *MountTargetParameters) {
 			}
 		}
 	}
+	if in.SecurityGroupsRefs != nil {
+		in, out := &in.SecurityGroupsRefs, &out.SecurityGroupsRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SecurityGroupsSelector != nil {
+		in, out := &in.SecurityGroupsSelector, &out.SecurityGroupsSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SubnetID != nil {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = new(string)

--- a/apis/efs/v1beta1/zz_mounttarget_types.go
+++ b/apis/efs/v1beta1/zz_mounttarget_types.go
@@ -67,8 +67,17 @@ type MountTargetParameters struct {
 
 	// A list of up to 5 VPC security group IDs (that must
 	// be for the same VPC as subnet specified) in effect for the mount target.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +kubebuilder:validation:Optional
 	SecurityGroups []*string `json:"securityGroups,omitempty" tf:"security_groups,omitempty"`
+
+	// References to SecurityGroup in ec2 to populate securityGroups.
+	// +kubebuilder:validation:Optional
+	SecurityGroupsRefs []v1.Reference `json:"securityGroupsRefs,omitempty" tf:"-"`
+
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroups.
+	// +kubebuilder:validation:Optional
+	SecurityGroupsSelector *v1.Selector `json:"securityGroupsSelector,omitempty" tf:"-"`
 
 	// The ID of the subnet to add the mount target in.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet

--- a/config/efs/config.go
+++ b/config/efs/config.go
@@ -12,6 +12,9 @@ func Configure(p *config.Provider) {
 		r.References["subnet_id"] = config.Reference{
 			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
 		}
+		r.References["security_groups"] = config.Reference{
+			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+		}
 		/*r.MetaResource.Examples[0].Dependencies["aws_efs_file_system.foo"] = `{"creation_token": "my-product-foo", "region": "us-west-1"}`
 		if err := r.MetaResource.Examples[0].Dependencies.SetPathValue("aws_subnet.alpha", "availability_zone", "us-west-1b"); err != nil {
 			panic(err)

--- a/examples/efs/mounttarget.yaml
+++ b/examples/efs/mounttarget.yaml
@@ -11,6 +11,9 @@ spec:
     subnetIdSelector:
       matchLabels:
         testing.upbound.io/example-name: efs
+    securityGroupsSelector:
+      matchLabels:
+        testing.upbound.io/example-name: efs
 ---
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: VPC
@@ -39,3 +42,16 @@ spec:
       matchLabels:
         testing.upbound.io/example-name: efs
     cidrBlock: 172.16.10.0/24
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroup
+metadata:
+  labels:
+    testing.upbound.io/example-name: efs
+  name: efs-sg
+spec:
+  forProvider:
+    region: us-west-1
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: efs

--- a/examples/efs/mounttarget.yaml
+++ b/examples/efs/mounttarget.yaml
@@ -63,3 +63,18 @@ spec:
     vpcIdSelector:
       matchLabels:
         testing.upbound.io/example-name: efs
+---
+apiVersion: efs.aws.upbound.io/v1beta1
+kind: FileSystem
+metadata:
+  annotations:
+    meta.upbound.io/example-id: efs/v1beta1/mounttarget
+  name: example
+  labels:
+    testing.upbound.io/example-name: efs
+spec:
+  forProvider:
+    region: us-west-1
+    creationToken: my-product
+    tags:
+      Name: MyProduct

--- a/examples/efs/mounttarget.yaml
+++ b/examples/efs/mounttarget.yaml
@@ -1,6 +1,8 @@
 apiVersion: efs.aws.upbound.io/v1beta1
 kind: MountTarget
 metadata:
+  annotations:
+    meta.upbound.io/example-id: efs/v1beta1/mounttarget
   name: example
 spec:
   forProvider:
@@ -18,9 +20,11 @@ spec:
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: VPC
 metadata:
-  name: sample-vpc
+  annotations:
+    meta.upbound.io/example-id: efs/v1beta1/mounttarget
   labels:
     testing.upbound.io/example-name: efs
+  name: sample-vpc
 spec:
   forProvider:
     region: us-west-1
@@ -31,9 +35,11 @@ spec:
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: Subnet
 metadata:
-  name: efs-subnet1
+  annotations:
+    meta.upbound.io/example-id: efs/v1beta1/mounttarget
   labels:
     testing.upbound.io/example-name: efs
+  name: efs-subnet1
 spec:
   forProvider:
     region: us-west-1
@@ -46,6 +52,8 @@ spec:
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: SecurityGroup
 metadata:
+  annotations:
+    meta.upbound.io/example-id: efs/v1beta1/mounttarget
   labels:
     testing.upbound.io/example-name: efs
   name: efs-sg

--- a/package/crds/efs.aws.upbound.io_mounttargets.yaml
+++ b/package/crds/efs.aws.upbound.io_mounttargets.yaml
@@ -157,6 +157,83 @@ spec:
                     items:
                       type: string
                     type: array
+                  securityGroupsRefs:
+                    description: References to SecurityGroup in ec2 to populate securityGroups.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: Resolution specifies whether resolution
+                                of this reference is required. The default is 'Required',
+                                which means the reconcile will fail if the reference
+                                cannot be resolved. 'Optional' means this reference
+                                will be a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: Resolve specifies when this reference should
+                                be resolved. The default is 'IfNotPresent', which
+                                will attempt to resolve the reference only when the
+                                corresponding field is not present. Use 'Always' to
+                                resolve the reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  securityGroupsSelector:
+                    description: Selector for a list of SecurityGroup in ec2 to populate
+                      securityGroups.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   subnetId:
                     description: The ID of the subnet to add the mount target in.
                     type: string


### PR DESCRIPTION

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* MountTarget of official provider was missing the selectors for SecurityGroup
* It is regression assuming scenario of migration from the community provider-aws, as the references are there https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.33.0/resources/efs.aws.crossplane.io/MountTarget/v1alpha1#doc:spec-forProvider-securityGroupsRefs

Signed-off-by: Yury Tsarev <yury@upbound.io>
I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

uptest with the comment below
