### PR TITLE
add more fields to connection details

### DIFF
--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -94,8 +94,9 @@ func Configure(p *config.Provider) {
 			if a, ok := attr["username"].(string); ok {
 				conn["username"] = []byte(a)
 			}
-
-			conn["port"] = []byte(fmt.Sprintf("%v", attr["port"]))
+			if a, ok := attr["port"]; ok {
+				conn["port"] = []byte(fmt.Sprintf("%v", a))
+			}
 
 			return conn, nil
 		}

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/upbound/upjet/pkg/config"
 
 	"github.com/upbound/provider-aws/config/common"
+
+	"fmt"
 )
 
 // Configure adds configurations for rds group.
@@ -85,9 +87,16 @@ func Configure(p *config.Provider) {
 			if a, ok := attr["endpoint"].(string); ok {
 				conn["endpoint"] = []byte(a)
 			}
+			if a, ok := attr["address"].(string); ok {
+				conn["address"] = []byte(a)
+				conn["host"] = []byte(a)
+			}
 			if a, ok := attr["username"].(string); ok {
 				conn["username"] = []byte(a)
 			}
+
+			conn["port"] = []byte(fmt.Sprintf("%v", attr["port"]))
+
 			return conn, nil
 		}
 	})


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

adds more fields  ( host , address, port )for rds instance connection details. We need this to pass them along to provider-sql and the upcoming upjet [generated provider-postgresql](https://github.com/alexinthesky/provider-postgresql) ). I guess this comes handy as the tf providerconfig asks for separate host and port, as most of the PG clients )

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
ran it locally against 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
