### PR TITLE
allow using assumeRoleChain with IAM resources

### DIFF
--- a/internal/clients/provider_config.go
+++ b/internal/clients/provider_config.go
@@ -264,9 +264,14 @@ func UseProviderSecret(ctx context.Context, data []byte, profile, region string)
 // AssumeRoleWithWebIdentity & AssumeRoles.
 func GetRoleChainConfig(ctx context.Context, pcs *v1beta1.ProviderConfigSpec, cfg *aws.Config) (*aws.Config, error) {
 	pCfg := cfg
+	regionOpt := func(o *sts.Options) {
+		if cfg.Region == "" {
+			o.Region = GlobalRegion
+		}
+	}
 	for _, aro := range pcs.AssumeRoleChain {
 		stsAssume := stscreds.NewAssumeRoleProvider(
-			sts.NewFromConfig(*pCfg), //nolint:contextcheck
+			sts.NewFromConfig(*pCfg, regionOpt), //nolint:contextcheck
 			aws.ToString(aro.RoleARN),
 			SetAssumeRoleOptions(aro),
 		)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #215

currently assumeRoleChain doesn't work for IAM resources because IAM resources don't require a region. the error is
```
cannot get terraform setup: failed to retrieve aws credentials from aws config: failed to refresh cached credentials, operation error STS: AssumeRole, failed to resolve service endpoint, an AWS region is required, but was not found
```
this change adds a fallback to "aws-global" region for STS requests in cases where no region is set in the managed resource

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I built the provider w/ the fix, installed it in my environment, and confirmed I no longer get the 'region is required' error
