### PR TITLE
fix(ec2_tag): fix identifier and key, seperated by a comma not a underscore

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -152,7 +152,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// No terraform import.
 	"aws_eip": config.IdentifierFromProvider,
 	// aws_ec2_tag can be imported by using the EC2 resource identifier and key, separated by a comma (,)
-	"aws_ec2_tag": config.TemplatedStringAsIdentifier("", "{{ .parameters.resource_id }}_{{ .parameters.key }}"),
+	"aws_ec2_tag": config.TemplatedStringAsIdentifier("", "{{ .parameters.resource_id }},{{ .parameters.key }}"),
 	// Imported by using the EC2 Transit Gateway identifier: tgw-12345678
 	"aws_ec2_transit_gateway": config.IdentifierFromProvider,
 	// Imported by using the EC2 Transit Gateway Route Table, an underscore,


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
missed after rebase and squash one needed commit https://github.com/upbound/provider-aws/pull/591 sorry for that 
the external-name is key, seperated by a comma not a underscore 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
created, updated and removed resource

```
tag.ec2.aws.upbound.io/xxxx-dr9p7-gw82d True    True     sg-08c821268fffc30c6,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-8hg7t-v5kn8 True    True     sg-0a4cc05e3de099b5b,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-fgjlt-7f2dh True    True     sg-0b48617ae1087419d,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-wbp2s-v9phw True    True     sg-06253ac86f8e0f474,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-fpdpz-kcw7d True    True     sg-018077a7a173e6339,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-5zb25-grqbz True    True     sg-0c137643951d79cf0,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-ld44x-hnqcf True    True     sg-0d40bc0bf49eb45cc,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-zxqqn-9lqq5 True    True     sg-069b5e7de133c1f12,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-8j4jq-q2rxs True    True     sg-00a5d720cb2694147,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-hhncg-vx5zk True    True     sg-04a9dc5521f412984,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-hd7jl-mlmvq True    True     sg-0d5c3edd4af3005f6,karpenter.sh/discovery   4d2h
tag.ec2.aws.upbound.io/xxxx-vcrg5-wvhzd True    True     sg-082c7e99a0e4ffc85,karpenter.sh/discovery   4d2h
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
