### PR TITLE
fix(launchTemplate): fixed kmsKeyId to use ARN

### DIFF
--- a/apis/ec2/v1beta1/zz_generated.resolvers.go
+++ b/apis/ec2/v1beta1/zz_generated.resolvers.go
@@ -782,7 +782,7 @@ func (mg *LaunchTemplate) ResolveReferences(ctx context.Context, c client.Reader
 		for i4 := 0; i4 < len(mg.Spec.ForProvider.BlockDeviceMappings[i3].EBS); i4++ {
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.BlockDeviceMappings[i3].EBS[i4].KMSKeyID),
-				Extract:      reference.ExternalName(),
+				Extract:      common.ARNExtractor(),
 				Reference:    mg.Spec.ForProvider.BlockDeviceMappings[i3].EBS[i4].KMSKeyIDRef,
 				Selector:     mg.Spec.ForProvider.BlockDeviceMappings[i3].EBS[i4].KMSKeyIDSelector,
 				To: reference.To{

--- a/apis/ec2/v1beta1/zz_launchtemplate_types.go
+++ b/apis/ec2/v1beta1/zz_launchtemplate_types.go
@@ -131,6 +131,7 @@ type EBSParameters struct {
 	// The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume.
 	// encrypted must be set to true when this is set.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -116,7 +116,8 @@ func Configure(p *config.Provider) {
 			SelectorFieldName: "SecurityGroupNameSelector",
 		}
 		r.References["block_device_mappings.ebs.kms_key_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			Extractor: common.PathARNExtractor,
 		}
 		r.References["iam_instance_profile.arn"] = config.Reference{
 			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.InstanceProfile",

--- a/examples/ec2/launchtemplate_encrypted.yaml
+++ b/examples/ec2/launchtemplate_encrypted.yaml
@@ -1,0 +1,63 @@
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: LaunchTemplate
+metadata:
+  name: example-encrypted
+spec:
+  forProvider:
+    region: us-west-1
+    blockDeviceMappings:
+    - deviceName: /dev/sda1
+      ebs:
+      - volumeSize: 20
+        encrypted: "true"
+        kmsKeyIdSelector:
+          matchLabels:
+            testing.upbound.io/example-name: launchtemplate-key
+    capacityReservationSpecification:
+    - capacityReservationPreference: open
+    cpuOptions:
+    - coreCount: 4
+      threadsPerCore: 2
+    creditSpecification:
+    - cpuCredits: standard
+    disableApiTermination: true
+    ebsOptimized: "true"
+    elasticGpuSpecifications:
+    - type: test
+    elasticInferenceAccelerator:
+    - type: eia1.medium
+    instanceInitiatedShutdownBehavior: terminate
+    instanceMarketOptions:
+    - marketType: spot
+    instanceType: t2.micro
+    keyName: test
+    metadataOptions:
+    - httpEndpoint: enabled
+      httpPutResponseHopLimit: 1
+      httpTokens: required
+      instanceMetadataTags: enabled
+    monitoring:
+    - enabled: true
+    name: foo
+    networkInterfaces:
+    - associatePublicIpAddress: "true"
+    placement:
+    - availabilityZone: us-west-2a
+    tagSpecifications:
+    - resourceType: instance
+      tags:
+        Name: test
+
+---
+
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  labels:
+    testing.upbound.io/example-name: launchtemplate-key
+  name: launchtemplate-key
+spec:
+  forProvider:
+    region: us-east-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- using ARN instead of ID for kmsKeyId in launchTemplate

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #637

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
created resource:

```
NAME                                        READY   SYNCED   EXTERNAL-NAME          AGE
launchtemplate.ec2.aws.upbound.io/example   True    True     lt-0e0a70effb499371b   81s

NAME                                        READY   SYNCED   EXTERNAL-NAME                          AGE
key.kms.aws.upbound.io/launchtemplate-key   True    True     644d0c73-0ec8-47a4-8e3b-0c3ed203b89d   3m49s
```

```
kubectl describe launchtemplate.ec2.aws.upbound.io/example 
Name:         example
Namespace:    
Labels:       <none>
Annotations:  crossplane.io/external-create-pending: 2023-04-01T19:40:45+02:00
              crossplane.io/external-create-succeeded: 2023-04-01T19:40:45+02:00
              crossplane.io/external-name: lt-0e0a70effb499371b
              upjet.crossplane.io/provider-meta: null
API Version:  ec2.aws.upbound.io/v1beta1
Kind:         LaunchTemplate
Metadata:
  Creation Timestamp:  2023-04-01T17:40:32Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generation:  4
  Managed Fields:
    API Version:  ec2.aws.upbound.io/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
      f:spec:
        .:
        f:deletionPolicy:
        f:forProvider:
          .:
          f:capacityReservationSpecification:
          f:cpuOptions:
          f:creditSpecification:
          f:disableApiTermination:
          f:ebsOptimized:
          f:elasticGpuSpecifications:
          f:elasticInferenceAccelerator:
          f:instanceInitiatedShutdownBehavior:
          f:instanceMarketOptions:
          f:instanceType:
          f:keyName:
          f:metadataOptions:
          f:monitoring:
          f:name:
          f:networkInterfaces:
          f:placement:
          f:region:
          f:tagSpecifications:
        f:providerConfigRef:
          .:
          f:name:
    Manager:      kubectl-client-side-apply
    Operation:    Update
    Time:         2023-04-01T17:40:32Z
    API Version:  ec2.aws.upbound.io/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:crossplane.io/external-create-pending:
          f:crossplane.io/external-create-succeeded:
          f:crossplane.io/external-name:
          f:upjet.crossplane.io/provider-meta:
        f:finalizers:
          .:
          v:"finalizer.managedresource.crossplane.io":
      f:spec:
        f:forProvider:
          f:blockDeviceMappings:
          f:defaultVersion:
          f:tags:
            .:
            f:crossplane-kind:
            f:crossplane-name:
            f:crossplane-providerconfig:
    Manager:      provider
    Operation:    Update
    Time:         2023-04-01T17:40:56Z
    API Version:  ec2.aws.upbound.io/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        .:
        f:atProvider:
          .:
          f:arn:
          f:id:
          f:latestVersion:
          f:tagsAll:
            .:
            f:crossplane-kind:
            f:crossplane-name:
            f:crossplane-providerconfig:
        f:conditions:
    Manager:         provider
    Operation:       Update
    Subresource:     status
    Time:            2023-04-01T17:40:59Z
  Resource Version:  198642
  UID:               2d96719c-f88b-46d9-bfa8-cee82ff30fab
Spec:
  Deletion Policy:  Delete
  For Provider:
    Block Device Mappings:
      Device Name:  /dev/sda1
      Ebs:
        Encrypted:   true
        Kms Key Id:  arn:aws:kms:us-east-1:123456789101:key/644d0c73-0ec8-47a4-8e3b-0c3ed203b89d
        Kms Key Id Ref:
          Name:  launchtemplate-key
        Kms Key Id Selector:
          Match Labels:
            testing.upbound.io/example-name:  launchtemplate-key
        Volume Size:                          20
    Capacity Reservation Specification:
      Capacity Reservation Preference:  open
    Cpu Options:
      Core Count:        4
      Threads Per Core:  2
    Credit Specification:
      Cpu Credits:            standard
    Default Version:          1
    Disable API Termination:  true
    Ebs Optimized:            true
    Elastic Gpu Specifications:
      Type:  test
    Elastic Inference Accelerator:
      Type:                                eia1.medium
    Instance Initiated Shutdown Behavior:  terminate
    Instance Market Options:
      Market Type:  spot
    Instance Type:  t2.micro
    Key Name:       test
    Metadata Options:
      Http Endpoint:                enabled
      Http Put Response Hop Limit:  1
      Http Tokens:                  required
      Instance Metadata Tags:       enabled
    Monitoring:
      Enabled:  true
    Name:       foo
    Network Interfaces:
      Associate Public Ip Address:  true
    Placement:
      Availability Zone:  us-west-2a
    Region:               us-west-1
    Tag Specifications:
      Resource Type:  instance
      Tags:
        Name:  test
    Tags:
      Crossplane - Kind:            launchtemplate.ec2.aws.upbound.io
      Crossplane - Name:            example
      Crossplane - Providerconfig:  default
  Provider Config Ref:
    Name:  default
Status:
  At Provider:
    Arn:             arn:aws:ec2:us-west-1:123456789101:launch-template/lt-0e0a70effb499371b
    Id:              lt-0e0a70effb499371b
    Latest Version:  1
    Tags All:
      Crossplane - Kind:            launchtemplate.ec2.aws.upbound.io
      Crossplane - Name:            example
      Crossplane - Providerconfig:  default
  Conditions:
    Last Transition Time:  2023-04-01T17:40:59Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2023-04-01T17:40:45Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
    Last Transition Time:  2023-04-01T17:40:50Z
    Reason:                Success
    Status:                True
    Type:                  LastAsyncOperation
    Last Transition Time:  2023-04-01T17:40:50Z
    Reason:                Finished
    Status:                True
    Type:                  AsyncOperation
Events:
  Type     Reason                       Age    From                                                     Message
  ----     ------                       ----   ----                                                     -------
  Normal   CreatedExternalResource      2m52s  managed/ec2.aws.upbound.io/v1beta1, kind=launchtemplate  Successfully requested creation of external resource
  Warning  CannotUpdateManagedResource  2m44s  managed/ec2.aws.upbound.io/v1beta1, kind=launchtemplate  Operation cannot be fulfilled on launchtemplates.ec2.aws.upbound.io "example": the object has been modified; please apply your changes to the latest version and try again
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
