### PR TITLE
ci: scheduled trivy scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,48 @@
+name: Scan
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      supported_releases_number:
+        description: 'Number of supported releases'
+        type: number
+        default: 1
+  schedule:
+    # run every day at 3:07am UTC
+    - cron: '7 3 * * *'
+
+permissions:
+  security-events: write
+
+env:
+  SUPPORTED_RELEASES_NUMBER: '1'
+  # comma separated list of images, without tag
+  IMAGES: "xpkg.upbound.io/upbound/provider-aws"
+
+jobs:
+  setup-vars:
+    runs-on: ubuntu-22.04
+    outputs:
+      supported_releases_number: ${{ steps.setup.outputs.supported_releases_number }}
+      images: ${{ steps.setup.outputs.images }}
+    steps:
+      - name: Setup outputs
+        shell: bash
+        id: setup
+        run: |
+          supported_releases_number="${{ fromJSON(inputs.supported_releases_number || env.SUPPORTED_RELEASES_NUMBER) }}"
+          echo "supported_releases_number=${supported_releases_number}" >> $GITHUB_OUTPUT
+
+          images="${{ env.IMAGES }}"
+          echo "images=${images}" >> $GITHUB_OUTPUT
+
+          echo "We are going to scan the last ${supported_releases_number} releases for: ${images}"
+
+  scan:
+    uses: upbound/uptest/.github/workflows/scan.yml@main
+    needs:
+      - setup-vars
+    with:
+      images: ${{ needs.setup-vars.outputs.images }}
+      supported_releases: ${{ fromJSON(needs.setup-vars.outputs.supported_releases_number) }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a scheduled trivy scan for supported images, by default it scans only the latest released image, but can be configured either when running manually using a dedicated input or by changing the env variable to change the scheduled scan behaviour.

See https://github.com/crossplane/crossplane/pull/3815 for more details about the Security tab.

Should be merged after https://github.com/upbound/uptest/pull/84 as it points to the workflow added there using directly the `main` branch.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

See https://github.com/upbound/uptest/pull/84 "How has this code been tested" section for screenshots and example runs.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
