### PR TITLE
add username to rds connection details

### DIFF
--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -79,6 +79,9 @@ func Configure(p *config.Provider) {
 			if a, ok := attr["endpoint"].(string); ok {
 				conn["endpoint"] = []byte(a)
 			}
+			if a, ok := attr["username"].(string); ok {
+				conn["username"] = []byte(a)
+			}
 			return conn, nil
 		}
 	})


### PR DESCRIPTION
Signed-off-by: josephferrero <joeferrero14@gmail.com>

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Added `username` to the RDS instance connection secret.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #442 ":

-->
Fixes #442 for the request to add the username to the connection secret. Note that the port is now included in the endpoint address, so it is not required to achieve feature parity with the `database.aws.crossplane.io/v1beta1` provider.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have run `make local-deploy` and created an RDS instance in AWS to test creation of the secret. 
