### PR TITLE
Fix conflicting parameters for `ec2.Instance` resource

### DIFF
--- a/apis/ec2/v1beta1/zz_generated_terraformed.go
+++ b/apis/ec2/v1beta1/zz_generated_terraformed.go
@@ -3855,6 +3855,8 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("AssociatePublicIPAddress"))
+	opts = append(opts, resource.WithNameFilter("CPUCoreCount"))
+	opts = append(opts, resource.WithNameFilter("CPUThreadsPerCore"))
 	opts = append(opts, resource.WithNameFilter("IPv6AddressCount"))
 	opts = append(opts, resource.WithNameFilter("IPv6Addresses"))
 	opts = append(opts, resource.WithNameFilter("NetworkInterface"))

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -48,6 +48,8 @@ func Configure(p *config.Provider) {
 				"associate_public_ip_address",
 				"ipv6_addresses",
 				"ipv6_address_count",
+				"cpu_core_count",
+				"cpu_threads_per_core",
 			},
 		}
 		config.MoveToStatus(r.TerraformResource, "security_groups")


### PR DESCRIPTION
### Description of your changes

While working on [this issue](https://github.com/upbound/provider-aws/issues/602), I got the following error while trying to create the `ec2.Instance` resource:
```
    message: |-
      observe failed: cannot run refresh: refresh failed: Conflicting configuration arguments: "cpu_core_count": conflicts with cpu_options.0.core_count
      Conflicting configuration arguments: "cpu_options.0.core_count": conflicts with cpu_core_count
      Conflicting configuration arguments: "cpu_options.0.threads_per_core": conflicts with cpu_threads_per_core
      Conflicting configuration arguments: "cpu_threads_per_core": conflicts with cpu_options.0.threads_per_core
```
These two parameters(`cpu_core_count`, `cpu_threads_per_core`) were deprecated in [version 4.66.0](https://registry.terraform.io/providers/hashicorp/aws/4.66.0/docs/resources/instance#cpu_core_count) and replaced by `cpu_options` and did not cause a breaking change as they are optional.

This PR, fixes conflicts with these parameters. 


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually and Uptest(https://github.com/upbound/provider-aws/actions/runs/5345616475)
```
NAME                                     READY   SYNCED   EXTERNAL-NAME           AGE
vpc.ec2.aws.upbound.io/sample-instance   True    True     vpc-05af0f75e1d436cda   54m

NAME                                          READY   SYNCED   EXTERNAL-NAME         AGE
instance.ec2.aws.upbound.io/sample-instance   True    True     i-0c610d22bc36fe3d1   14m

NAME                                        READY   SYNCED   EXTERNAL-NAME              AGE
subnet.ec2.aws.upbound.io/sample-instance   True    True     subnet-09ecd50d2461982dd   54m

NAME                                                  READY   SYNCED   EXTERNAL-NAME           AGE
networkinterface.ec2.aws.upbound.io/sample-instance   True    True     eni-054bc17e4c435ab75   54m
```
