### PR TITLE
Provide up-to-date UPTEST_CLOUD_CREDENTIALS export examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,10 @@ local-deploy: build-monolith controlplane.up local.xpkg.deploy.provider.$(PROJEC
 	@$(OK) running locally built provider
 
 # This target requires the following environment variables to be set:
-# - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat ~/.aws/credentials)
+# - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g.
+#   $ export UPTEST_CLOUD_CREDENTIALS="DEFAULT='$(cat ~/.aws/credentials-uptest)'"
+#   or in case of multiple sets of credentials:
+#   $ export UPTEST_CLOUD_CREDENTIALS=$(echo "DEFAULT='$(cat ~/.aws/credentials)'\nPEER='$(cat ~/.aws/credentials-uptest)'")
 # - UPTEST_EXAMPLE_LIST, a comma-separated list of examples to test
 # - UPTEST_DATASOURCE_PATH, see https://github.com/upbound/uptest#injecting-dynamic-values-and-datasource
 e2e: local-deploy uptest


### PR DESCRIPTION

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* The current instructions in Makefile was containing outdated instructions before introdcution of the `PEER` test credentials
* Update examples to cover both single `DEFAULT` and multicred `PEER` export examples

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

by testing the `export` command together with uptest `make e2e` local invocation in #463 
