### PR TITLE
Use monolith for local run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ submodules:
 run: go.build
 	@$(INFO) Running Crossplane locally out-of-cluster . . .
 	@# To see other arguments that can be provided, run the command with --help instead
-	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/provider --debug
+	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/monolith --debug
 
 # NOTE(hasheddan): we ensure up is installed prior to running platform-specific
 # build steps in parallel to avoid encountering an installation race condition.

--- a/config/networkfirewall/config.go
+++ b/config/networkfirewall/config.go
@@ -5,8 +5,9 @@ Copyright 2022 Upbound Inc.
 package networkfirewall
 
 import (
-	"github.com/upbound/provider-aws/config/common"
 	"github.com/upbound/upjet/pkg/config"
+
+	"github.com/upbound/provider-aws/config/common"
 )
 
 // Configure adds configurations for networkfirewall group.


### PR DESCRIPTION
### Description of your changes

While testing a new resource in provider-aws, after running `make run` in my local, the `ready` and `synced` status of the resource remained empty. I didn't encounter any error message in the description and when I used `monolith` package instead of `provider` in local run, the problem was solved.

<img width="766" alt="Screenshot 2023-05-03 at 15 02 33" src="https://user-images.githubusercontent.com/103541666/235911548-5b619e18-7ea7-4475-b0b9-986741f49b5a.png">


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.



