### PR TITLE
Add native provider version bump workflow

### DIFF
--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -1,0 +1,14 @@
+name: Native Provider Version Bump
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  open-bump-pr:
+    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@main
+    with:
+      provider-source: hashicorp/aws
+      go-version: 1.19
+    secrets:
+      TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}
+


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Depends on: https://github.com/upbound/uptest/pull/67

This PR adds a workflow to check for the latest version of the hashicorp/aws Terraform provider and opens a version bump PR if a newer version of it is found.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually tested using the `pull_request` event but the default `GITHUB_TOKEN` does not have the required permissions. Thus, switched to using `UPBOUND_BOT_GITHUB_TOKEN` repo secret but these secrets are not available in the context of the `pull_request` events. Will continue testing after the PR is merged.