### PR TITLE
Add lateinit fields for rds instance

### DIFF
--- a/apis/rds/v1beta1/zz_generated_terraformed.go
+++ b/apis/rds/v1beta1/zz_generated_terraformed.go
@@ -225,8 +225,13 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AllocatedStorage"))
 	opts = append(opts, resource.WithNameFilter("DBName"))
+	opts = append(opts, resource.WithNameFilter("Engine"))
+	opts = append(opts, resource.WithNameFilter("EngineVersion"))
 	opts = append(opts, resource.WithNameFilter("Name"))
+	opts = append(opts, resource.WithNameFilter("Password"))
+	opts = append(opts, resource.WithNameFilter("Username"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -97,7 +97,14 @@ func Configure(p *config.Provider) {
 		}
 		r.UseAsync = true
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"name", "db_name"},
+			IgnoredFields: []string{
+				"allocated_storage",
+				"db_name",
+				"engine",
+				"engine_version",
+				"name",
+				"password",
+				"username"},
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}

--- a/examples/rds/instance-with-replica.yaml
+++ b/examples/rds/instance-with-replica.yaml
@@ -3,6 +3,7 @@ kind: Instance
 metadata:
   annotations:
     meta.upbound.io/example-id: rds/v1beta1/instance
+    uptest.upbound.io/timeout: "3600" # one hour timeout
   labels:
     testing.upbound.io/example-name: example-dbinstance-replicate-primary
   name: example-dbinstance-replicate-primary-${Rand.RFC1123Subdomain}

--- a/examples/rds/instance-with-replica.yaml
+++ b/examples/rds/instance-with-replica.yaml
@@ -30,7 +30,7 @@ spec:
     storageType: gp2
     kmsKeyIdSelector:
       matchLabels:
-        testing.upbound.io/example-name: sample-key
+        testing.upbound.io/example-name: sample-key-rds-replicate
   writeConnectionSecretToRef:
     name: example-dbinstance-replicate-primary
     namespace: default

--- a/examples/rds/instance-with-replica.yaml
+++ b/examples/rds/instance-with-replica.yaml
@@ -1,0 +1,69 @@
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: example-dbinstance-replicate-primary
+  name: example-dbinstance-replicate-primary-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    allocatedStorage: 20
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 14
+    instanceClass: db.t3.micro
+    name: example
+    engine: postgres
+    engineVersion: "13.7"
+    username: adminuser
+    autoGeneratePassword: true
+    passwordSecretRef:
+      key: password
+      name: example-dbinstance
+      namespace: upbound-system
+    backupWindow: "09:46-10:16"
+    maintenanceWindow: "Mon:00:00-Mon:03:00"
+    publiclyAccessible: false
+    skipFinalSnapshot: true
+    storageEncrypted: true
+    storageType: gp2
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-key
+  writeConnectionSecretToRef:
+    name: example-dbinstance-replicate-primary
+    namespace: default
+---
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-key-rds-replicate
+  name: sample-key-replicate-rds-replicate-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7
+---
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: example-dbinstance-replica
+  name: example-dbinstance-replicate-replica-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    instanceClass: db.t3.micro
+    replicateSourceDbSelector:
+      matchLabels:
+          testing.upbound.io/example-name: example-dbinstance-replicate-primary
+  writeConnectionSecretToRef:
+    name: example-dbinstance-replicate-replica
+    namespace: default

--- a/examples/rds/instance-with-replica.yaml
+++ b/examples/rds/instance-with-replica.yaml
@@ -64,6 +64,7 @@ spec:
     replicateSourceDbSelector:
       matchLabels:
           testing.upbound.io/example-name: example-dbinstance-replicate-primary
+    skipFinalSnapshot: true
   writeConnectionSecretToRef:
     name: example-dbinstance-replicate-replica
     namespace: default


### PR DESCRIPTION
### Description of your changes

Add additional fields to `aws_db_instance` lateInit. 

Fixes #723

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually using the following manifest: after 11 hours still `READY/SYNCED`:

```console
 kubectl get -f instance.yaml
NAME                                                               READY   SYNCED   EXTERNAL-NAME                          AGE
instance.rds.aws.upbound.io/example-dbinstance-replicate-primary   True    True     example-dbinstance-replicate-primary   11h

NAME                                                        READY   SYNCED   EXTERNAL-NAME                          AGE
key.kms.aws.upbound.io/sample-key-replicate-rds-replicate   True    True     163b26ec-dac3-4c54-80d5-4d80d31ded84   11h

NAME                                                               READY   SYNCED   EXTERNAL-NAME                          AGE
instance.rds.aws.upbound.io/example-dbinstance-replicate-replica   True    True     example-dbinstance-replicate-replica   11h
```

```yaml
apiVersion: rds.aws.upbound.io/v1beta1
kind: Instance
metadata:
  annotations:
    meta.upbound.io/example-id: rds/v1beta1/instance
  labels:
    testing.upbound.io/example-name: example-dbinstance-replicate-primary
  name: example-dbinstance-replicate-primary
spec:
  forProvider:
    region: us-west-1
    allocatedStorage: 20
    autoMinorVersionUpgrade: true
    backupRetentionPeriod: 14
    instanceClass: db.t3.micro
    name: example
    engine: postgres
    engineVersion: "13.7"
    username: adminuser
    autoGeneratePassword: true
    passwordSecretRef:
      key: password
      name: example-dbinstance
      namespace: upbound-system
    backupWindow: "09:46-10:16"
    maintenanceWindow: "Mon:00:00-Mon:03:00"
    publiclyAccessible: false
    skipFinalSnapshot: true
    storageEncrypted: true
    storageType: gp2
    kmsKeyIdSelector:
      matchLabels:
        testing.upbound.io/example-name: sample-key-rds-replicate
  writeConnectionSecretToRef:
    name: example-dbinstance-replicate-primary
    namespace: default
---
apiVersion: kms.aws.upbound.io/v1beta1
kind: Key
metadata:
  annotations:
    meta.upbound.io/example-id: rds/v1beta1/instance
  labels:
    testing.upbound.io/example-name: sample-key-rds-replicate
  name: sample-key-replicate-rds-replicate
spec:
  forProvider:
    region: us-west-1
    description: Created with Crossplane
    deletionWindowInDays: 7
---
apiVersion: rds.aws.upbound.io/v1beta1
kind: Instance
metadata:
  annotations:
    meta.upbound.io/example-id: rds/v1beta1/instance
  labels:
    testing.upbound.io/example-name: example-dbinstance-replica
  name: example-dbinstance-replicate-replica
spec:
  forProvider:
    region: us-west-1
    instanceClass: db.t3.micro
    replicateSourceDbSelector:
      matchLabels:
          testing.upbound.io/example-name: example-dbinstance-replicate-primary
  writeConnectionSecretToRef:
    name: example-dbinstance-replicate-replica
    namespace: default
```
