### PR TITLE
Explicitly configure transit_gateway_route_table_id cross-referencefo…

### DIFF
--- a/apis/ec2/v1beta1/zz_generated.resolvers.go
+++ b/apis/ec2/v1beta1/zz_generated.resolvers.go
@@ -2277,12 +2277,12 @@ func (mg *TransitGatewayRoute) ResolveReferences(ctx context.Context, c client.R
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.TransitGatewayRouteTableID),
-		Extract:      resource.ExtractParamPath("association_default_route_table_id", true),
+		Extract:      reference.ExternalName(),
 		Reference:    mg.Spec.ForProvider.TransitGatewayRouteTableIDRef,
 		Selector:     mg.Spec.ForProvider.TransitGatewayRouteTableIDSelector,
 		To: reference.To{
-			List:    &TransitGatewayList{},
-			Managed: &TransitGateway{},
+			List:    &TransitGatewayRouteTableList{},
+			Managed: &TransitGatewayRouteTable{},
 		},
 	})
 	if err != nil {

--- a/apis/ec2/v1beta1/zz_transitgatewayroute_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayroute_types.go
@@ -48,16 +48,15 @@ type TransitGatewayRouteParameters struct {
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Route Table.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGateway
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractParamPath("association_default_route_table_id",true)
+	// +crossplane:generate:reference:type=TransitGatewayRouteTable
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableID *string `json:"transitGatewayRouteTableId,omitempty" tf:"transit_gateway_route_table_id,omitempty"`
 
-	// Reference to a TransitGateway in ec2 to populate transitGatewayRouteTableId.
+	// Reference to a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDRef *v1.Reference `json:"transitGatewayRouteTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGateway in ec2 to populate transitGatewayRouteTableId.
+	// Selector for a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDSelector *v1.Selector `json:"transitGatewayRouteTableIdSelector,omitempty" tf:"-"`
 }

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -64,6 +64,9 @@ func Configure(p *config.Provider) {
 		r.References["transit_gateway_attachment_id"] = config.Reference{
 			Type: "TransitGatewayVPCAttachment",
 		}
+		r.References["transit_gateway_route_table_id"] = config.Reference{
+			Type: "TransitGatewayRouteTable",
+		}
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_route_table", func(r *config.Resource) {

--- a/package/crds/ec2.aws.upbound.io_transitgatewayroutes.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayroutes.yaml
@@ -158,7 +158,7 @@ spec:
                     description: Identifier of EC2 Transit Gateway Route Table.
                     type: string
                   transitGatewayRouteTableIdRef:
-                    description: Reference to a TransitGateway in ec2 to populate
+                    description: Reference to a TransitGatewayRouteTable to populate
                       transitGatewayRouteTableId.
                     properties:
                       name:
@@ -193,7 +193,7 @@ spec:
                     - name
                     type: object
                   transitGatewayRouteTableIdSelector:
-                    description: Selector for a TransitGateway in ec2 to populate
+                    description: Selector for a TransitGatewayRouteTable to populate
                       transitGatewayRouteTableId.
                     properties:
                       matchControllerRef:


### PR DESCRIPTION
… for transit_gateway_route resources


### Description of your changes

Upjet appears to have been generating incorrect types and extractors for transit_gateway_route.transit_gateway_route_table_id fields. This PR adds an explicit reference section to the config to correct the behavior
Fixes #618 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Pipeline tests will be run
Uptest: https://github.com/upbound/provider-aws/actions/runs/4489881839
