### PR TITLE
Fix KMSKeyID reference extractor for Instance.rds

### DIFF
--- a/apis/rds/v1beta1/zz_generated.resolvers.go
+++ b/apis/rds/v1beta1/zz_generated.resolvers.go
@@ -487,7 +487,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.KMSKeyID),
-		Extract:      reference.ExternalName(),
+		Extract:      common.ARNExtractor(),
 		Reference:    mg.Spec.ForProvider.KMSKeyIDRef,
 		Selector:     mg.Spec.ForProvider.KMSKeyIDSelector,
 		To: reference.To{

--- a/apis/rds/v1beta1/zz_instance_types.go
+++ b/apis/rds/v1beta1/zz_instance_types.go
@@ -215,6 +215,7 @@ type InstanceParameters struct {
 	// The ARN for the KMS encryption key. If creating an
 	// encrypted replica, set this to the destination KMS ARN.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -6,6 +6,8 @@ package rds
 
 import (
 	"github.com/upbound/upjet/pkg/config"
+
+	"github.com/upbound/provider-aws/config/common"
 )
 
 // Configure adds configurations for rds group.
@@ -69,6 +71,10 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_db_instance", func(r *config.Resource) {
 		r.References["db_subnet_group_name"] = config.Reference{
 			Type: "SubnetGroup",
+		}
+		r.References["kms_key_id"] = config.Reference{
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.UseAsync = true
 		r.LateInitializer = config.LateInitializer{

--- a/examples/rds/instance.yaml
+++ b/examples/rds/instance.yaml
@@ -5,7 +5,7 @@ metadata:
     meta.upbound.io/example-id: rds/v1beta1/instance
   labels:
     testing.upbound.io/example-name: example-dbinstance
-  name: example-dbinstance
+  name: example-dbinstance-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
     region: us-west-1
@@ -25,8 +25,11 @@ spec:
     maintenanceWindow: "Mon:00:00-Mon:03:00"
     publiclyAccessible: false
     skipFinalSnapshot: true
-    storageEncrypted: false
+    storageEncrypted: true
     storageType: gp2
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-key
   writeConnectionSecretToRef:
     name: example-dbinstance-out
     namespace: default
@@ -45,3 +48,19 @@ metadata:
 type: Opaque
 stringData:
   password: "Upbound!"
+
+---
+
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-key
+  name: sample-key-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #411 

This PR changes the auto-injected reference extractor for the `KMSKeyID` of `rds.Instance` to `common.ARNExtractor`. Also adds a `kms.Key` as a dependency to the example manifest of `rds.Instance`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The ARN is correctly resolved now:
```yaml
spec:
  deletionPolicy: Delete
  forProvider:
    kmsKeyId: arn:aws:kms:us-west-1:<account>:key/f3766940-bfde-4304-bb31-ea04be153547
    kmsKeyIdRef:
      name: sample-key
    kmsKeyIdSelector:
      matchLabels:
        testing.upbound.io/example-name: sample-key
```

Corresponding uptest run: https://github.com/upbound/provider-aws/actions/runs/4113302303