### PR TITLE
Add ProviderConfig auth documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ GO111MODULE = on
 # Setup Kubernetes tools
 
 KIND_VERSION = v0.15.0
-UP_VERSION = v0.14.0
+UP_VERSION = v0.16.0
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.5.0
 -include build/makelib/k8s_tools.mk

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ GO111MODULE = on
 # Setup Kubernetes tools
 
 KIND_VERSION = v0.15.0
-UP_VERSION = v0.16.0
+UP_VERSION = v0.16.1
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.5.0
 -include build/makelib/k8s_tools.mk

--- a/package/auth.yaml
+++ b/package/auth.yaml
@@ -1,0 +1,74 @@
+version: '2023-01-30'
+discriminant: spec.credentials.source
+sources:
+- name: Secret
+  docs: |
+    # Storing Credentials as a Kubernetes Secret
+
+    AWS credentials may be supplied as a Kubernetes `Secret`. Credentials will
+    be stored in this control plane and will only be accessible to installed
+    providers.
+
+    Credentials should be provided in the following format:
+    ```
+    [default]
+    aws_access_key_id = <aws_access_key>
+    aws_secret_access_key = <aws_secret_key>
+    ```
+
+    See the [AWS
+    documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)
+    for more information on how to generate credentials.
+  additionalResources:
+  - type: Secret
+    ref: spec.credentials.secretRef
+  showFields:
+  - spec.credentials.secretRef
+- name: Upbound
+  docs: |
+    # OpenID Connect (OIDC)
+    
+    Using OIDC to authenticate to AWS eliminates the need to store credentials
+    in this control plane. Instead, you will need to add Upbound as an identity
+    provider in your AWS account, then create an IAM role that the AWS provider
+    in your control plane can assume. Go through the following steps to add the
+    identity provider.
+    1. Open the IAM console at [https://console.aws.amazon.com/iam](https://console.aws.amazon.com/iam').
+    2. Navigate to **Identity Providers** > **Add Provider** and select **OpenID Connect**.
+    3. Use `https://proidc.upbound.io` as the **Provider URL** and `sts.amazonaws.com` as the **Audience**.
+    4. Select **Add Provider**.
+
+    With an identity provider created, multiple roles may be associated, each
+    with its own permissions and identity validation. Go through the following
+    steps to acquire the ARN for a role that allows the AWS provider your
+    control plane to assume its permissions.
+    1. Navigate to **Roles**.
+    2. Select an existing role or create a new one.
+    3. Select **Custom trust policy**.
+    4. Author a trust policy. An example is shown below.
+    ```
+    {
+       "Version":"2012-10-17",
+       "Statement":[
+          {
+             "Effect":"Allow",
+             "Principal":{
+                "Federated":"arn:aws:iam::YOUR_AWS_ACCOUNT_ID:oidc-provider/proidc.upbound.io"
+             },
+             "Action":"sts:AssumeRoleWithWebIdentity",
+             "Condition":{
+                "StringEquals":{
+                   "proidc.upbound.io:sub":"mcp:YOUR_UPBOUND_ACCOUNT/YOUR_CONTROL_PLANE:provider:provider-aws",
+                   "proidc.upbound.io:aud":"sts.amazonaws.com"
+                }
+             }
+          }
+       ]
+    }
+    ```
+    5. Add the desired permissions.
+    6. Create role.
+
+    Copy the ARN from the **Summary** section of the role into the input.
+  showFields:
+  - spec.credentials.upbound

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -13,4 +13,4 @@ metadata:
       (AWS)](https://aws.amazon.com/) developed and supported by Upbound.
       If you encounter an issue please reach out on our support@upbound.io
       email address.
-    friendly-name.meta.crossplane.io: Provider AWS
+    auth.upbound.io/group: aws.upbound.io


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds the auth group annotation to the crossplane.yaml.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds documentation and schema info for ProviderConfig auth.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates the up version to v0.16.0.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Built locally and inspected image contents.