### PR TITLE
Fix ec2: `TransitGatewayRouteTablePropagation` inverted `transit_gateway_attachment_id` and `transit_gateway_route_table_id`ids

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -202,7 +202,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// Imported by using the EC2 Transit Gateway Route Table identifier, an
 	// underscore, and the EC2 Transit Gateway Attachment identifier:
 	// tgw-rtb-12345678_tgw-attach-87654321
-	"aws_ec2_transit_gateway_route_table_propagation": FormattedIdentifierFromProvider("_", "transit_gateway_attachment_id", "transit_gateway_route_table_id"),
+	"aws_ec2_transit_gateway_route_table_propagation": FormattedIdentifierFromProvider("_", "transit_gateway_route_table_id", "transit_gateway_attachment_id"),
 	// Imported using the id: igw-c0a643a9
 	"aws_internet_gateway": config.IdentifierFromProvider,
 	// NAT Gateways can be imported using the id


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

I inverted the `transit_gateway_attachment_id` and `transit_gateway_route_table_id` in the `aws_ec2_transit_gateway_route_table_propagation`  external name. Because IDs were inverted as suspected in #434 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #434

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I deployed the freshly built provider in my setup, it created the expected `TransitGatewayRouteTablePropagation`.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
