### PR TITLE
fix(ecs-service): #624 fix description of ecs service cluster field

### DIFF
--- a/apis/ecs/v1beta1/zz_service_types.go
+++ b/apis/ecs/v1beta1/zz_service_types.go
@@ -274,7 +274,7 @@ type ServiceParameters struct {
 	// +kubebuilder:validation:Optional
 	CapacityProviderStrategy []CapacityProviderStrategyParameters `json:"capacityProviderStrategy,omitempty" tf:"capacity_provider_strategy,omitempty"`
 
-	// ARN of an ECS cluster.
+	// Name of an ECS cluster.
 	// +crossplane:generate:reference:type=Cluster
 	// +kubebuilder:validation:Optional
 	Cluster *string `json:"cluster,omitempty" tf:"cluster,omitempty"`

--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -81,6 +81,7 @@ func Configure(p *config.Provider) {
 				SelectorFieldName: "SecurityGroupSelector",
 			},
 		}
+		r.MetaResource.ArgumentDocs["cluster"] = `Name of an ECS cluster.`
 		r.UseAsync = true
 	})
 

--- a/examples/ecs/service-static-cluster.yaml
+++ b/examples/ecs/service-static-cluster.yaml
@@ -1,0 +1,53 @@
+apiVersion: ecs.aws.upbound.io/v1beta1
+kind: Service
+metadata:
+  name: example-service
+  annotations:
+    meta.upbound.io/example-id: ecs/v1beta1/service-static-cluster
+    upjet.upbound.io/manual-intervention: "Resource stuck in update loop, see https://github.com/upbound/provider-aws/issues/585"
+  labels:
+    testing.upbound.io/example-name: example-service
+spec:
+  forProvider:
+    taskDefinitionSelector:
+      matchLabels:
+          testing.upbound.io/example-name: example-service-definition
+    cluster: example-cluster-service
+    region: us-west-1
+    launchType: EC2
+    propagateTags: TASK_DEFINITION
+---
+apiVersion: ecs.aws.upbound.io/v1beta1
+kind: TaskDefinition
+metadata:
+  name: example-service-definition
+  annotations:
+    meta.upbound.io/example-id: ecs/v1beta1/service-static-cluster
+  labels:
+    testing.upbound.io/example-name: example-service-definition
+spec:
+  forProvider:
+    region: us-west-1
+    family: sampleservice
+    containerDefinitions: |-
+      [
+        {
+          "name": "first",
+          "image": "service-first",
+          "cpu": 10,
+          "memory": 512,
+          "essential":true
+        }
+      ]
+---
+apiVersion: ecs.aws.upbound.io/v1beta1
+kind: Cluster
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ecs/v1beta1/service-static-cluster
+  labels:
+    testing.upbound.io/example-name: example-cluster-service
+  name: example-cluster-service
+spec:
+  forProvider:
+    region: us-west-1

--- a/package/crds/ecs.aws.upbound.io_services.yaml
+++ b/package/crds/ecs.aws.upbound.io_services.yaml
@@ -114,7 +114,7 @@ spec:
                       type: object
                     type: array
                   cluster:
-                    description: ARN of an ECS cluster.
+                    description: Name of an ECS cluster.
                     type: string
                   clusterRef:
                     description: Reference to a Cluster to populate cluster.


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
fixed the description for ecs_service cluster field - we need the cluster name / short-id instead of ARN - ref & selector working as expected as mentioned by @dverveiko in #624 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #624

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
applied new example:

```
NAME                                                 READY   SYNCED   EXTERNAL-NAME             AGE
cluster.ecs.aws.upbound.io/example-cluster-service   True    True     example-cluster-service   4m2s

NAME                                         READY   SYNCED   EXTERNAL-NAME     AGE
service.ecs.aws.upbound.io/example-service   True    True     example-service   4m2s

NAME                                                           READY   SYNCED   EXTERNAL-NAME   AGE
taskdefinition.ecs.aws.upbound.io/example-service-definition   True    True     sampleservice   4m2s
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
