### PR TITLE
Add configurations of datasync (1), directory_service (4), dms (1), dx (1), dynamodb (1), ec2 (4), efs (1), emrserverless (1), evidently (3), fis (1), fix (1), glue (1), grafana (1), identitystore (3), inspector2 (3), ivs (3) groups

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -712,4 +712,127 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	// Control Tower Controls can be imported using their organizational_unit_arn/control_identifier
 	// Example: arn:aws:organizations::123456789101:ou/o-qqaejywet/ou-qg5o-ufbhdtv3,arn:aws:controltower:us-east-1::control/WTDSMKDKDNLE
 	"aws_controltower_control": config.TemplatedStringAsIdentifier("", "{{ .parameters.target_identifier }},{{ .external_name }}"),
+	// datasync
+	//
+	// aws_datasync_location_object_storage can be imported by using the Amazon Resource Name (ARN)
+	// Example: arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+	"aws_datasync_location_object_storage": config.TemplatedStringAsIdentifier("", "arn:aws:datasync:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:location/{{ .external_name }}"),
+
+	// directory_service
+	//
+	// RADIUS settings can be imported using the directory ID
+	"aws_directory_service_radius_settings": config.IdentifierFromProvider,
+	// Replicated Regions can be imported using directory ID,Region name
+	"aws_directory_service_region": config.IdentifierFromProvider,
+	// Directory Service Shared Directories can be imported using the owner directory ID/shared directory ID
+	"aws_directory_service_shared_directory": config.TemplatedStringAsIdentifier("", "{{ .parameters.directory_id }}/{{ .external_name }}"),
+	// Directory Service Shared Directories can be imported using the shared directory ID
+	"aws_directory_service_shared_directory_accepter": config.IdentifierFromProvider,
+
+	// dms
+	//
+	// Endpoints can be imported using the endpoint_id
+	"aws_dms_s3_endpoint": config.ParameterAsIdentifier("endpoint_id"),
+
+	// dx
+	//
+	// No import
+	// TODO: For now API is not normalized. While testing resource we can check the actual ID and normalize the API.
+	"aws_dx_macsec_key_association": config.IdentifierFromProvider,
+
+	// dynamodb
+	//
+	// DynamoDB table replicas can be imported using the table-name:main-region
+	"aws_dynamodb_table_replica": config.IdentifierFromProvider,
+
+	// ec2
+	//
+	// aws_ec2_instance_state can be imported by using the instance_id attribute
+	"aws_ec2_instance_state": config.IdentifierFromProvider,
+	// Network Insights Analyses can be imported using the id
+	"aws_ec2_network_insights_analysis": config.IdentifierFromProvider,
+	// aws_ec2_transit_gateway_policy_table can be imported by using the EC2 Transit Gateway Policy Table identifier
+	"aws_ec2_transit_gateway_policy_table": config.IdentifierFromProvider,
+	// aws_ec2_transit_gateway_policy_table_association can be imported by using the EC2 Transit Gateway Policy Table identifier, an underscore, and the EC2 Transit Gateway Attachment identifier
+	"aws_ec2_transit_gateway_policy_table_association": config.IdentifierFromProvider,
+
+	// efs
+	//
+	// EFS Replication Configurations can be imported using the file system ID of either the source or destination file system
+	"aws_efs_replication_configuration": config.IdentifierFromProvider,
+
+	// emrserverless
+	//
+	// EMR Severless applications can be imported using the id
+	"aws_emrserverless_application": config.IdentifierFromProvider,
+
+	// evidently
+	//
+	// CloudWatch Evidently Feature can be imported using the feature name and name or arn of the hosting CloudWatch Evidently Project separated by a :
+	// Example: exampleFeatureName:arn:aws:evidently:us-east-1:123456789012:project/example
+	"aws_evidently_feature": config.TemplatedStringAsIdentifier("name", "{{ .external_name }}:{{ .parameters.project }}"),
+	// CloudWatch Evidently Project can be imported using the arn
+	// Example: arn:aws:evidently:us-east-1:123456789012:segment/example
+	// TODO: Maybe there is a typo in documentation. Check while teting
+	"aws_evidently_project": config.TemplatedStringAsIdentifier("name", "arn:aws:evidently:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:project/{{ .external_name }}"),
+	// CloudWatch Evidently Segment can be imported using the arn
+	// Example: arn:aws:evidently:us-west-2:123456789012:segment/example
+	"aws_evidently_segment": config.TemplatedStringAsIdentifier("name", "arn:aws:evidently:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:segment/{{ .external_name }}"),
+
+	// fis
+	//
+	// FIS Experiment Templates can be imported using the id
+	"aws_fis_experiment_template": config.IdentifierFromProvider,
+
+	// fsx
+	//
+	// Amazon File Cache cache can be imported using the resource id
+	"aws_fsx_file_cache": config.IdentifierFromProvider,
+
+	// glue
+	//
+	// Glue Registries can be imported using arn
+	// Example: arn:aws:glue:us-west-2:123456789012:schema/example/example
+	// TODO: The ARN in documentation doesn't match ARN given for the aws_glue_registry resource. Check while testing
+	"aws_glue_schema": config.TemplatedStringAsIdentifier("schema_name", "{{ .parameters.registry_arn }}/{{ .external_name }}"),
+
+	// grafana
+	//
+	// No import
+	// TODO: For now API is not normalized. While testing resource we can check the actual ID and normalize the API.
+	"aws_grafana_workspace_api_key": config.IdentifierFromProvider,
+
+	// identitystore
+	//
+	// An Identity Store Group can be imported using the combination identity_store_id/group_id
+	"aws_identitystore_group": config.TemplatedStringAsIdentifier("", "{{ .parameters.identity_store_id }}/{{ .external_name }}"),
+	// aws_identitystore_group_membership can be imported using the identity_store_id/membership_id
+	"aws_identitystore_group_membership": config.TemplatedStringAsIdentifier("", "{{ .parameters.identity_store_id }}/{{ .external_name }}"),
+	// An Identity Store User can be imported using the combination identity_store_id/user_id
+	"aws_identitystore_user": config.TemplatedStringAsIdentifier("", "{{ .parameters.identity_store_id }}/{{ .external_name }}"),
+
+	// inspector2
+	//
+	// Inspector V2 Delegated Admin Account can be imported using the account_id
+	"aws_inspector2_delegated_admin_account": config.IdentifierFromProvider,
+	// No import
+	// TODO: For now API is not normalized. While testing resource we can check the actual ID and normalize the API.
+	// TODO: Due to testing limitations, not sure if we will be able to test this resource. Do not spend a lot of time for test it.
+	"aws_inspector2_enabler": config.IdentifierFromProvider,
+	// No import
+	// TODO: For now API is not normalized. While testing resource we can check the actual ID and normalize the API.
+	// TODO: Check if we need privilege to test this resource. If yes - split it with "Need privilege" label.
+	"aws_inspector2_organization_configuration": config.IdentifierFromProvider,
+
+	// ivs
+	//
+	// IVS (Interactive Video) Channel can be imported using the ARN
+	// Example: arn:aws:ivs:us-west-2:326937407773:channel/0Y1lcs4U7jk5
+	"aws_ivs_channel": config.TemplatedStringAsIdentifier("", "arn:aws:ivs:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:channel/{{ .external_name }}"),
+	// IVS (Interactive Video) Playback Key Pair can be imported using the ARN
+	// Example: arn:aws:ivs:us-west-2:326937407773:playback-key/KDJRJNQhiQzA
+	"aws_ivs_playback_key_pair": config.TemplatedStringAsIdentifier("", "arn:aws:ivs:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:playback-key/{{ .external_name }}"),
+	// IVS (Interactive Video) Recording Configuration can be imported using the ARN
+	// Example: arn:aws:ivs:us-west-2:326937407773:recording-configuration/KAk1sHBl2L47
+	"aws_ivs_recording_configuration": config.TemplatedStringAsIdentifier("", "arn:aws:ivs:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:recording-configuration/{{ .external_name }}"),
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add external name configuration without testing:

* `datasync`
  * [x] [aws_datasync_location_object_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/datasync_location_object_storage)

* `directory_service`
  * [x] [aws_directory_service_radius_settings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_radius_settings)
  * [x] [aws_directory_service_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_region)
  * [x] [aws_directory_service_shared_directory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_shared_directory)
  * [x] [aws_directory_service_shared_directory_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/directory_service_shared_directory_accepter)

* `dms`
  * [x] [aws_dms_s3_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_s3_endpoint)

* `dx`
  * [x] [aws_dx_macsec_key_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dx_macsec_key_association)

* `dynamodb`
  * [x] [aws_dynamodb_table_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table_replica)

* `ec2`
  * [x] [aws_ec2_instance_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_instance_state)
  * [x] [aws_ec2_network_insights_analysis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_network_insights_analysis)
  * [x] [aws_ec2_transit_gateway_policy_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_policy_table)
  * [x] [aws_ec2_transit_gateway_policy_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_policy_table_association)

* `efs`
  * [x] [aws_efs_replication_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_replication_configuration)

* `emrserverless`
  * [x] [aws_emrserverless_application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emrserverless_application)

* `evidently`
  * [x] [aws_evidently_feature](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/evidently_feature)
  * [x] [aws_evidently_project](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/evidently_project)
  * [x] [aws_evidently_segment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/evidently_segment)

* `fis`
  * [x] [aws_fis_experiment_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template)

* `fsx`
  * [x] [aws_fsx_file_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fsx_file_cache)

* `glue`
  * [x] [aws_glue_schema](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_schema)

* `grafana`
  * [x] [aws_grafana_workspace_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace_api_key)

* `identitystore`
  * [x] [aws_identitystore_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group)
  * [x] [aws_identitystore_group_membership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group_membership)
  * [x] [aws_identitystore_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_user)

* `inspector2`
  * [x] [aws_inspector2_delegated_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_delegated_admin_account)
  * [x] [aws_inspector2_enabler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_enabler)
  * [x] [aws_inspector2_organization_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_organization_configuration)

* `ivs`
  * [x] [aws_ivs_channel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ivs_channel)
  * [x] [aws_ivs_playback_key_pair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ivs_playback_key_pair)
  * [x] [aws_ivs_recording_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ivs_recording_configuration)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #471 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
