### PR TITLE
fix(iam): Policy ID should contain path and the external-name derived from the ID should be the name part only

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2640,7 +2640,17 @@ func iamUserGroupMembership() config.ExternalName {
 }
 
 func iamPolicy() config.ExternalName {
-	e := config.TemplatedStringAsIdentifier("name", "arn:aws:iam::{{ .setup.client_metadata.account_id }}:policy{{ .parameters.path }}{{ .external_name }}")
+	e := config.NameAsIdentifier
+
+	e.GetIDFn = func(_ context.Context, externalName string, parameters map[string]any, setup map[string]any) (string, error) {
+		path, ok := parameters["path"]
+		if !ok {
+			path = "/"
+		}
+		accountID := setup["client_metadata"].(map[string]string)["account_id"]
+		return fmt.Sprintf("arn:aws:iam::%s:policy%s%s", accountID, path, externalName), nil
+	}
+
 	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
 		id, ok := tfstate["id"]
 		if !ok {

--- a/examples/iam/policy-with-path.yaml
+++ b/examples/iam/policy-with-path.yaml
@@ -1,0 +1,23 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  annotations:
+    meta.upbound.io/example-id: iam/v1beta1/policy
+  labels:
+    testing.upbound.io/example-name: policy
+  name: sample-user-policy-with-path
+spec:
+  forProvider:
+    path: /test-path/
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+              "Sid": "VisualEditor0",
+              "Effect": "Allow",
+              "Action": "elastic-inference:Connect",
+              "Resource": "*"
+          }
+        ]
+      }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Terraform uses the policy path in the `tfstate` id, and name (derived from the ID) must match [\w+=,.@-]. Both are bugs in v0.36.0, both are fixed in this PR.

Fixes #742 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested by running locally against existing non-ready resources and by creating new resources with and without paths.