### PR TITLE
Update LeaderElectionID for Scoped Providers

### DIFF
--- a/cmd/provider/accessanalyzer/zz_main.go
+++ b/cmd/provider/accessanalyzer/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-accessanalyzer",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/account/zz_main.go
+++ b/cmd/provider/account/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-account",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/acm/zz_main.go
+++ b/cmd/provider/acm/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-acm",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/acmpca/zz_main.go
+++ b/cmd/provider/acmpca/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-acmpca",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/amp/zz_main.go
+++ b/cmd/provider/amp/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-amp",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/amplify/zz_main.go
+++ b/cmd/provider/amplify/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-amplify",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/apigateway/zz_main.go
+++ b/cmd/provider/apigateway/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-apigateway",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/apigatewayv2/zz_main.go
+++ b/cmd/provider/apigatewayv2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-apigatewayv2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appautoscaling/zz_main.go
+++ b/cmd/provider/appautoscaling/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-appautoscaling",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appconfig/zz_main.go
+++ b/cmd/provider/appconfig/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-appconfig",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appflow/zz_main.go
+++ b/cmd/provider/appflow/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-appflow",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appintegrations/zz_main.go
+++ b/cmd/provider/appintegrations/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-appintegrations",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/applicationinsights/zz_main.go
+++ b/cmd/provider/applicationinsights/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-applicationinsights",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appmesh/zz_main.go
+++ b/cmd/provider/appmesh/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-appmesh",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/apprunner/zz_main.go
+++ b/cmd/provider/apprunner/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-apprunner",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appstream/zz_main.go
+++ b/cmd/provider/appstream/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-appstream",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appsync/zz_main.go
+++ b/cmd/provider/appsync/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-appsync",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/athena/zz_main.go
+++ b/cmd/provider/athena/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-athena",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/autoscaling/zz_main.go
+++ b/cmd/provider/autoscaling/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-autoscaling",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/autoscalingplans/zz_main.go
+++ b/cmd/provider/autoscalingplans/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-autoscalingplans",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/backup/zz_main.go
+++ b/cmd/provider/backup/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-backup",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/batch/zz_main.go
+++ b/cmd/provider/batch/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-batch",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/budgets/zz_main.go
+++ b/cmd/provider/budgets/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-budgets",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ce/zz_main.go
+++ b/cmd/provider/ce/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ce",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/chime/zz_main.go
+++ b/cmd/provider/chime/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-chime",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloud9/zz_main.go
+++ b/cmd/provider/cloud9/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloud9",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudcontrol/zz_main.go
+++ b/cmd/provider/cloudcontrol/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudcontrol",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudformation/zz_main.go
+++ b/cmd/provider/cloudformation/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudformation",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudfront/zz_main.go
+++ b/cmd/provider/cloudfront/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudfront",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudsearch/zz_main.go
+++ b/cmd/provider/cloudsearch/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudsearch",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudtrail/zz_main.go
+++ b/cmd/provider/cloudtrail/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudtrail",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudwatch/zz_main.go
+++ b/cmd/provider/cloudwatch/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudwatch",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudwatchevents/zz_main.go
+++ b/cmd/provider/cloudwatchevents/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudwatchevents",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cloudwatchlogs/zz_main.go
+++ b/cmd/provider/cloudwatchlogs/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cloudwatchlogs",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/codecommit/zz_main.go
+++ b/cmd/provider/codecommit/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-codecommit",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/codepipeline/zz_main.go
+++ b/cmd/provider/codepipeline/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-codepipeline",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/codestarconnections/zz_main.go
+++ b/cmd/provider/codestarconnections/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-codestarconnections",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/codestarnotifications/zz_main.go
+++ b/cmd/provider/codestarnotifications/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-codestarnotifications",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cognitoidentity/zz_main.go
+++ b/cmd/provider/cognitoidentity/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cognitoidentity",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cognitoidp/zz_main.go
+++ b/cmd/provider/cognitoidp/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cognitoidp",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/config/zz_main.go
+++ b/cmd/provider/config/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-config",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/configservice/zz_main.go
+++ b/cmd/provider/configservice/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-configservice",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/connect/zz_main.go
+++ b/cmd/provider/connect/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-connect",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cur/zz_main.go
+++ b/cmd/provider/cur/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-cur",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dataexchange/zz_main.go
+++ b/cmd/provider/dataexchange/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-dataexchange",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/datapipeline/zz_main.go
+++ b/cmd/provider/datapipeline/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-datapipeline",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/datasync/zz_main.go
+++ b/cmd/provider/datasync/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-datasync",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dax/zz_main.go
+++ b/cmd/provider/dax/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-dax",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/deploy/zz_main.go
+++ b/cmd/provider/deploy/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-deploy",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/detective/zz_main.go
+++ b/cmd/provider/detective/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-detective",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/devicefarm/zz_main.go
+++ b/cmd/provider/devicefarm/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-devicefarm",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/directconnect/zz_main.go
+++ b/cmd/provider/directconnect/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-directconnect",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dlm/zz_main.go
+++ b/cmd/provider/dlm/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-dlm",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dms/zz_main.go
+++ b/cmd/provider/dms/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-dms",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/docdb/zz_main.go
+++ b/cmd/provider/docdb/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-docdb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ds/zz_main.go
+++ b/cmd/provider/ds/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ds",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dynamodb/zz_main.go
+++ b/cmd/provider/dynamodb/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-dynamodb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ec2/zz_main.go
+++ b/cmd/provider/ec2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ec2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ecr/zz_main.go
+++ b/cmd/provider/ecr/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ecr",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ecrpublic/zz_main.go
+++ b/cmd/provider/ecrpublic/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ecrpublic",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ecs/zz_main.go
+++ b/cmd/provider/ecs/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ecs",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/efs/zz_main.go
+++ b/cmd/provider/efs/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-efs",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/eks/zz_main.go
+++ b/cmd/provider/eks/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-eks",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/elasticache/zz_main.go
+++ b/cmd/provider/elasticache/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-elasticache",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/elasticbeanstalk/zz_main.go
+++ b/cmd/provider/elasticbeanstalk/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-elasticbeanstalk",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/elasticsearch/zz_main.go
+++ b/cmd/provider/elasticsearch/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-elasticsearch",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/elastictranscoder/zz_main.go
+++ b/cmd/provider/elastictranscoder/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-elastictranscoder",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/elb/zz_main.go
+++ b/cmd/provider/elb/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-elb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/elbv2/zz_main.go
+++ b/cmd/provider/elbv2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-elbv2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/emr/zz_main.go
+++ b/cmd/provider/emr/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-emr",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/emrserverless/zz_main.go
+++ b/cmd/provider/emrserverless/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-emrserverless",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/evidently/zz_main.go
+++ b/cmd/provider/evidently/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-evidently",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/firehose/zz_main.go
+++ b/cmd/provider/firehose/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-firehose",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/fis/zz_main.go
+++ b/cmd/provider/fis/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-fis",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/fsx/zz_main.go
+++ b/cmd/provider/fsx/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-fsx",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/gamelift/zz_main.go
+++ b/cmd/provider/gamelift/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-gamelift",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/glacier/zz_main.go
+++ b/cmd/provider/glacier/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-glacier",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/globalaccelerator/zz_main.go
+++ b/cmd/provider/globalaccelerator/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-globalaccelerator",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/glue/zz_main.go
+++ b/cmd/provider/glue/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-glue",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/grafana/zz_main.go
+++ b/cmd/provider/grafana/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-grafana",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/guardduty/zz_main.go
+++ b/cmd/provider/guardduty/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-guardduty",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/iam/zz_main.go
+++ b/cmd/provider/iam/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-iam",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/imagebuilder/zz_main.go
+++ b/cmd/provider/imagebuilder/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-imagebuilder",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/inspector/zz_main.go
+++ b/cmd/provider/inspector/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-inspector",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/inspector2/zz_main.go
+++ b/cmd/provider/inspector2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-inspector2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/iot/zz_main.go
+++ b/cmd/provider/iot/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-iot",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ivs/zz_main.go
+++ b/cmd/provider/ivs/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ivs",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kafka/zz_main.go
+++ b/cmd/provider/kafka/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-kafka",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kendra/zz_main.go
+++ b/cmd/provider/kendra/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-kendra",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/keyspaces/zz_main.go
+++ b/cmd/provider/keyspaces/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-keyspaces",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kinesis/zz_main.go
+++ b/cmd/provider/kinesis/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-kinesis",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kinesisanalytics/zz_main.go
+++ b/cmd/provider/kinesisanalytics/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-kinesisanalytics",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kinesisanalyticsv2/zz_main.go
+++ b/cmd/provider/kinesisanalyticsv2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-kinesisanalyticsv2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kinesisvideo/zz_main.go
+++ b/cmd/provider/kinesisvideo/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-kinesisvideo",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kms/zz_main.go
+++ b/cmd/provider/kms/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-kms",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/lakeformation/zz_main.go
+++ b/cmd/provider/lakeformation/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-lakeformation",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/lambda/zz_main.go
+++ b/cmd/provider/lambda/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-lambda",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/lexmodels/zz_main.go
+++ b/cmd/provider/lexmodels/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-lexmodels",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/licensemanager/zz_main.go
+++ b/cmd/provider/licensemanager/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-licensemanager",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/lightsail/zz_main.go
+++ b/cmd/provider/lightsail/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-lightsail",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/location/zz_main.go
+++ b/cmd/provider/location/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-location",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/macie2/zz_main.go
+++ b/cmd/provider/macie2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-macie2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/mediaconvert/zz_main.go
+++ b/cmd/provider/mediaconvert/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-mediaconvert",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/medialive/zz_main.go
+++ b/cmd/provider/medialive/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-medialive",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/mediapackage/zz_main.go
+++ b/cmd/provider/mediapackage/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-mediapackage",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/mediastore/zz_main.go
+++ b/cmd/provider/mediastore/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-mediastore",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/memorydb/zz_main.go
+++ b/cmd/provider/memorydb/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-memorydb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws-monolith",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-monolith",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/mq/zz_main.go
+++ b/cmd/provider/mq/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-mq",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/neptune/zz_main.go
+++ b/cmd/provider/neptune/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-neptune",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/networkfirewall/zz_main.go
+++ b/cmd/provider/networkfirewall/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-networkfirewall",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/networkmanager/zz_main.go
+++ b/cmd/provider/networkmanager/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-networkmanager",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/opensearch/zz_main.go
+++ b/cmd/provider/opensearch/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-opensearch",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/opsworks/zz_main.go
+++ b/cmd/provider/opsworks/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-opsworks",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/organizations/zz_main.go
+++ b/cmd/provider/organizations/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-organizations",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/pinpoint/zz_main.go
+++ b/cmd/provider/pinpoint/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-pinpoint",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/qldb/zz_main.go
+++ b/cmd/provider/qldb/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-qldb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/quicksight/zz_main.go
+++ b/cmd/provider/quicksight/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-quicksight",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ram/zz_main.go
+++ b/cmd/provider/ram/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ram",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/rds/zz_main.go
+++ b/cmd/provider/rds/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-rds",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/redshift/zz_main.go
+++ b/cmd/provider/redshift/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-redshift",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/resourcegroups/zz_main.go
+++ b/cmd/provider/resourcegroups/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-resourcegroups",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/rolesanywhere/zz_main.go
+++ b/cmd/provider/rolesanywhere/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-rolesanywhere",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/route53/zz_main.go
+++ b/cmd/provider/route53/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-route53",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/route53recoverycontrolconfig/zz_main.go
+++ b/cmd/provider/route53recoverycontrolconfig/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-route53recoverycontrolconfig",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/route53recoveryreadiness/zz_main.go
+++ b/cmd/provider/route53recoveryreadiness/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-route53recoveryreadiness",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/route53resolver/zz_main.go
+++ b/cmd/provider/route53resolver/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-route53resolver",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/rum/zz_main.go
+++ b/cmd/provider/rum/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-rum",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/s3/zz_main.go
+++ b/cmd/provider/s3/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-s3",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/s3control/zz_main.go
+++ b/cmd/provider/s3control/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-s3control",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/sagemaker/zz_main.go
+++ b/cmd/provider/sagemaker/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-sagemaker",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/scheduler/zz_main.go
+++ b/cmd/provider/scheduler/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-scheduler",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/schemas/zz_main.go
+++ b/cmd/provider/schemas/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-schemas",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/secretsmanager/zz_main.go
+++ b/cmd/provider/secretsmanager/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-secretsmanager",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/securityhub/zz_main.go
+++ b/cmd/provider/securityhub/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-securityhub",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/serverlessrepo/zz_main.go
+++ b/cmd/provider/serverlessrepo/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-serverlessrepo",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/servicecatalog/zz_main.go
+++ b/cmd/provider/servicecatalog/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-servicecatalog",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/servicediscovery/zz_main.go
+++ b/cmd/provider/servicediscovery/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-servicediscovery",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/servicequotas/zz_main.go
+++ b/cmd/provider/servicequotas/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-servicequotas",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ses/zz_main.go
+++ b/cmd/provider/ses/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ses",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/sesv2/zz_main.go
+++ b/cmd/provider/sesv2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-sesv2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/sfn/zz_main.go
+++ b/cmd/provider/sfn/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-sfn",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/signer/zz_main.go
+++ b/cmd/provider/signer/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-signer",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/simpledb/zz_main.go
+++ b/cmd/provider/simpledb/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-simpledb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/sns/zz_main.go
+++ b/cmd/provider/sns/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-sns",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/sqs/zz_main.go
+++ b/cmd/provider/sqs/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-sqs",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ssm/zz_main.go
+++ b/cmd/provider/ssm/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ssm",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/ssoadmin/zz_main.go
+++ b/cmd/provider/ssoadmin/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-ssoadmin",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/swf/zz_main.go
+++ b/cmd/provider/swf/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-swf",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/timestreamwrite/zz_main.go
+++ b/cmd/provider/timestreamwrite/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-timestreamwrite",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/transcribe/zz_main.go
+++ b/cmd/provider/transcribe/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-transcribe",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/transfer/zz_main.go
+++ b/cmd/provider/transfer/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-transfer",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/vpc/zz_main.go
+++ b/cmd/provider/vpc/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-vpc",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/waf/zz_main.go
+++ b/cmd/provider/waf/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-waf",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/wafregional/zz_main.go
+++ b/cmd/provider/wafregional/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-wafregional",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/wafv2/zz_main.go
+++ b/cmd/provider/wafv2/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-wafv2",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/workspaces/zz_main.go
+++ b/cmd/provider/workspaces/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-workspaces",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/xray/zz_main.go
+++ b/cmd/provider/xray/zz_main.go
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-xray",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws-{{ .Group }}",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -74,7 +74,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-aws-{{ .Group }}",
+		LeaderElectionID:           "crossplane-leader-election-provider-aws{{ if ne .Group "monolith" }}-{{ .Group }}{{ end }}",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),


### PR DESCRIPTION
### Description of your changes

Fixes #734 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally with iam and eks providers, confirmed that each one uses a family-scoped Leader Election ID and each provider can select a leader:

```console
0615 11:16:03.051536   50062 leaderelection.go:248] attempting to acquire leader lease upbound-system/crossplane-leader-election-provider-aws-iam...
I0615 11:17:03.094603   50062 leaderelection.go:258] successfully acquired lease upbound-system/crossplane-leader-election-provider-aws-iam
```

```console
I0615 11:16:40.747300   50170 leaderelection.go:248] attempting to acquire leader lease upbound-system/crossplane-leader-election-provider-aws-eks...
I0615 11:17:41.663548   50170 leaderelection.go:258] successfully acquired lease upbound-system/crossplane-leader-election-provider-aws-eks
```