### PR TITLE
fix(ram): skip reference/selector for resource_arn for aws_ram_resource_association

### DIFF
--- a/apis/ram/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ram/v1beta1/zz_generated.deepcopy.go
@@ -106,16 +106,6 @@ func (in *ResourceAssociationParameters) DeepCopyInto(out *ResourceAssociationPa
 		*out = new(string)
 		**out = **in
 	}
-	if in.ResourceArnRef != nil {
-		in, out := &in.ResourceArnRef, &out.ResourceArnRef
-		*out = new(v1.Reference)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.ResourceArnSelector != nil {
-		in, out := &in.ResourceArnSelector, &out.ResourceArnSelector
-		*out = new(v1.Selector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.ResourceShareArn != nil {
 		in, out := &in.ResourceShareArn, &out.ResourceShareArn
 		*out = new(string)

--- a/apis/ram/v1beta1/zz_generated.resolvers.go
+++ b/apis/ram/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
-	v1beta1 "github.com/upbound/provider-aws/apis/ec2/v1beta1"
 	resource "github.com/upbound/upjet/pkg/resource"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -20,22 +19,6 @@ func (mg *ResourceAssociation) ResolveReferences(ctx context.Context, c client.R
 
 	var rsp reference.ResolutionResponse
 	var err error
-
-	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
-		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ResourceArn),
-		Extract:      resource.ExtractParamPath("arn", true),
-		Reference:    mg.Spec.ForProvider.ResourceArnRef,
-		Selector:     mg.Spec.ForProvider.ResourceArnSelector,
-		To: reference.To{
-			List:    &v1beta1.SubnetList{},
-			Managed: &v1beta1.Subnet{},
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "mg.Spec.ForProvider.ResourceArn")
-	}
-	mg.Spec.ForProvider.ResourceArn = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.ResourceArnRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ResourceShareArn),

--- a/apis/ram/v1beta1/zz_resourceassociation_types.go
+++ b/apis/ram/v1beta1/zz_resourceassociation_types.go
@@ -27,18 +27,8 @@ type ResourceAssociationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Amazon Resource Name (ARN) of the resource to associate with the RAM Resource Share.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
-	// +crossplane:generate:reference:extractor=github.com/upbound/upjet/pkg/resource.ExtractParamPath("arn",true)
-	// +kubebuilder:validation:Optional
-	ResourceArn *string `json:"resourceArn,omitempty" tf:"resource_arn,omitempty"`
-
-	// Reference to a Subnet in ec2 to populate resourceArn.
-	// +kubebuilder:validation:Optional
-	ResourceArnRef *v1.Reference `json:"resourceArnRef,omitempty" tf:"-"`
-
-	// Selector for a Subnet in ec2 to populate resourceArn.
-	// +kubebuilder:validation:Optional
-	ResourceArnSelector *v1.Selector `json:"resourceArnSelector,omitempty" tf:"-"`
+	// +kubebuilder:validation:Required
+	ResourceArn *string `json:"resourceArn" tf:"resource_arn,omitempty"`
 
 	// Amazon Resource Name (ARN) of the RAM Resource Share.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ram/v1beta1.ResourceShare

--- a/config/provider.go
+++ b/config/provider.go
@@ -70,6 +70,7 @@ import (
 	"github.com/upbound/provider-aws/config/opsworks"
 	"github.com/upbound/provider-aws/config/organization"
 	"github.com/upbound/provider-aws/config/qldb"
+	"github.com/upbound/provider-aws/config/ram"
 	"github.com/upbound/provider-aws/config/rds"
 	"github.com/upbound/provider-aws/config/redshift"
 	"github.com/upbound/provider-aws/config/rolesanywhere"
@@ -206,6 +207,7 @@ func GetProvider() *config.Provider {
 		mq.Configure,
 		neptune.Configure,
 		opensearch.Configure,
+		ram.Configure,
 		rds.Configure,
 		redshift.Configure,
 		rolesanywhere.Configure,

--- a/config/ram/config.go
+++ b/config/ram/config.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package ram
+
+import (
+	"github.com/upbound/upjet/pkg/config"
+)
+
+// Configure adds configurations for ram group.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("aws_ram_resource_association", func(r *config.Resource) {
+		delete(r.References, "resource_arn")
+	})
+}

--- a/examples-generated/ram/resourceassociation.yaml
+++ b/examples-generated/ram/resourceassociation.yaml
@@ -9,9 +9,7 @@ metadata:
 spec:
   forProvider:
     region: us-west-1
-    resourceArnSelector:
-      matchLabels:
-        testing.upbound.io/example-name: example
+    resourceArn: ${aws_subnet.example.arn}
     resourceShareArnSelector:
       matchLabels:
         testing.upbound.io/example-name: example

--- a/examples/ram/resourceassociation.yaml
+++ b/examples/ram/resourceassociation.yaml
@@ -3,16 +3,14 @@ kind: ResourceAssociation
 metadata:
   annotations:
     meta.upbound.io/example-id: ram/v1beta1/resourceassociation
-    upjet.upbound.io/manual-intervention: "This resource requires to enable resource sharing within your organization."
+    upjet.upbound.io/manual-intervention: "This resource requires to enable resource sharing within your organization and adding an resourceArn"
   labels:
     testing.upbound.io/example-name: example
   name: example
 spec:
   forProvider:
     region: us-west-1
-    resourceArnSelector:
-      matchLabels:
-        testing.upbound.io/example-name: example
+    resourceArn: ${arn}
     resourceShareArnSelector:
       matchLabels:
         testing.upbound.io/example-name: example

--- a/package/crds/ram.aws.upbound.io_resourceassociations.yaml
+++ b/package/crds/ram.aws.upbound.io_resourceassociations.yaml
@@ -72,79 +72,6 @@ spec:
                     description: Amazon Resource Name (ARN) of the resource to associate
                       with the RAM Resource Share.
                     type: string
-                  resourceArnRef:
-                    description: Reference to a Subnet in ec2 to populate resourceArn.
-                    properties:
-                      name:
-                        description: Name of the referenced object.
-                        type: string
-                      policy:
-                        description: Policies for referencing.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  resourceArnSelector:
-                    description: Selector for a Subnet in ec2 to populate resourceArn.
-                    properties:
-                      matchControllerRef:
-                        description: MatchControllerRef ensures an object with the
-                          same controller reference as the selecting object is selected.
-                        type: boolean
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: MatchLabels ensures an object with matching labels
-                          is selected.
-                        type: object
-                      policy:
-                        description: Policies for selection.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: Resolution specifies whether resolution of
-                              this reference is required. The default is 'Required',
-                              which means the reconcile will fail if the reference
-                              cannot be resolved. 'Optional' means this reference
-                              will be a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: Resolve specifies when this reference should
-                              be resolved. The default is 'IfNotPresent', which will
-                              attempt to resolve the reference only when the corresponding
-                              field is not present. Use 'Always' to resolve the reference
-                              on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    type: object
                   resourceShareArn:
                     description: Amazon Resource Name (ARN) of the RAM Resource Share.
                     type: string
@@ -223,6 +150,7 @@ spec:
                     type: object
                 required:
                 - region
+                - resourceArn
                 type: object
               providerConfigRef:
                 default:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
the problem is that `resource_arn` can have a selector / reference to multiple resource types checkout #662

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #662

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
up-test is not possible because of manual-intervention
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
