### PR TITLE
Fix for the issue 574: rds: DBCluster writeConnectionSecret missing fields

### DIFF
--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -52,6 +52,12 @@ func Configure(p *config.Provider) {
 			if a, ok := attr["reader_endpoint"].(string); ok {
 				conn["reader_endpoint"] = []byte(a)
 			}
+			if a, ok := attr["master_username"].(string); ok {
+				conn["master_username"] = []byte(a)
+			}
+			if a, ok := attr["port"]; ok {
+				conn["port"] = []byte(fmt.Sprintf("%v", a))
+			}
 			return conn, nil
 		}
 	})

--- a/examples/rds/cluster.yaml
+++ b/examples/rds/cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: example
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource has a password secret reference."
+    meta.upbound.io/example-id: rds/v1beta1/cluster
 spec:
   forProvider:
     region: us-west-1
@@ -17,3 +17,12 @@ spec:
   writeConnectionSecretToRef:
     name: sample-rds-cluster-secret
     namespace: upbound-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sample-cluster-password
+  namespace: upbound-system
+type: Opaque
+stringData:
+  password: TestPass0!


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add next fields: write the username and port field to the connection secret
![image](https://github.com/upbound/provider-aws/assets/114226153/5618bcd5-612a-4742-8b0b-9fbf36baefcd)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/provider-aws/issues/574

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Uptest: https://github.com/upbound/provider-aws/actions/runs/5212568558
Manually
<img width="571" alt="image" src="https://github.com/upbound/provider-aws/assets/114226153/69344069-cda7-4f05-82fb-e6fbcb1a4bb0">

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
