### PR TITLE
EndpointService NLB ARN selector and reference parameter added

### DIFF
--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -22249,6 +22249,18 @@ func (in *VPCEndpointServiceParameters) DeepCopyInto(out *VPCEndpointServicePara
 			}
 		}
 	}
+	if in.NetworkLoadBalancerArnRefs != nil {
+		in, out := &in.NetworkLoadBalancerArnRefs, &out.NetworkLoadBalancerArnRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.NetworkLoadBalancerArnSelector != nil {
+		in, out := &in.NetworkLoadBalancerArnSelector, &out.NetworkLoadBalancerArnSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NetworkLoadBalancerArns != nil {
 		in, out := &in.NetworkLoadBalancerArns, &out.NetworkLoadBalancerArns
 		*out = make([]*string, len(*in))

--- a/apis/ec2/v1beta1/zz_vpcendpointservice_types.go
+++ b/apis/ec2/v1beta1/zz_vpcendpointservice_types.go
@@ -77,7 +77,18 @@ type VPCEndpointServiceParameters struct {
 	// +kubebuilder:validation:Optional
 	GatewayLoadBalancerArns []*string `json:"gatewayLoadBalancerArns,omitempty" tf:"gateway_load_balancer_arns,omitempty"`
 
+	// References to  to populate networkLoadBalancerArns.
+	// +kubebuilder:validation:Optional
+	NetworkLoadBalancerArnRefs []v1.Reference `json:"networkLoadBalancerArnRefs,omitempty" tf:"-"`
+
+	// Selector for a list of  to populate networkLoadBalancerArns.
+	// +kubebuilder:validation:Optional
+	NetworkLoadBalancerArnSelector *v1.Selector `json:"networkLoadBalancerArnSelector,omitempty" tf:"-"`
+
 	// Amazon Resource Names (ARNs) of one or more Network Load Balancers for the endpoint service.
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
+	// +crossplane:generate:reference:refFieldName=NetworkLoadBalancerArnRefs
+	// +crossplane:generate:reference:selectorFieldName=NetworkLoadBalancerArnSelector
 	// +kubebuilder:validation:Optional
 	NetworkLoadBalancerArns []*string `json:"networkLoadBalancerArns,omitempty" tf:"network_load_balancer_arns,omitempty"`
 

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -285,6 +285,11 @@ func Configure(p *config.Provider) {
 		// Mutually exclusive with:
 		// vpc_endpoint_service_allowed_principal
 		config.MoveToStatus(r.TerraformResource, "allowed_principals")
+		r.References["network_load_balancer_arns"] = config.Reference{
+			RefFieldName:      "NetworkLoadBalancerArnRefs",
+			SelectorFieldName: "NetworkLoadBalancerArnSelector",
+			Extractor:         common.PathARNExtractor,
+		}
 	})
 
 	p.AddResourceConfigurator("aws_flow_log", func(r *config.Resource) {

--- a/examples-generated/ec2/vpcendpointconnectionnotification.yaml
+++ b/examples-generated/ec2/vpcendpointconnectionnotification.yaml
@@ -58,8 +58,8 @@ metadata:
 spec:
   forProvider:
     acceptanceRequired: false
-    networkLoadBalancerArns:
-    - ${aws_lb.test.arn}
+    networkLoadBalancerArnRefs:
+    - name: test
     region: us-west-1
 
 ---

--- a/examples-generated/ec2/vpcendpointservice.yaml
+++ b/examples-generated/ec2/vpcendpointservice.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   forProvider:
     acceptanceRequired: false
-    networkLoadBalancerArns:
-    - ${aws_lb.example.arn}
+    networkLoadBalancerArnRefs:
+    - name: example
     region: us-west-1
 
 ---

--- a/package/crds/ec2.aws.upbound.io_vpcendpointservices.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcendpointservices.yaml
@@ -75,6 +75,82 @@ spec:
                     items:
                       type: string
                     type: array
+                  networkLoadBalancerArnRefs:
+                    description: References to  to populate networkLoadBalancerArns.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: Resolution specifies whether resolution
+                                of this reference is required. The default is 'Required',
+                                which means the reconcile will fail if the reference
+                                cannot be resolved. 'Optional' means this reference
+                                will be a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: Resolve specifies when this reference should
+                                be resolved. The default is 'IfNotPresent', which
+                                will attempt to resolve the reference only when the
+                                corresponding field is not present. Use 'Always' to
+                                resolve the reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  networkLoadBalancerArnSelector:
+                    description: Selector for a list of  to populate networkLoadBalancerArns.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   networkLoadBalancerArns:
                     description: Amazon Resource Names (ARNs) of one or more Network
                       Load Balancers for the endpoint service.


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Existing:
VPCEndpointservice resource requires networkLoadBalancerArn as a input, so user has to add NLB arn directly, there is no option to refer or select NLB ARN with labels, so I have added "NetworkLoadBalancerArnRefs" and "NetworkLoadBalancerArnSelector" to make this easy.

Fixes #425 
-->
Fixes #

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.
- [ ] I have manual tested specific changes.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
