### PR TITLE
Configure plural names for resources whose kind names end with "fleet"

### DIFF
--- a/apis/appstream/v1beta1/zz_fleet_types.go
+++ b/apis/appstream/v1beta1/zz_fleet_types.go
@@ -198,7 +198,7 @@ type FleetStatus struct {
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws},path=fleet
 type Fleet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/gamelift/v1beta1/zz_fleet_types.go
+++ b/apis/gamelift/v1beta1/zz_fleet_types.go
@@ -221,7 +221,7 @@ type FleetStatus struct {
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws},path=fleet
 type Fleet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/sagemaker/v1beta1/zz_devicefleet_types.go
+++ b/apis/sagemaker/v1beta1/zz_devicefleet_types.go
@@ -99,7 +99,7 @@ type DeviceFleetStatus struct {
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws},path=devicefleet
 type DeviceFleet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/appstream/config.go
+++ b/config/appstream/config.go
@@ -17,6 +17,7 @@ func Configure(p *config.Provider) { // nolint:gocyclo
 			SelectorFieldName: "SubnetIDSelector",
 		}
 		r.UseAsync = true
+		r.Path = "fleet"
 	})
 	p.AddResourceConfigurator("aws_appstream_image_builder", func(r *config.Resource) {
 		r.References["vpc_config.subnet_ids"] = config.Reference{

--- a/config/gamelift/config.go
+++ b/config/gamelift/config.go
@@ -23,6 +23,7 @@ func Configure(p *config.Provider) {
 			Type: "Build",
 		}
 		r.UseAsync = true
+		r.Path = "fleet"
 	})
 
 	p.AddResourceConfigurator("aws_gamelift_game_server_group", func(r *config.Resource) {

--- a/config/sagemaker/config.go
+++ b/config/sagemaker/config.go
@@ -11,4 +11,7 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"source_ip_config"},
 		}
 	})
+	p.AddResourceConfigurator("aws_sagemaker_device_fleet", func(r *config.Resource) {
+		r.Path = "devicefleet"
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/pkg/errors v0.9.1
-	github.com/upbound/upjet v0.9.0-rc.0.0.20230327151245-05c3d628e791
+	github.com/upbound/upjet v0.9.0-rc.0.0.20230403193742-b89baca4ae24
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/upbound/upjet v0.9.0-rc.0.0.20230327151245-05c3d628e791 h1:Y2+LQwPlfgRFbe3Yev6P+7aumifXRvGl+I3nryrU8qM=
-github.com/upbound/upjet v0.9.0-rc.0.0.20230327151245-05c3d628e791/go.mod h1:wwCuupQRfs+SL6LGAlAHu5Z/oPffvWaBQ9Luf+7CIZ8=
+github.com/upbound/upjet v0.9.0-rc.0.0.20230403193742-b89baca4ae24 h1:zWEi4gUi1kZ8e/rFsA2Q5ZLs1ABSgz1SjckecQjELDM=
+github.com/upbound/upjet v0.9.0-rc.0.0.20230403193742-b89baca4ae24/go.mod h1:wwCuupQRfs+SL6LGAlAHu5Z/oPffvWaBQ9Luf+7CIZ8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/package/crds/appstream.aws.upbound.io_fleet.yaml
+++ b/package/crds/appstream.aws.upbound.io_fleet.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
-  name: fleets.gamelift.aws.upbound.io
+  name: fleet.appstream.aws.upbound.io
 spec:
-  group: gamelift.aws.upbound.io
+  group: appstream.aws.upbound.io
   names:
     categories:
     - crossplane
@@ -15,7 +15,7 @@ spec:
     - aws
     kind: Fleet
     listKind: FleetList
-    plural: fleets
+    plural: fleet
     singular: fleet
   scope: Cluster
   versions:
@@ -35,8 +35,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Fleet is the Schema for the Fleets API. Provides a GameLift Fleet
-          resource.
+        description: Fleet is the Schema for the Fleets API. Provides an AppStream
+          fleet
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -64,141 +64,56 @@ spec:
                 type: string
               forProvider:
                 properties:
-                  buildId:
-                    description: ID of the GameLift Build to be deployed on the fleet.
-                    type: string
-                  buildIdRef:
-                    description: Reference to a Build to populate buildId.
-                    properties:
-                      name:
-                        description: Name of the referenced object.
-                        type: string
-                      policy:
-                        description: Policies for referencing.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  buildIdSelector:
-                    description: Selector for a Build to populate buildId.
-                    properties:
-                      matchControllerRef:
-                        description: MatchControllerRef ensures an object with the
-                          same controller reference as the selecting object is selected.
-                        type: boolean
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: MatchLabels ensures an object with matching labels
-                          is selected.
-                        type: object
-                      policy:
-                        description: Policies for selection.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    type: object
-                  certificateConfiguration:
-                    description: Prompts GameLift to generate a TLS/SSL certificate
-                      for the fleet. See certificate_configuration.
+                  computeCapacity:
+                    description: Configuration block for the desired capacity of the
+                      fleet. See below.
                     items:
                       properties:
-                        certificateType:
-                          description: Indicates whether a TLS/SSL certificate is
-                            generated for a fleet. Valid values are DISABLED and GENERATED.
-                            Default value is DISABLED.
-                          type: string
+                        desiredInstances:
+                          description: Desired number of streaming instances.
+                          type: number
+                      required:
+                      - desiredInstances
                       type: object
                     type: array
                   description:
-                    description: Human-readable description of the fleet.
+                    description: Description to display.
                     type: string
-                  ec2InboundPermission:
-                    description: Range of IP addresses and port settings that permit
-                      inbound traffic to access server processes running on the fleet.
-                      See below.
+                  disconnectTimeoutInSeconds:
+                    description: Amount of time that a streaming session remains active
+                      after users disconnect.
+                    type: number
+                  displayName:
+                    description: Human-readable friendly name for the AppStream fleet.
+                    type: string
+                  domainJoinInfo:
+                    description: Configuration block for the name of the directory
+                      and organizational unit (OU) to use to join the fleet to a Microsoft
+                      Active Directory domain. See below.
                     items:
                       properties:
-                        fromPort:
-                          description: Starting value for a range of allowed port
-                            numbers.
-                          type: number
-                        ipRange:
-                          description: Range of allowed IP addresses expressed in
-                            CIDR notationE.g., 000.000.000.000/[subnet mask] or 0.0.0.0/[subnet
-                            mask].
+                        directoryName:
+                          description: Fully qualified name of the directory (for
+                            example, corp.example.com).
                           type: string
-                        protocol:
-                          description: Network communication protocol used by the
-                            fleetE.g., TCP or UDP
+                        organizationalUnitDistinguishedName:
+                          description: Distinguished name of the organizational unit
+                            for computer accounts.
                           type: string
-                        toPort:
-                          description: Ending value for a range of allowed port numbers.
-                            Port numbers are end-inclusive. This value must be higher
-                            than from_port.
-                          type: number
-                      required:
-                      - fromPort
-                      - ipRange
-                      - protocol
-                      - toPort
                       type: object
                     type: array
-                  ec2InstanceType:
-                    description: Name of an EC2 instance typeE.g., t2.micro
-                    type: string
+                  enableDefaultInternetAccess:
+                    description: Enables or disables default internet access for the
+                      fleet.
+                    type: boolean
                   fleetType:
-                    description: Type of fleet. This value must be ON_DEMAND or SPOT.
-                      Defaults to ON_DEMAND.
+                    description: 'Fleet type. Valid values are: ON_DEMAND, ALWAYS_ON'
                     type: string
-                  instanceRoleArn:
-                    description: ARN of an IAM role that instances in the fleet can
-                      assume.
+                  iamRoleArn:
+                    description: ARN of the IAM role to apply to the fleet.
                     type: string
-                  instanceRoleArnRef:
-                    description: Reference to a Role in iam to populate instanceRoleArn.
+                  iamRoleArnRef:
+                    description: Reference to a Role in iam to populate iamRoleArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -231,8 +146,8 @@ spec:
                     required:
                     - name
                     type: object
-                  instanceRoleArnSelector:
-                    description: Selector for a Role in iam to populate instanceRoleArn.
+                  iamRoleArnSelector:
+                    description: Selector for a Role in iam to populate iamRoleArn.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the
@@ -270,90 +185,147 @@ spec:
                             type: string
                         type: object
                     type: object
-                  metricGroups:
-                    description: List of names of metric groups to add this fleet
-                      to. A metric group tracks metrics across all fleets in the group.
-                      Defaults to default.
-                    items:
-                      type: string
-                    type: array
-                  name:
-                    description: The name of the fleet.
+                  idleDisconnectTimeoutInSeconds:
+                    description: Amount of time that users can be idle (inactive)
+                      before they are disconnected from their streaming session and
+                      the disconnect_timeout_in_seconds time interval begins.
+                    type: number
+                  imageArn:
+                    description: ARN of the public, private, or shared image to use.
                     type: string
-                  newGameSessionProtectionPolicy:
-                    description: Game session protection policy to apply to all instances
-                      in this fleetE.g., FullProtection. Defaults to NoProtection.
+                  imageName:
+                    description: Name of the image used to create the fleet.
+                    type: string
+                  instanceType:
+                    description: Instance type to use when launching fleet instances.
+                    type: string
+                  maxUserDurationInSeconds:
+                    description: Maximum amount of time that a streaming session can
+                      remain active, in seconds.
+                    type: number
+                  name:
+                    description: Unique name for the fleet.
                     type: string
                   region:
                     description: Region is the region you'd like your resource to
                       be created in.
                     type: string
-                  resourceCreationLimitPolicy:
-                    description: Policy that limits the number of game sessions an
-                      individual player can create over a span of time for this fleet.
-                      See below.
-                    items:
-                      properties:
-                        newGameSessionsPerCreator:
-                          description: Maximum number of game sessions that an individual
-                            can create during the policy period.
-                          type: number
-                        policyPeriodInMinutes:
-                          description: Time span used in evaluating the resource creation
-                            limit policy.
-                          type: number
-                      type: object
-                    type: array
-                  runtimeConfiguration:
-                    description: Instructions for launching server processes on each
-                      instance in the fleet. See below.
-                    items:
-                      properties:
-                        gameSessionActivationTimeoutSeconds:
-                          description: Maximum amount of time (in seconds) that a
-                            game session can remain in status ACTIVATING.
-                          type: number
-                        maxConcurrentGameSessionActivations:
-                          description: Maximum number of game sessions with status
-                            ACTIVATING to allow on an instance simultaneously.
-                          type: number
-                        serverProcess:
-                          description: Collection of server process configurations
-                            that describe which server processes to run on each instance
-                            in a fleet. See below.
-                          items:
-                            properties:
-                              concurrentExecutions:
-                                description: Number of server processes using this
-                                  configuration to run concurrently on an instance.
-                                type: number
-                              launchPath:
-                                description: 'Location of the server executable in
-                                  a game build. All game builds are installed on instances
-                                  at the root : for Windows instances C:\game, and
-                                  for Linux instances /local/game.'
-                                type: string
-                              parameters:
-                                description: Optional list of parameters to pass to
-                                  the server executable on launch.
-                                type: string
-                            required:
-                            - concurrentExecutions
-                            - launchPath
-                            type: object
-                          type: array
-                      type: object
-                    type: array
-                  scriptId:
-                    description: ID of the GameLift Script to be deployed on the fleet.
+                  streamView:
+                    description: AppStream 2.0 view that is displayed to your users
+                      when they stream from the fleet. When APP is specified, only
+                      the windows of applications opened by users display. When DESKTOP
+                      is specified, the standard desktop that is provided by the operating
+                      system displays. If not specified, defaults to APP.
                     type: string
                   tags:
                     additionalProperties:
                       type: string
                     description: Key-value map of resource tags.
                     type: object
+                  vpcConfig:
+                    description: Configuration block for the VPC configuration for
+                      the image builder. See below.
+                    items:
+                      properties:
+                        securityGroupIds:
+                          description: Identifiers of the security groups for the
+                            fleet or image builder.
+                          items:
+                            type: string
+                          type: array
+                        subnetIdRefs:
+                          description: References to Subnet in ec2 to populate subnetIds.
+                          items:
+                            description: A Reference to a named object.
+                            properties:
+                              name:
+                                description: Name of the referenced object.
+                                type: string
+                              policy:
+                                description: Policies for referencing.
+                                properties:
+                                  resolution:
+                                    default: Required
+                                    description: Resolution specifies whether resolution
+                                      of this reference is required. The default is
+                                      'Required', which means the reconcile will fail
+                                      if the reference cannot be resolved. 'Optional'
+                                      means this reference will be a no-op if it cannot
+                                      be resolved.
+                                    enum:
+                                    - Required
+                                    - Optional
+                                    type: string
+                                  resolve:
+                                    description: Resolve specifies when this reference
+                                      should be resolved. The default is 'IfNotPresent',
+                                      which will attempt to resolve the reference
+                                      only when the corresponding field is not present.
+                                      Use 'Always' to resolve the reference on every
+                                      reconcile.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        subnetIdSelector:
+                          description: Selector for a list of Subnet in ec2 to populate
+                            subnetIds.
+                          properties:
+                            matchControllerRef:
+                              description: MatchControllerRef ensures an object with
+                                the same controller reference as the selecting object
+                                is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: Resolution specifies whether resolution
+                                    of this reference is required. The default is
+                                    'Required', which means the reconcile will fail
+                                    if the reference cannot be resolved. 'Optional'
+                                    means this reference will be a no-op if it cannot
+                                    be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: Resolve specifies when this reference
+                                    should be resolved. The default is 'IfNotPresent',
+                                    which will attempt to resolve the reference only
+                                    when the corresponding field is not present. Use
+                                    'Always' to resolve the reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
+                        subnetIds:
+                          description: Identifiers of the subnets to which a network
+                            interface is attached from the fleet instance or image
+                            builder instance.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
                 required:
-                - ec2InstanceType
+                - computeCapacity
+                - instanceType
                 - name
                 - region
                 type: object
@@ -534,30 +506,40 @@ spec:
               atProvider:
                 properties:
                   arn:
-                    description: Fleet ARN.
+                    description: ARN of the appstream fleet.
                     type: string
-                  buildArn:
-                    description: Build ARN.
+                  computeCapacity:
+                    description: Configuration block for the desired capacity of the
+                      fleet. See below.
+                    items:
+                      properties:
+                        available:
+                          description: Number of currently available instances that
+                            can be used to stream sessions.
+                          type: number
+                        inUse:
+                          description: Number of instances in use for streaming.
+                          type: number
+                        running:
+                          description: Total number of simultaneous streaming instances
+                            that are running.
+                          type: number
+                      type: object
+                    type: array
+                  createdTime:
+                    description: Date and time, in UTC and extended RFC 3339 format,
+                      when the fleet was created.
                     type: string
                   id:
-                    description: Fleet ID.
+                    description: Unique identifier (ID) of the appstream fleet.
                     type: string
-                  logPaths:
-                    items:
-                      type: string
-                    type: array
-                  operatingSystem:
-                    description: Operating system of the fleet's computing resources.
-                    type: string
-                  scriptArn:
-                    description: Script ARN.
+                  state:
+                    description: State of the fleet. Can be STARTING, RUNNING, STOPPING
+                      or STOPPED
                     type: string
                   tagsAll:
                     additionalProperties:
                       type: string
-                    description: A map of tags assigned to the resource, including
-                      those inherited from the provider default_tags configuration
-                      block.
                     type: object
                 type: object
               conditions:

--- a/package/crds/gamelift.aws.upbound.io_fleet.yaml
+++ b/package/crds/gamelift.aws.upbound.io_fleet.yaml
@@ -5,18 +5,18 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
-  name: devicefleets.sagemaker.aws.upbound.io
+  name: fleet.gamelift.aws.upbound.io
 spec:
-  group: sagemaker.aws.upbound.io
+  group: gamelift.aws.upbound.io
   names:
     categories:
     - crossplane
     - managed
     - aws
-    kind: DeviceFleet
-    listKind: DeviceFleetList
-    plural: devicefleets
-    singular: devicefleet
+    kind: Fleet
+    listKind: FleetList
+    plural: fleet
+    singular: fleet
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -35,8 +35,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: DeviceFleet is the Schema for the DeviceFleets API. Provides
-          a SageMaker Device Fleet resource.
+        description: Fleet is the Schema for the Fleets API. Provides a GameLift Fleet
+          resource.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -51,7 +51,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DeviceFleetSpec defines the desired state of DeviceFleet
+            description: FleetSpec defines the desired state of Fleet
             properties:
               deletionPolicy:
                 default: Delete
@@ -64,43 +64,11 @@ spec:
                 type: string
               forProvider:
                 properties:
-                  description:
-                    description: A description of the fleet.
+                  buildId:
+                    description: ID of the GameLift Build to be deployed on the fleet.
                     type: string
-                  enableIotRoleAlias:
-                    description: 'Whether to create an AWS IoT Role Alias during device
-                      fleet creation. The name of the role alias generated will match
-                      this pattern: "SageMakerEdge-{DeviceFleetName}".'
-                    type: boolean
-                  outputConfig:
-                    description: Specifies details about the repository. see Output
-                      Config details below.
-                    items:
-                      properties:
-                        kmsKeyId:
-                          description: The AWS Key Management Service (AWS KMS) key
-                            that Amazon SageMaker uses to encrypt data on the storage
-                            volume after compilation job. If you don't provide a KMS
-                            key ID, Amazon SageMaker uses the default KMS key for
-                            Amazon S3 for your role's account.
-                          type: string
-                        s3OutputLocation:
-                          description: The Amazon Simple Storage (S3) bucker URI.
-                          type: string
-                      required:
-                      - s3OutputLocation
-                      type: object
-                    type: array
-                  region:
-                    description: Region is the region you'd like your resource to
-                      be created in.
-                    type: string
-                  roleArn:
-                    description: The Amazon Resource Name (ARN) that has access to
-                      AWS Internet of Things (IoT).
-                    type: string
-                  roleArnRef:
-                    description: Reference to a Role in iam to populate roleArn.
+                  buildIdRef:
+                    description: Reference to a Build to populate buildId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -133,8 +101,8 @@ spec:
                     required:
                     - name
                     type: object
-                  roleArnSelector:
-                    description: Selector for a Role in iam to populate roleArn.
+                  buildIdSelector:
+                    description: Selector for a Build to populate buildId.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the
@@ -172,13 +140,221 @@ spec:
                             type: string
                         type: object
                     type: object
+                  certificateConfiguration:
+                    description: Prompts GameLift to generate a TLS/SSL certificate
+                      for the fleet. See certificate_configuration.
+                    items:
+                      properties:
+                        certificateType:
+                          description: Indicates whether a TLS/SSL certificate is
+                            generated for a fleet. Valid values are DISABLED and GENERATED.
+                            Default value is DISABLED.
+                          type: string
+                      type: object
+                    type: array
+                  description:
+                    description: Human-readable description of the fleet.
+                    type: string
+                  ec2InboundPermission:
+                    description: Range of IP addresses and port settings that permit
+                      inbound traffic to access server processes running on the fleet.
+                      See below.
+                    items:
+                      properties:
+                        fromPort:
+                          description: Starting value for a range of allowed port
+                            numbers.
+                          type: number
+                        ipRange:
+                          description: Range of allowed IP addresses expressed in
+                            CIDR notationE.g., 000.000.000.000/[subnet mask] or 0.0.0.0/[subnet
+                            mask].
+                          type: string
+                        protocol:
+                          description: Network communication protocol used by the
+                            fleetE.g., TCP or UDP
+                          type: string
+                        toPort:
+                          description: Ending value for a range of allowed port numbers.
+                            Port numbers are end-inclusive. This value must be higher
+                            than from_port.
+                          type: number
+                      required:
+                      - fromPort
+                      - ipRange
+                      - protocol
+                      - toPort
+                      type: object
+                    type: array
+                  ec2InstanceType:
+                    description: Name of an EC2 instance typeE.g., t2.micro
+                    type: string
+                  fleetType:
+                    description: Type of fleet. This value must be ON_DEMAND or SPOT.
+                      Defaults to ON_DEMAND.
+                    type: string
+                  instanceRoleArn:
+                    description: ARN of an IAM role that instances in the fleet can
+                      assume.
+                    type: string
+                  instanceRoleArnRef:
+                    description: Reference to a Role in iam to populate instanceRoleArn.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  instanceRoleArnSelector:
+                    description: Selector for a Role in iam to populate instanceRoleArn.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
+                  metricGroups:
+                    description: List of names of metric groups to add this fleet
+                      to. A metric group tracks metrics across all fleets in the group.
+                      Defaults to default.
+                    items:
+                      type: string
+                    type: array
+                  name:
+                    description: The name of the fleet.
+                    type: string
+                  newGameSessionProtectionPolicy:
+                    description: Game session protection policy to apply to all instances
+                      in this fleetE.g., FullProtection. Defaults to NoProtection.
+                    type: string
+                  region:
+                    description: Region is the region you'd like your resource to
+                      be created in.
+                    type: string
+                  resourceCreationLimitPolicy:
+                    description: Policy that limits the number of game sessions an
+                      individual player can create over a span of time for this fleet.
+                      See below.
+                    items:
+                      properties:
+                        newGameSessionsPerCreator:
+                          description: Maximum number of game sessions that an individual
+                            can create during the policy period.
+                          type: number
+                        policyPeriodInMinutes:
+                          description: Time span used in evaluating the resource creation
+                            limit policy.
+                          type: number
+                      type: object
+                    type: array
+                  runtimeConfiguration:
+                    description: Instructions for launching server processes on each
+                      instance in the fleet. See below.
+                    items:
+                      properties:
+                        gameSessionActivationTimeoutSeconds:
+                          description: Maximum amount of time (in seconds) that a
+                            game session can remain in status ACTIVATING.
+                          type: number
+                        maxConcurrentGameSessionActivations:
+                          description: Maximum number of game sessions with status
+                            ACTIVATING to allow on an instance simultaneously.
+                          type: number
+                        serverProcess:
+                          description: Collection of server process configurations
+                            that describe which server processes to run on each instance
+                            in a fleet. See below.
+                          items:
+                            properties:
+                              concurrentExecutions:
+                                description: Number of server processes using this
+                                  configuration to run concurrently on an instance.
+                                type: number
+                              launchPath:
+                                description: 'Location of the server executable in
+                                  a game build. All game builds are installed on instances
+                                  at the root : for Windows instances C:\game, and
+                                  for Linux instances /local/game.'
+                                type: string
+                              parameters:
+                                description: Optional list of parameters to pass to
+                                  the server executable on launch.
+                                type: string
+                            required:
+                            - concurrentExecutions
+                            - launchPath
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  scriptId:
+                    description: ID of the GameLift Script to be deployed on the fleet.
+                    type: string
                   tags:
                     additionalProperties:
                       type: string
                     description: Key-value map of resource tags.
                     type: object
                 required:
-                - outputConfig
+                - ec2InstanceType
+                - name
                 - region
                 type: object
               providerConfigRef:
@@ -353,18 +529,28 @@ spec:
             - forProvider
             type: object
           status:
-            description: DeviceFleetStatus defines the observed state of DeviceFleet.
+            description: FleetStatus defines the observed state of Fleet.
             properties:
               atProvider:
                 properties:
                   arn:
-                    description: The Amazon Resource Name (ARN) assigned by AWS to
-                      this Device Fleet.
+                    description: Fleet ARN.
+                    type: string
+                  buildArn:
+                    description: Build ARN.
                     type: string
                   id:
-                    description: The name of the Device Fleet.
+                    description: Fleet ID.
                     type: string
-                  iotRoleAlias:
+                  logPaths:
+                    items:
+                      type: string
+                    type: array
+                  operatingSystem:
+                    description: Operating system of the fleet's computing resources.
+                    type: string
+                  scriptArn:
+                    description: Script ARN.
                     type: string
                   tagsAll:
                     additionalProperties:

--- a/package/crds/sagemaker.aws.upbound.io_devicefleet.yaml
+++ b/package/crds/sagemaker.aws.upbound.io_devicefleet.yaml
@@ -5,18 +5,18 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
-  name: fleets.appstream.aws.upbound.io
+  name: devicefleet.sagemaker.aws.upbound.io
 spec:
-  group: appstream.aws.upbound.io
+  group: sagemaker.aws.upbound.io
   names:
     categories:
     - crossplane
     - managed
     - aws
-    kind: Fleet
-    listKind: FleetList
-    plural: fleets
-    singular: fleet
+    kind: DeviceFleet
+    listKind: DeviceFleetList
+    plural: devicefleet
+    singular: devicefleet
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -35,8 +35,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Fleet is the Schema for the Fleets API. Provides an AppStream
-          fleet
+        description: DeviceFleet is the Schema for the DeviceFleets API. Provides
+          a SageMaker Device Fleet resource.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -51,7 +51,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FleetSpec defines the desired state of Fleet
+            description: DeviceFleetSpec defines the desired state of DeviceFleet
             properties:
               deletionPolicy:
                 default: Delete
@@ -64,56 +64,43 @@ spec:
                 type: string
               forProvider:
                 properties:
-                  computeCapacity:
-                    description: Configuration block for the desired capacity of the
-                      fleet. See below.
-                    items:
-                      properties:
-                        desiredInstances:
-                          description: Desired number of streaming instances.
-                          type: number
-                      required:
-                      - desiredInstances
-                      type: object
-                    type: array
                   description:
-                    description: Description to display.
+                    description: A description of the fleet.
                     type: string
-                  disconnectTimeoutInSeconds:
-                    description: Amount of time that a streaming session remains active
-                      after users disconnect.
-                    type: number
-                  displayName:
-                    description: Human-readable friendly name for the AppStream fleet.
-                    type: string
-                  domainJoinInfo:
-                    description: Configuration block for the name of the directory
-                      and organizational unit (OU) to use to join the fleet to a Microsoft
-                      Active Directory domain. See below.
+                  enableIotRoleAlias:
+                    description: 'Whether to create an AWS IoT Role Alias during device
+                      fleet creation. The name of the role alias generated will match
+                      this pattern: "SageMakerEdge-{DeviceFleetName}".'
+                    type: boolean
+                  outputConfig:
+                    description: Specifies details about the repository. see Output
+                      Config details below.
                     items:
                       properties:
-                        directoryName:
-                          description: Fully qualified name of the directory (for
-                            example, corp.example.com).
+                        kmsKeyId:
+                          description: The AWS Key Management Service (AWS KMS) key
+                            that Amazon SageMaker uses to encrypt data on the storage
+                            volume after compilation job. If you don't provide a KMS
+                            key ID, Amazon SageMaker uses the default KMS key for
+                            Amazon S3 for your role's account.
                           type: string
-                        organizationalUnitDistinguishedName:
-                          description: Distinguished name of the organizational unit
-                            for computer accounts.
+                        s3OutputLocation:
+                          description: The Amazon Simple Storage (S3) bucker URI.
                           type: string
+                      required:
+                      - s3OutputLocation
                       type: object
                     type: array
-                  enableDefaultInternetAccess:
-                    description: Enables or disables default internet access for the
-                      fleet.
-                    type: boolean
-                  fleetType:
-                    description: 'Fleet type. Valid values are: ON_DEMAND, ALWAYS_ON'
+                  region:
+                    description: Region is the region you'd like your resource to
+                      be created in.
                     type: string
-                  iamRoleArn:
-                    description: ARN of the IAM role to apply to the fleet.
+                  roleArn:
+                    description: The Amazon Resource Name (ARN) that has access to
+                      AWS Internet of Things (IoT).
                     type: string
-                  iamRoleArnRef:
-                    description: Reference to a Role in iam to populate iamRoleArn.
+                  roleArnRef:
+                    description: Reference to a Role in iam to populate roleArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -146,8 +133,8 @@ spec:
                     required:
                     - name
                     type: object
-                  iamRoleArnSelector:
-                    description: Selector for a Role in iam to populate iamRoleArn.
+                  roleArnSelector:
+                    description: Selector for a Role in iam to populate roleArn.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the
@@ -185,148 +172,13 @@ spec:
                             type: string
                         type: object
                     type: object
-                  idleDisconnectTimeoutInSeconds:
-                    description: Amount of time that users can be idle (inactive)
-                      before they are disconnected from their streaming session and
-                      the disconnect_timeout_in_seconds time interval begins.
-                    type: number
-                  imageArn:
-                    description: ARN of the public, private, or shared image to use.
-                    type: string
-                  imageName:
-                    description: Name of the image used to create the fleet.
-                    type: string
-                  instanceType:
-                    description: Instance type to use when launching fleet instances.
-                    type: string
-                  maxUserDurationInSeconds:
-                    description: Maximum amount of time that a streaming session can
-                      remain active, in seconds.
-                    type: number
-                  name:
-                    description: Unique name for the fleet.
-                    type: string
-                  region:
-                    description: Region is the region you'd like your resource to
-                      be created in.
-                    type: string
-                  streamView:
-                    description: AppStream 2.0 view that is displayed to your users
-                      when they stream from the fleet. When APP is specified, only
-                      the windows of applications opened by users display. When DESKTOP
-                      is specified, the standard desktop that is provided by the operating
-                      system displays. If not specified, defaults to APP.
-                    type: string
                   tags:
                     additionalProperties:
                       type: string
                     description: Key-value map of resource tags.
                     type: object
-                  vpcConfig:
-                    description: Configuration block for the VPC configuration for
-                      the image builder. See below.
-                    items:
-                      properties:
-                        securityGroupIds:
-                          description: Identifiers of the security groups for the
-                            fleet or image builder.
-                          items:
-                            type: string
-                          type: array
-                        subnetIdRefs:
-                          description: References to Subnet in ec2 to populate subnetIds.
-                          items:
-                            description: A Reference to a named object.
-                            properties:
-                              name:
-                                description: Name of the referenced object.
-                                type: string
-                              policy:
-                                description: Policies for referencing.
-                                properties:
-                                  resolution:
-                                    default: Required
-                                    description: Resolution specifies whether resolution
-                                      of this reference is required. The default is
-                                      'Required', which means the reconcile will fail
-                                      if the reference cannot be resolved. 'Optional'
-                                      means this reference will be a no-op if it cannot
-                                      be resolved.
-                                    enum:
-                                    - Required
-                                    - Optional
-                                    type: string
-                                  resolve:
-                                    description: Resolve specifies when this reference
-                                      should be resolved. The default is 'IfNotPresent',
-                                      which will attempt to resolve the reference
-                                      only when the corresponding field is not present.
-                                      Use 'Always' to resolve the reference on every
-                                      reconcile.
-                                    enum:
-                                    - Always
-                                    - IfNotPresent
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        subnetIdSelector:
-                          description: Selector for a list of Subnet in ec2 to populate
-                            subnetIds.
-                          properties:
-                            matchControllerRef:
-                              description: MatchControllerRef ensures an object with
-                                the same controller reference as the selecting object
-                                is selected.
-                              type: boolean
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: MatchLabels ensures an object with matching
-                                labels is selected.
-                              type: object
-                            policy:
-                              description: Policies for selection.
-                              properties:
-                                resolution:
-                                  default: Required
-                                  description: Resolution specifies whether resolution
-                                    of this reference is required. The default is
-                                    'Required', which means the reconcile will fail
-                                    if the reference cannot be resolved. 'Optional'
-                                    means this reference will be a no-op if it cannot
-                                    be resolved.
-                                  enum:
-                                  - Required
-                                  - Optional
-                                  type: string
-                                resolve:
-                                  description: Resolve specifies when this reference
-                                    should be resolved. The default is 'IfNotPresent',
-                                    which will attempt to resolve the reference only
-                                    when the corresponding field is not present. Use
-                                    'Always' to resolve the reference on every reconcile.
-                                  enum:
-                                  - Always
-                                  - IfNotPresent
-                                  type: string
-                              type: object
-                          type: object
-                        subnetIds:
-                          description: Identifiers of the subnets to which a network
-                            interface is attached from the fleet instance or image
-                            builder instance.
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type: array
                 required:
-                - computeCapacity
-                - instanceType
-                - name
+                - outputConfig
                 - region
                 type: object
               providerConfigRef:
@@ -501,45 +353,25 @@ spec:
             - forProvider
             type: object
           status:
-            description: FleetStatus defines the observed state of Fleet.
+            description: DeviceFleetStatus defines the observed state of DeviceFleet.
             properties:
               atProvider:
                 properties:
                   arn:
-                    description: ARN of the appstream fleet.
-                    type: string
-                  computeCapacity:
-                    description: Configuration block for the desired capacity of the
-                      fleet. See below.
-                    items:
-                      properties:
-                        available:
-                          description: Number of currently available instances that
-                            can be used to stream sessions.
-                          type: number
-                        inUse:
-                          description: Number of instances in use for streaming.
-                          type: number
-                        running:
-                          description: Total number of simultaneous streaming instances
-                            that are running.
-                          type: number
-                      type: object
-                    type: array
-                  createdTime:
-                    description: Date and time, in UTC and extended RFC 3339 format,
-                      when the fleet was created.
+                    description: The Amazon Resource Name (ARN) assigned by AWS to
+                      this Device Fleet.
                     type: string
                   id:
-                    description: Unique identifier (ID) of the appstream fleet.
+                    description: The name of the Device Fleet.
                     type: string
-                  state:
-                    description: State of the fleet. Can be STARTING, RUNNING, STOPPING
-                      or STOPPED
+                  iotRoleAlias:
                     type: string
                   tagsAll:
                     additionalProperties:
                       type: string
+                    description: A map of tags assigned to the resource, including
+                      those inherited from the provider default_tags configuration
+                      block.
                     type: object
                 type: object
               conditions:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #646
Depends on: https://github.com/upbound/upjet/pull/184

Prior to the `v0.32.0` release, we bumped the `sigs.k8s.io/controller-tools` to `v0.11.3` together with some other Kubernetes libraries such as the controller-runtime. This introduced a change where the plural names of custom (managed) resources whose names end with `fleet` to have new plural names due to https://github.com/kubernetes-sigs/controller-tools/pull/660. Since with the official providers we are generating & installing new CRDs, this results in a new CRD being installed by the Crossplane package manager with name, for example, `fleets.gamelift.aws.upbound.io` with `provider-aws@v0.32.0` in addition to the already installed CRD with name `fleet.gamelift.aws.upbound.io` from `provider-aws@v0.31.0`.  In my tests from last Friday (31/03) and today, I could *not* reproduce the issue reported in #646. However, although the upgrade was successful from Crossplane perspective, the new CRD (from `v0.32.0`) did not get the `Established` status condition. This is discussed in more detail [here](https://github.com/upbound/provider-aws/issues/646#issuecomment-1494234474):
```
❯ k get providerrevisions
NAME                        HEALTHY   REVISION   IMAGE                                          STATE      DEP-FOUND   DEP-INSTALLED   AGE
provider-aws-90b53987357c   True      1          xpkg.upbound.io/upbound/provider-aws:v0.31.0   Inactive                               4h55m
provider-aws-ab8a0c8dcadd   True      2          xpkg.upbound.io/upbound/provider-aws:v0.32.0   Active                                 4h38m

> k logs -f provider-aws-ab8a0c8dcadd-7589984d5d-cg877
...
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/memorydb.aws.upbound.io/v1beta1, kind=parametergroup", "controllerGroup": "memorydb.aws.upbound.io", "controllerKind": "ParameterGroup", "worker count": 10}
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/glue.aws.upbound.io/v1beta1, kind=userdefinedfunction", "controllerGroup": "glue.aws.upbound.io", "controllerKind": "UserDefinedFunction", "worker count": 10}
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=group", "controllerGroup": "iam.aws.upbound.io", "controllerKind": "Group", "worker count": 10}
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/ses.aws.upbound.io/v1beta1, kind=receiptfilter", "controllerGroup": "ses.aws.upbound.io", "controllerKind": "ReceiptFilter", "worker count": 10}
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=instanceprofile", "controllerGroup": "iam.aws.upbound.io", "controllerKind": "InstanceProfile", "worker count": 10}
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/lightsail.aws.upbound.io/v1beta1, kind=bucket", "controllerGroup": "lightsail.aws.upbound.io", "controllerKind": "Bucket", "worker count": 10}
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/mediastore.aws.upbound.io/v1beta1, kind=container", "controllerGroup": "mediastore.aws.upbound.io", "controllerKind": "Container", "worker count": 10}
2023-04-03T11:02:53Z    INFO    Starting workers        {"controller": "managed/ses.aws.upbound.io/v1beta1, kind=template", "controllerGroup": "ses.aws.upbound.io", "controllerKind": "Template", "worker count": 10}

❯ k get pods
NAME                                         READY   STATUS    RESTARTS      AGE
crossplane-86f47f8687-9957r                  1/1     Running   0             5d23h
crossplane-rbac-manager-7d6f4f67c9-6wfj2     1/1     Running   0             3h43m
provider-aws-ab8a0c8dcadd-7589984d5d-cg877   1/1     Running   0             4h37m
tf                                           1/1     Running   0             14d
upbound-bootstrapper-5dc4b457fc-clwwc        1/1     Running   0             17d
xgql-7c4b74c458-cf6rm                        1/1     Running   1 (17d ago)   17d

> k get crds fleets.gamelift.aws.upbound.io -o yaml
...
status:
  acceptedNames:
    categories:
    - crossplane
    - managed
    - aws
    kind: ""
    plural: fleets
  conditions:
  - lastTransitionTime: "2023-04-03T11:02:32Z"
    message: '"FleetList" is already in use'
    reason: ListKindConflict
    status: "False"
    type: NamesAccepted
  - lastTransitionTime: "2023-04-03T11:02:32Z"
    message: not all names are accepted
    reason: NotAccepted
    status: "False"
    type: Established
  storedVersions:
  - v1beta1
```

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Since we could not yet reproduce #646 in our test clusters yet, we will build a provider package and ask the folks to validate if the plural name renaming actually fixes it.