### PR TITLE
Remove `.parameters.region` references from external-name configuration template bodies

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -46,7 +46,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	//
 	// ID is a random UUID.
 	"aws_prometheus_workspace":            config.IdentifierFromProvider,
-	"aws_prometheus_rule_group_namespace": config.TemplatedStringAsIdentifier("name", "arn:aws:aps:{{ .parameters.region }}:{{ .client_metadata.account_id }}:rulegroupsnamespace/IDstring/{{ .external_name }}"),
+	"aws_prometheus_rule_group_namespace": config.TemplatedStringAsIdentifier("name", "arn:aws:aps:{{ .setup.configuration.region }}:{{ .client_metadata.account_id }}:rulegroupsnamespace/IDstring/{{ .external_name }}"),
 	// Uses the ID of workspace, workspace_id parameter.
 	"aws_prometheus_alert_manager_definition": config.IdentifierFromProvider,
 
@@ -1647,7 +1647,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	//
 	// config.NameAsIdentifier did not work, the identifier for the resource turned out to be an ARN
 	// arn:aws:cloudformation:us-west-1:123456789123:stack/networking-stack/1e691240-6f2c-11ed-8f91-06094dc221f3
-	"aws_cloudformation_stack": TemplatedStringAsIdentifierWithNoName("arn:aws:cloudformation:{{ .parameters.region }}:{{ .client_metadata.account_id }}:stack/{{ .parameters.name }}/{{ .external_name }}"),
+	"aws_cloudformation_stack": TemplatedStringAsIdentifierWithNoName("arn:aws:cloudformation:{{ .setup.configuration.region }}:{{ .client_metadata.account_id }}:stack/{{ .parameters.name }}/{{ .external_name }}"),
 	// CloudFormation StackSets can be imported using the name
 	"aws_cloudformation_stack_set": config.NameAsIdentifier,
 
@@ -1755,7 +1755,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// appflow
 	//
 	// arn:aws:appflow:us-west-2:123456789012:flow/example-flow
-	"aws_appflow_flow": config.TemplatedStringAsIdentifier("name", "arn:aws:appflow:{{ .parameters.region }}:{{ .client_metadata.account_id }}:flow/{{ .external_name }}"),
+	"aws_appflow_flow": config.TemplatedStringAsIdentifier("name", "arn:aws:appflow:{{ .setup.configuration.region }}:{{ .client_metadata.account_id }}:flow/{{ .external_name }}"),
 
 	// sns
 	//
@@ -2262,10 +2262,10 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	"aws_networkmanager_transit_gateway_registration": config.TemplatedStringAsIdentifier("", "{{ .parameters.global_network_id }},{{ .parameters.transit_gateway_arn }}"),
 	// aws_networkmanager_transit_gateway_connect_peer_association can be imported using the global network ID and customer gateway ARN
 	// Example: global-network-0d47f6t230mz46dy4,arn:aws:ec2:us-west-2:123456789012:transit-gateway-connect-peer/tgw-connect-peer-12345678
-	"aws_networkmanager_transit_gateway_connect_peer_association": config.TemplatedStringAsIdentifier("", "{{ .parameters.global_network_id }},arn:aws:ec2:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:transit-gateway-connect-peer/{{ .parameters.transit_gateway_connect_peer_arn }}"),
+	"aws_networkmanager_transit_gateway_connect_peer_association": config.TemplatedStringAsIdentifier("", "{{ .parameters.global_network_id }},arn:aws:ec2:{{ .setup.configuration.region }}:{{ .setup.client_metadata.account_id }}:transit-gateway-connect-peer/{{ .parameters.transit_gateway_connect_peer_arn }}"),
 	// aws_networkmanager_customer_gateway_association can be imported using the global network ID and customer gateway ARN
 	// Example: global-network-0d47f6t230mz46dy4,arn:aws:ec2:us-west-2:123456789012:customer-gateway/cgw-123abc05e04123abc
-	"aws_networkmanager_customer_gateway_association": config.TemplatedStringAsIdentifier("", "{{ .parameters.global_network_id }},arn:aws:ec2:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:customer-gateway/{{ .parameters.customer_gateway_arn }}"),
+	"aws_networkmanager_customer_gateway_association": config.TemplatedStringAsIdentifier("", "{{ .parameters.global_network_id }},arn:aws:ec2:{{ .setup.configuration.region }}:{{ .setup.client_metadata.account_id }}:customer-gateway/{{ .parameters.customer_gateway_arn }}"),
 
 	// waf
 	//
@@ -2587,7 +2587,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	"aws_evidently_project": config.IdentifierFromProvider,
 	// CloudWatch Evidently Segment can be imported using the arn
 	// Example: arn:aws:evidently:us-west-2:123456789012:segment/example
-	"aws_evidently_segment": config.TemplatedStringAsIdentifier("name", "arn:aws:evidently:{{ .parameters.region }}:{{ .setup.client_metadata.account_id }}:segment/{{ .external_name }}"),
+	"aws_evidently_segment": config.TemplatedStringAsIdentifier("name", "arn:aws:evidently:{{ .setup.configuration.region }}:{{ .setup.client_metadata.account_id }}:segment/{{ .external_name }}"),
 
 	// fis
 	//

--- a/examples/appflow/flow.yaml
+++ b/examples/appflow/flow.yaml
@@ -41,7 +41,7 @@ apiVersion: s3.aws.upbound.io/v1beta1
 kind: Bucket
 metadata:
   annotations:
-    crossplane.io/external-name: example-destination-rand456
+    crossplane.io/external-name: example-destination-rand1test
     meta.upbound.io/example-id: appflow/v1beta1/flow
   labels:
     testing.upbound.io/example-name: example_destination
@@ -54,7 +54,7 @@ apiVersion: s3.aws.upbound.io/v1beta1
 kind: Bucket
 metadata:
   annotations:
-    crossplane.io/external-name: example-source-rand123
+    crossplane.io/external-name: example-source-rand2test
     meta.upbound.io/example-id: appflow/v1beta1/flow
   labels:
     testing.upbound.io/example-name: example_source
@@ -93,8 +93,8 @@ spec:
                     "s3:PutObjectAcl"
                   ],
                   "Resource": [
-                    "arn:aws:s3:::example-destination-rand456",
-                    "arn:aws:s3:::example-destination-rand456/*"
+                    "arn:aws:s3:::example-destination-rand1test",
+                    "arn:aws:s3:::example-destination-rand1test/*"
                   ]
               }
           ]
@@ -127,8 +127,8 @@ spec:
                       "s3:GetObject"
                   ],
                   "Resource": [
-                     "arn:aws:s3:::example-source-rand123",
-                     "arn:aws:s3:::example-source-rand123/*"
+                     "arn:aws:s3:::example-source-rand2test",
+                     "arn:aws:s3:::example-source-rand2test/*"
                   ]
 
               }

--- a/examples/appflow/flow.yaml
+++ b/examples/appflow/flow.yaml
@@ -3,6 +3,7 @@ kind: Flow
 metadata:
   annotations:
     meta.upbound.io/example-id: appflow/v1beta1/flow
+    upjet.upbound.io/manual-intervention: "This resource depends on BucketPolicy. This resource is skipping because the BucketPolicy resource was skipped."
   labels:
     testing.upbound.io/example-name: example
   name: example
@@ -41,11 +42,11 @@ apiVersion: s3.aws.upbound.io/v1beta1
 kind: Bucket
 metadata:
   annotations:
-    crossplane.io/external-name: example-destination-rand1test
     meta.upbound.io/example-id: appflow/v1beta1/flow
+    upjet.upbound.io/manual-intervention: "This resource is skipping because the parent resource was skipped."
   labels:
     testing.upbound.io/example-name: example_destination
-  name: example-destination
+  name: example-destination-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
     region: us-west-1
@@ -54,11 +55,11 @@ apiVersion: s3.aws.upbound.io/v1beta1
 kind: Bucket
 metadata:
   annotations:
-    crossplane.io/external-name: example-source-rand2test
     meta.upbound.io/example-id: appflow/v1beta1/flow
+    upjet.upbound.io/manual-intervention: "This resource is skipping because the parent resource was skipped."
   labels:
     testing.upbound.io/example-name: example_source
-  name: example-source
+  name: example-source-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
     region: us-west-1
@@ -68,6 +69,7 @@ kind: BucketPolicy
 metadata:
   annotations:
     meta.upbound.io/example-id: appflow/v1beta1/flow
+    upjet.upbound.io/manual-intervention: "The bucket ARN in policy should be changed manually."
   labels:
     testing.upbound.io/example-name: example_destination
   name: example-destination
@@ -83,7 +85,9 @@ spec:
               {
                   "Sid": "AllowAppFlowDestinationActions",
                   "Effect": "Allow",
-                  "Principal":"*",
+                  "Principal": {
+                    "Service": "appflow.amazonaws.com"
+                  },
                   "Action": [
                     "s3:PutObject",
                     "s3:AbortMultipartUpload",
@@ -93,8 +97,8 @@ spec:
                     "s3:PutObjectAcl"
                   ],
                   "Resource": [
-                    "arn:aws:s3:::example-destination-rand1test",
-                    "arn:aws:s3:::example-destination-rand1test/*"
+                    "arn:aws:s3:::<bucket name>",
+                    "arn:aws:s3:::<bucket name>/*"
                   ]
               }
           ]
@@ -106,6 +110,7 @@ kind: BucketPolicy
 metadata:
   annotations:
     meta.upbound.io/example-id: appflow/v1beta1/flow
+    upjet.upbound.io/manual-intervention: "The bucket ARN in policy should be changed manually."
   labels:
     testing.upbound.io/example-name: example_source
   name: example-source
@@ -121,14 +126,16 @@ spec:
               {
                   "Sid": "AllowAppFlowSourceActions",
                   "Effect": "Allow",
-                  "Principal":"*",
+                  "Principal": {
+                    "Service": "appflow.amazonaws.com"
+                  },
                   "Action": [
                       "s3:ListBucket",
                       "s3:GetObject"
                   ],
                   "Resource": [
-                     "arn:aws:s3:::example-source-rand2test",
-                     "arn:aws:s3:::example-source-rand2test/*"
+                     "arn:aws:s3:::<bucket name>",
+                     "arn:aws:s3:::<bucket name>/*"
                   ]
 
               }
@@ -141,6 +148,7 @@ kind: Object
 metadata:
   annotations:
     meta.upbound.io/example-id: appflow/v1beta1/flow
+    upjet.upbound.io/manual-intervention: "This resource is skipping because the parent resource was skipped."
   labels:
     testing.upbound.io/example-name: example
   name: example


### PR DESCRIPTION
### Description of your changes

This PR removes `.parameters.region` references from external-name configuration template bodies for the following resources:

- aws_prometheus_rule_group_namespace
- aws_cloudformation_stack
- aws_appflow_flow
- aws_networkmanager_transit_gateway_connect_peer_association
- aws_networkmanager_customer_gateway_association
- aws_evidently_segment

Fixes: https://github.com/upbound/provider-aws/issues/673

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- `aws_prometheus_rule_group_namespace`: Manually, Uptest(https://github.com/upbound/provider-aws/actions/runs/5003502943)
```
NAME                                         READY   SYNCED   EXTERNAL-NAME   AGE
rulegroupnamespace.amp.aws.upbound.io/demo   True    True     demo            6m16s
```
- `aws_cloudformation_stack`: Manually, Uptest(https://github.com/upbound/provider-aws/actions/runs/5003675082)
```
NAME                                          READY   SYNCED   EXTERNAL-NAME                          AGE
stack.cloudformation.aws.upbound.io/network   True    True     2fef01d0-f3e0-11ed-8066-0639a74e3abf   3m33s
```
- `aws_appflow_flow`: Manually
```
NAME                                  READY   SYNCED   EXTERNAL-NAME   AGE
flow.appflow.aws.upbound.io/example   True    True     example         7m25s

NAME                                                   READY   SYNCED   EXTERNAL-NAME                 AGE
bucket.s3.aws.upbound.io/example-destination-test926   True    True     example-destination-test926   7m27s
bucket.s3.aws.upbound.io/example-source-test927        True    True     example-source-test927        7m27s

NAME                                                 READY   SYNCED   EXTERNAL-NAME                 AGE
bucketpolicy.s3.aws.upbound.io/example-destination   True    True     example-destination-test926   7m27s
bucketpolicy.s3.aws.upbound.io/example-source        True    True     example-source-test927        7m27s

NAME                               READY   SYNCED   EXTERNAL-NAME   AGE
object.s3.aws.upbound.io/example   True    True     object_key      7m27s
```
- `aws_networkmanager_transit_gateway_connect_peer_association`: Manually
```
NAME                                                                         READY   SYNCED   EXTERNAL-NAME
                                                                                   AGE
transitgatewayconnectpeerassociation.networkmanager.aws.upbound.io/example   True    True     global-network-0e0963e1afb6e1df1,arn:aws:ec2:us-wes
t-2:569674547146:transit-gateway-connect-peer/tgw-connect-peer-01279e6e548906544   21m
```
- `aws_networkmanager_customer_gateway_association`: Uptest(https://github.com/upbound/provider-aws/actions/runs/5002477254)
- `aws_evidently_segment`: Uptest(https://github.com/upbound/provider-aws/actions/runs/5002689073)