### PR TITLE
fix(kms): Alias ID for tfstate should begin with "alias/"

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -532,8 +532,8 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	//
 	// 1234abcd-12ab-34cd-56ef-1234567890ab
 	"aws_kms_key": config.IdentifierFromProvider,
-	// KMS aliases are imported using "alias/" + name
-	"aws_kms_alias": kmsAlias(),
+	// KMS aliases can be imported using the id
+	"aws_kms_alias": config.IdentifierFromProvider,
 	// No import
 	"aws_kms_ciphertext": config.IdentifierFromProvider,
 	// KMS External Keys can be imported using the id
@@ -2636,34 +2636,6 @@ func iamUserGroupMembership() config.ExternalName {
 		}
 		return strings.Join(append([]string{u.(string)}, groups...), "/"), nil
 	}
-	return e
-}
-
-func kmsAlias() config.ExternalName {
-	e := config.NameAsIdentifier
-	e.SetIdentifierArgumentFn = func(base map[string]interface{}, externalName string) {
-		if _, ok := base["name"]; !ok {
-			if !strings.HasPrefix(externalName, "alias/") {
-				base["name"] = fmt.Sprintf("alias/%s", externalName)
-			} else {
-				base["name"] = externalName
-			}
-		}
-	}
-	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
-		id, ok := tfstate["id"]
-		if !ok {
-			return "", errors.New("id attribute missing from state file")
-		}
-
-		idStr, ok := id.(string)
-		if !ok {
-			return "", errors.New("value of id needs to be string")
-		}
-
-		return strings.TrimPrefix(idStr, "alias/"), nil
-	}
-
 	return e
 }
 

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -532,8 +532,8 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	//
 	// 1234abcd-12ab-34cd-56ef-1234567890ab
 	"aws_kms_key": config.IdentifierFromProvider,
-	// KMS aliases can be imported using the id
-	"aws_kms_alias": config.IdentifierFromProvider,
+	// KMS aliases are imported using "alias/" + name
+	"aws_kms_alias": kmsAlias(),
 	// No import
 	"aws_kms_ciphertext": config.IdentifierFromProvider,
 	// KMS External Keys can be imported using the id
@@ -2636,6 +2636,34 @@ func iamUserGroupMembership() config.ExternalName {
 		}
 		return strings.Join(append([]string{u.(string)}, groups...), "/"), nil
 	}
+	return e
+}
+
+func kmsAlias() config.ExternalName {
+	e := config.NameAsIdentifier
+	e.SetIdentifierArgumentFn = func(base map[string]interface{}, externalName string) {
+		if _, ok := base["name"]; !ok {
+			if !strings.HasPrefix(externalName, "alias/") {
+				base["name"] = fmt.Sprintf("alias/%s", externalName)
+			} else {
+				base["name"] = externalName
+			}
+		}
+	}
+	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
+		id, ok := tfstate["id"]
+		if !ok {
+			return "", errors.New("id attribute missing from state file")
+		}
+
+		idStr, ok := id.(string)
+		if !ok {
+			return "", errors.New("value of id needs to be string")
+		}
+
+		return strings.TrimPrefix(idStr, "alias/"), nil
+	}
+
 	return e
 }
 

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2664,22 +2664,11 @@ func kmsAlias() config.ExternalName {
 		return strings.TrimPrefix(idStr, "alias/"), nil
 	}
 
-	e.GetIDFn = func(_ context.Context, _ string, parameters map[string]interface{}, _ map[string]interface{}) (string, error) {
-		n, ok := parameters["name"]
-		if !ok {
-			return "", errors.New("name cannot be empty")
+	e.GetIDFn = func(_ context.Context, externalName string, _ map[string]interface{}, _ map[string]interface{}) (string, error) {
+		if !strings.HasPrefix(externalName, "alias/") {
+			return fmt.Sprintf("alias/%s", externalName), nil
 		}
-
-		nameStr, ok := n.(string)
-		if !ok {
-			return "", errors.New("value of name must be a string")
-		}
-
-		if !strings.HasPrefix(nameStr, "alias/") {
-			return fmt.Sprintf("alias/%s", nameStr), nil
-		}
-
-		return nameStr, nil
+		return externalName, nil
 	}
 	return e
 }

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2664,6 +2664,23 @@ func kmsAlias() config.ExternalName {
 		return strings.TrimPrefix(idStr, "alias/"), nil
 	}
 
+	e.GetIDFn = func(_ context.Context, _ string, parameters map[string]interface{}, _ map[string]interface{}) (string, error) {
+		n, ok := parameters["name"]
+		if !ok {
+			return "", errors.New("name cannot be empty")
+		}
+
+		nameStr, ok := n.(string)
+		if !ok {
+			return "", errors.New("value of name must be a string")
+		}
+
+		if !strings.HasPrefix(nameStr, "alias/") {
+			return fmt.Sprintf("alias/%s", nameStr), nil
+		}
+
+		return nameStr, nil
+	}
 	return e
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

KMS alias ID should be used from provider (incudes /alias prefix).
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #722 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested by running the build kms provider against a cluster with KMS aliases in a non-ready state due to ID mismatch. 
