### PR TITLE
rds.instance: add ability to auto-generate password in referenced secret

### DIFF
--- a/apis/rds/v1beta1/zz_generated.deepcopy.go
+++ b/apis/rds/v1beta1/zz_generated.deepcopy.go
@@ -3310,6 +3310,11 @@ func (in *InstanceParameters) DeepCopyInto(out *InstanceParameters) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AutoGeneratePassword != nil {
+		in, out := &in.AutoGeneratePassword, &out.AutoGeneratePassword
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AutoMinorVersionUpgrade != nil {
 		in, out := &in.AutoMinorVersionUpgrade, &out.AutoMinorVersionUpgrade
 		*out = new(bool)

--- a/apis/rds/v1beta1/zz_instance_types.go
+++ b/apis/rds/v1beta1/zz_instance_types.go
@@ -79,6 +79,13 @@ type InstanceParameters struct {
 	// +kubebuilder:validation:Optional
 	ApplyImmediately *bool `json:"applyImmediately,omitempty" tf:"apply_immediately,omitempty"`
 
+	// Password for the master DB user. Note that this may show up in
+	// logs, and it will be stored in the state file.
+	// If true, the password will be auto-generated and stored in the Secret referenced by the passwordSecretRef field.
+	// +upjet:crd:field:TFTag=-
+	// +kubebuilder:validation:Optional
+	AutoGeneratePassword *bool `json:"autoGeneratePassword,omitempty" tf:"-"`
+
 	// Indicates that minor engine upgrades
 	// will be applied automatically to the DB instance during the maintenance window.
 	// Defaults to true.

--- a/apis/rds/v1beta1/zz_instance_types.go
+++ b/apis/rds/v1beta1/zz_instance_types.go
@@ -303,6 +303,7 @@ type InstanceParameters struct {
 
 	// Password for the master DB user. Note that this may show up in
 	// logs, and it will be stored in the state file.
+	// Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one.
 	// +kubebuilder:validation:Optional
 	PasswordSecretRef *v1.SecretKeySelector `json:"passwordSecretRef,omitempty" tf:"-"`
 

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -7,7 +7,6 @@ package rds
 import (
 	"context"
 	"fmt"
-	"github.com/upbound/upjet/pkg/types/comments"
 
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -21,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/upbound/upjet/pkg/config"
+	"github.com/upbound/upjet/pkg/types/comments"
 
 	"github.com/upbound/provider-aws/config/common"
 )
@@ -184,13 +184,8 @@ func PasswordGenerator(secretRefFieldPath, toggleFieldPath string) config.NewIni
 			}
 			sel := &v1.SecretKeySelector{}
 			err = paved.GetValueInto(secretRefFieldPath, sel)
-			if fieldpath.IsNotFound(err) {
-				// No secret reference is given, user wants to submit empty
-				// password.
-				return nil
-			}
 			if err != nil {
-				return errors.Wrapf(err, "cannot unmarshal %s into a secret key selector", secretRefFieldPath)
+				return errors.Wrapf(resource.Ignore(fieldpath.IsNotFound, err), "cannot unmarshal %s into a secret key selector", secretRefFieldPath)
 			}
 			s := &corev1.Secret{}
 			if err := client.Get(ctx, types.NamespacedName{Namespace: sel.Namespace, Name: sel.Name}, s); resource.IgnoreNotFound(err) != nil {

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -10,12 +10,12 @@ import (
 	"github.com/upbound/upjet/pkg/types/comments"
 
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/password"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +23,10 @@ import (
 	"github.com/upbound/upjet/pkg/config"
 
 	"github.com/upbound/provider-aws/config/common"
+)
+
+const (
+	errGetPasswordSecret = "cannot get password secret"
 )
 
 // Configure adds configurations for rds group.
@@ -110,7 +114,9 @@ func Configure(p *config.Provider) {
 			if a, ok := attr["port"]; ok {
 				conn["port"] = []byte(fmt.Sprintf("%v", a))
 			}
-
+			if a, ok := attr["password"].(string); ok {
+				conn["password"] = []byte(a)
+			}
 			return conn, nil
 		}
 		desc, _ := comments.New("If true, the password will be auto-generated and"+
@@ -121,48 +127,15 @@ func Configure(p *config.Provider) {
 			Optional:    true,
 			Description: desc.String(),
 		}
-		r.InitializerFns = append(r.InitializerFns, func(client client.Client) managed.Initializer {
-			return managed.InitializerFn(func(ctx context.Context, mg resource.Managed) error {
-				paved, err := fieldpath.PaveObject(mg)
-				if err != nil {
-					return err
-				}
-				sel := &v1.SecretKeySelector{}
-				if err := paved.GetValueInto("spec.forProvider.passwordSecretRef", sel); err != nil {
-					return errors.Wrap(err, "cannot unmarshal passwordSecretRef into a secret key selector")
-				}
-				s := &corev1.Secret{}
-				if err := client.Get(ctx, types.NamespacedName{Namespace: sel.Namespace, Name: sel.Name}, s); resource.IgnoreNotFound(err) != nil {
-					return errors.Wrap(err, "cannot get password secret")
-				}
-				if err == nil && len(s.Data[sel.Key]) != 0 {
-					// Password is already set.
-					return nil
-				}
-				// At this point, either the secret doesn't exist, or it doesn't
-				// have the password filled.
-				gen, err := paved.GetBool("spec.forProvider.autoGeneratePassword")
-				if err != nil {
-					return errors.Wrap(err, "cannot get autoGeneratePassword field value")
-				}
-				if !gen {
-					// Password is not set, and we don't want to generate one.
-					return nil
-				}
-				pw, err := password.Generate()
-				if err != nil {
-					return errors.Wrap(err, "cannot generate password")
-				}
-				s.SetName(sel.Name)
-				s.SetNamespace(sel.Namespace)
-				if s.Data == nil {
-					s.Data = make(map[string][]byte, 1)
-				}
-				s.Data[sel.Key] = []byte(pw)
-				return errors.Wrap(resource.NewAPIPatchingApplicator(client).Apply(ctx, s), "cannot apply password secret")
-			})
-		})
-		r.TerraformResource.Schema["password"].Description = "Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one."
+		r.InitializerFns = append(r.InitializerFns,
+			PasswordGenerator(
+				"spec.forProvider.passwordSecretRef",
+				"spec.forProvider.autoGeneratePassword",
+			))
+		r.TerraformResource.Schema["password"].Description = "Password for the " +
+			"master DB user. If you set autoGeneratePassword to true, the Secret" +
+			" referenced here will be created or updated with generated password" +
+			" if it does not already contain one."
 	})
 
 	p.AddResourceConfigurator("aws_db_proxy", func(r *config.Resource) {
@@ -196,4 +169,58 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_rds_cluster_role_association", func(r *config.Resource) {
 		r.UseAsync = true
 	})
+}
+
+// PasswordGenerator returns an InitializerFn that will generate a password
+// for a resource if the toggle field is set to true and the secret referenced
+// by the secretRefFieldPath is not found or does not have content corresponding
+// to the password key.
+func PasswordGenerator(secretRefFieldPath, toggleFieldPath string) config.NewInitializerFn {
+	return func(client client.Client) managed.Initializer {
+		return managed.InitializerFn(func(ctx context.Context, mg resource.Managed) error {
+			paved, err := fieldpath.PaveObject(mg)
+			if err != nil {
+				return errors.Wrap(err, "cannot pave object")
+			}
+			sel := &v1.SecretKeySelector{}
+			err = paved.GetValueInto(secretRefFieldPath, sel)
+			if fieldpath.IsNotFound(err) {
+				// No secret reference is given, user wants to submit empty
+				// password.
+				return nil
+			}
+			if err != nil {
+				return errors.Wrapf(err, "cannot unmarshal %s into a secret key selector", secretRefFieldPath)
+			}
+			s := &corev1.Secret{}
+			if err := client.Get(ctx, types.NamespacedName{Namespace: sel.Namespace, Name: sel.Name}, s); resource.IgnoreNotFound(err) != nil {
+				return errors.Wrap(err, errGetPasswordSecret)
+			}
+			if err == nil && len(s.Data[sel.Key]) != 0 {
+				// Password is already set.
+				return nil
+			}
+			// At this point, either the secret doesn't exist, or it doesn't
+			// have the password filled.
+			gen, err := paved.GetBool(toggleFieldPath)
+			if resource.Ignore(fieldpath.IsNotFound, err) != nil {
+				return errors.Wrapf(err, "cannot get the value of %s", toggleFieldPath)
+			}
+			if !gen {
+				// Password is not set, and we don't want to generate one.
+				return nil
+			}
+			pw, err := password.Generate()
+			if err != nil {
+				return errors.Wrap(err, "cannot generate password")
+			}
+			s.SetName(sel.Name)
+			s.SetNamespace(sel.Namespace)
+			if s.Data == nil {
+				s.Data = make(map[string][]byte, 1)
+			}
+			s.Data[sel.Key] = []byte(pw)
+			return errors.Wrap(resource.NewAPIPatchingApplicator(client).Apply(ctx, s), "cannot apply password secret")
+		})
+	}
 }

--- a/config/rds/config_test.go
+++ b/config/rds/config_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2023 Upbound Inc.
+*/
+
+package rds
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ujfake "github.com/upbound/upjet/pkg/resource/fake"
+)
+
+var (
+	errBoom = errors.New("boom")
+)
+
+func TestPasswordGenerator(t *testing.T) {
+	type args struct {
+		kube               client.Client
+		secretRefFieldPath string
+		toggleFieldPath    string
+		mg                 resource.Managed
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"CannotGetSecret": {
+			reason: "An error should be returned if the referenced secret cannot be retrieved.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+				},
+				secretRefFieldPath: "",
+				toggleFieldPath:    "",
+				mg:                 &fake.Managed{},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetPasswordSecret),
+			},
+		},
+		"SecretAlreadyFull": {
+			reason: "Should be no-op if the Secret already has password.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("needs to be secret")
+						}
+						s.Data = map[string][]byte{
+							"password": []byte("foo"),
+						}
+						return nil
+					},
+				},
+				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"passwordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+						},
+					},
+				},
+			},
+		},
+		"NoSecretReference": {
+			reason: "Should be no-op if the secret reference is not given.",
+			args: args{
+				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"another": "field",
+						},
+					},
+				},
+			},
+		},
+		"ToggleNotSet": {
+			reason: "Should be no-op if the toggle is not set at all.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				},
+				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
+				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"passwordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+						},
+					},
+				},
+			},
+		},
+		"ToggleFalse": {
+			reason: "Should be no-op if the toggle is set to false.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				},
+				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
+				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"passwordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+							"autoGeneratePassword": false,
+						},
+					},
+				},
+			},
+		},
+		"GenerateAndApply": {
+			reason: "Should apply if we generate and set the content.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("needs to be secret")
+						}
+						if len(s.Data["password"]) == 0 {
+							return errors.New("password is not set")
+						}
+						return nil
+					},
+				},
+				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
+				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"passwordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+							"autoGeneratePassword": true,
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := PasswordGenerator(tc.args.secretRefFieldPath, tc.args.toggleFieldPath)(tc.args.kube).Initialize(context.Background(), tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("PasswordGenerator(...): -want error, +got error:\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/examples/rds/instance.yaml
+++ b/examples/rds/instance.yaml
@@ -17,6 +17,7 @@ spec:
     engine: postgres
     engineVersion: "13.7"
     username: adminuser
+    autoGeneratePassword: true
     passwordSecretRef:
       key: password
       name: example-dbinstance
@@ -33,21 +34,6 @@ spec:
   writeConnectionSecretToRef:
     name: example-dbinstance-out
     namespace: default
-
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  annotations:
-    meta.upbound.io/example-id: rds/v1beta1/instance
-  labels:
-    testing.upbound.io/example-name: example-dbinstance
-  name: example-dbinstance
-  namespace: upbound-system
-type: Opaque
-stringData:
-  password: "Upbound!"
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/upbound/upjet v0.9.0-rc.0.0.20230327151245-05c3d628e791
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/client-go v0.26.3
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
@@ -148,7 +149,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.3 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/package/crds/rds.aws.upbound.io_instances.yaml
+++ b/package/crds/rds.aws.upbound.io_instances.yaml
@@ -81,6 +81,12 @@ spec:
                       applied immediately, or during the next maintenance window.
                       Default is false. See Amazon RDS Documentation for more information.
                     type: boolean
+                  autoGeneratePassword:
+                    description: Password for the master DB user. Note that this may
+                      show up in logs, and it will be stored in the state file. If
+                      true, the password will be auto-generated and stored in the
+                      Secret referenced by the passwordSecretRef field.
+                    type: boolean
                   autoMinorVersionUpgrade:
                     description: Indicates that minor engine upgrades will be applied
                       automatically to the DB instance during the maintenance window.

--- a/package/crds/rds.aws.upbound.io_instances.yaml
+++ b/package/crds/rds.aws.upbound.io_instances.yaml
@@ -503,7 +503,10 @@ spec:
                     type: string
                   passwordSecretRef:
                     description: Password for the master DB user. Note that this may
-                      show up in logs, and it will be stored in the state file.
+                      show up in logs, and it will be stored in the state file. Password
+                      for the master DB user. If you set autoGeneratePassword to true,
+                      the Secret referenced here will be created or updated with generated
+                      password if it does not already contain one.
                     properties:
                       key:
                         description: The key to select.


### PR DESCRIPTION
### Description of your changes

Adds ability to auto-generate password. Users need to opt-in by setting `autoGeneratePassword` as `true` and should have a `Secret` reference. It will create if the referenced `Secret` does not exist and it will populate if it doesn't have the password for the given key.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests, local end-to-end test and Uptest.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
