### PR TITLE
fix lateinit on rds instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 # correctly.
 export GOPRIVATE = github.com/upbound/*
 
-GO_REQUIRED_VERSION ?= 1.19
+GO_REQUIRED_VERSION ?= 1.20
 GOLANGCILINT_VERSION ?= 1.50.0
 # SUBPACKAGES ?= $(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3)
 SUBPACKAGES ?= monolith

--- a/apis/rds/v1beta1/zz_generated_terraformed.go
+++ b/apis/rds/v1beta1/zz_generated_terraformed.go
@@ -225,8 +225,13 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AllocatedStorage"))
 	opts = append(opts, resource.WithNameFilter("DBName"))
+	opts = append(opts, resource.WithNameFilter("Engine"))
+	opts = append(opts, resource.WithNameFilter("EngineVersion"))
 	opts = append(opts, resource.WithNameFilter("Name"))
+	opts = append(opts, resource.WithNameFilter("Password"))
+	opts = append(opts, resource.WithNameFilter("Username"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -97,7 +97,14 @@ func Configure(p *config.Provider) {
 		}
 		r.UseAsync = true
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"name", "db_name"},
+			IgnoredFields: []string{
+				"allocated_storage",
+				"db_name",
+				"engine",
+				"engine_version",
+				"name",
+				"password",
+				"username"},
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}

--- a/examples/providerconfig.yaml
+++ b/examples/providerconfig.yaml
@@ -6,6 +6,6 @@ spec:
   credentials:
     source: Secret
     secretRef:
-      name: provider-creds
+      name: aws-creds
       namespace: upbound-system
       key: creds

--- a/examples/rds/instance-with-replica.yaml
+++ b/examples/rds/instance-with-replica.yaml
@@ -1,0 +1,69 @@
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: example-dbinstance-replicate-primary
+  name: example-dbinstance-replicate-primary-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    allocatedStorage: 20
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 14
+    instanceClass: db.t3.micro
+    name: example
+    engine: postgres
+    engineVersion: "13.7"
+    username: adminuser
+    autoGeneratePassword: true
+    passwordSecretRef:
+      key: password
+      name: example-dbinstance
+      namespace: upbound-system
+    backupWindow: "09:46-10:16"
+    maintenanceWindow: "Mon:00:00-Mon:03:00"
+    publiclyAccessible: false
+    skipFinalSnapshot: true
+    storageEncrypted: true
+    storageType: gp2
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-key
+  writeConnectionSecretToRef:
+    name: example-dbinstance-replicate-primary
+    namespace: default
+---
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-key-rds-replicate
+  name: sample-key-replicate-rds-replicate-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7
+---
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: example-dbinstance-replica
+  name: example-dbinstance-replicate-replica-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    instanceClass: db.t3.micro
+    replicateSourceDbSelector:
+      matchLabels:
+          testing.upbound.io/example-name: example-dbinstance-replicate-primary
+  writeConnectionSecretToRef:
+    name: example-dbinstance-replicate-replica
+    namespace: default

--- a/examples/sqs/queue.yaml
+++ b/examples/sqs/queue.yaml
@@ -11,6 +11,6 @@ spec:
     maxMessageSize: 2048
     messageRetentionSeconds: 86400
     receiveWaitTimeSeconds: 10
-    region: us-west-1
+    region: us-east-1
     tags:
       Environment: production

--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
-	github.com/yuin/goldmark v1.4.13 // indirect
+	github.com/yuin/goldmark v1.5.3 // indirect
 	github.com/zclconf/go-cty v1.11.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
-github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.5.3 h1:3HUJmBFbQW9fhQOzMgseU134xfi6hU+mjWywx5Ty+/M=
+github.com/yuin/goldmark v1.5.3/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=


### PR DESCRIPTION

### Description of your changes

Add additional fields to `aws_db_instance` lateInit. 

Fixes #723

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually using the following manifest:

```console
 kubectl get -f instance.yaml
NAME                                                               READY   SYNCED   EXTERNAL-NAME                          AGE
instance.rds.aws.upbound.io/example-dbinstance-replicate-primary   True    True     example-dbinstance-replicate-primary   20m

NAME                                                        READY   SYNCED   EXTERNAL-NAME                          AGE
key.kms.aws.upbound.io/sample-key-replicate-rds-replicate   True    True     163b26ec-dac3-4c54-80d5-4d80d31ded84   20m

NAME                                                               READY   SYNCED   EXTERNAL-NAME                          AGE
instance.rds.aws.upbound.io/example-dbinstance-replicate-replica   True    True     example-dbinstance-replicate-replica   20m
```

```yaml
apiVersion: rds.aws.upbound.io/v1beta1
kind: Instance
metadata:
  annotations:
    meta.upbound.io/example-id: rds/v1beta1/instance
  labels:
    testing.upbound.io/example-name: example-dbinstance-replicate-primary
  name: example-dbinstance-replicate-primary
spec:
  forProvider:
    region: us-west-1
    allocatedStorage: 20
    autoMinorVersionUpgrade: true
    backupRetentionPeriod: 14
    instanceClass: db.t3.micro
    name: example
    engine: postgres
    engineVersion: "13.7"
    username: adminuser
    autoGeneratePassword: true
    passwordSecretRef:
      key: password
      name: example-dbinstance
      namespace: upbound-system
    backupWindow: "09:46-10:16"
    maintenanceWindow: "Mon:00:00-Mon:03:00"
    publiclyAccessible: false
    skipFinalSnapshot: true
    storageEncrypted: true
    storageType: gp2
    kmsKeyIdSelector:
      matchLabels:
        testing.upbound.io/example-name: sample-key-rds-replicate
  writeConnectionSecretToRef:
    name: example-dbinstance-replicate-primary
    namespace: default
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Key
metadata:
  annotations:
    meta.upbound.io/example-id: rds/v1beta1/instance
  labels:
    testing.upbound.io/example-name: sample-key-rds-replicate
  name: sample-key-replicate-rds-replicate
spec:
  forProvider:
    region: us-west-1
    description: Created with Crossplane
    deletionWindowInDays: 7
---
apiVersion: rds.aws.upbound.io/v1beta1
kind: Instance
metadata:
  annotations:
    meta.upbound.io/example-id: rds/v1beta1/instance
  labels:
    testing.upbound.io/example-name: example-dbinstance-replica
  name: example-dbinstance-replicate-replica
spec:
  forProvider:
    region: us-west-1
    instanceClass: db.t3.micro
    replicateSourceDbSelector:
      matchLabels:
          testing.upbound.io/example-name: example-dbinstance-replicate-primary
  writeConnectionSecretToRef:
    name: example-dbinstance-replicate-replica
    namespace: default
```
