### PR TITLE
Revert "Remove family label from the config provider for proper searc…

### DIFF
--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Provider
 metadata:
   name: {{ .Name }}
-{{ if and (ne .Service "config") (ne .Service "monolith") }}
+{{ if ne .Service "monolith" }}
   labels:
     pkg.crossplane.io/provider-family: provider-family-{{ .ProviderName }}
 {{ end }}


### PR DESCRIPTION
…h indexing (#728)"

This reverts commit 3df2e870efb9da3a12451bddc33bb5bcfdb4e889.

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Reverts #728 , as upon testing of platform-ref-aws it was noted that the Crossplane RBAC manager could not define the required RBAC rules for the `ProviderConfig` in the family config package without this label.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Rebuilt package and extracted annotated layer to inspect the crossplane.yaml:

```
  labels:
    pkg.crossplane.io/provider-family: provider-family-aws
 ```
