### PR TITLE
fix(iam): added username and password for iam accesskey connection-secret

### DIFF
--- a/config/iam/config.go
+++ b/config/iam/config.go
@@ -18,6 +18,16 @@ func Configure(p *config.Provider) {
 				Type: "User",
 			},
 		}
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["id"].(string); ok {
+				conn["username"] = []byte(a)
+			}
+			if a, ok := attr["secret"].(string); ok {
+				conn["password"] = []byte(a)
+			}
+			return conn, nil
+		}
 	})
 
 	p.AddResourceConfigurator("aws_iam_role", func(r *config.Resource) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
add username and password for iam accesskey connection secret like community provider-aws 

community provider-aws:
```
apiVersion: v1
data:
  password: *****
  username: *****
```

official provider-aws:
```
apiVersion: v1
data:
  attribute.secret: *****
  attribute.ses_smtp_password_v4: *****
```

after that PR we have 2 additional keys for official provider-aws:
```
apiVersion: v1
data:
  attribute.secret: *****
  attribute.ses_smtp_password_v4: *****
  password: *****
  username: *****
```

think today its not possible to run an uptest action for this `AdditionalConnectionDetailsFn` we have one open issue for that: https://github.com/upbound/uptest/issues/82

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #479

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
create user.yaml and checked secret

```
NAME                                  READY   SYNCED   EXTERNAL-NAME   AGE
user.iam.aws.upbound.io/sample-user   True    True     sample-user     84s

NAME                                             READY   SYNCED   EXTERNAL-NAME          AGE
accesskey.iam.aws.upbound.io/sample-access-key   True    True     AKIAWLLR7LGH24LYMW5R   84s

NAME                       TYPE                                DATA   AGE
sample-access-key-secret   connection.crossplane.io/v1alpha1   4      85s
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
