### PR TITLE
CognitoIDP[UserPoolClient]: Avoid underlying provider validation failure

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -111,7 +111,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// us-west-2_abc123
 	"aws_cognito_user_pool": config.IdentifierFromProvider,
 	// us-west-2_abc123/3ho4ek12345678909nh3fmhpko
-	"aws_cognito_user_pool_client": config.IdentifierFromProvider,
+	"aws_cognito_user_pool_client": FormattedIdentifierFromProvider("", "name"),
 	// auth.example.org
 	"aws_cognito_user_pool_domain": config.IdentifierFromProvider,
 	// us-west-2_ZCTarbt5C,12bu4fuk3mlgqa2rtrujgp6egq


### PR DESCRIPTION
### Description of your changes

* In a current state the instantiation of `UserPoolClient` fails with
  ```
  cannot run refresh: refresh failed: reading Amazon Cognito IDP (Identity Provider) User Pool Client (): InvalidParameter: 1 
  validation error(s) found.
  - minimum field size of 1, DescribeUserPoolClientInput.ClientId.
  ```
  unless we explicitly set the `external-name` annotation. See #752 for more debugging data

* This change will preset the `id` with `spec.forProvider.name` to avoid the validation failure. The `id` will be populated eventually with the dynamic value from the cloud provider

* I also tried to follow the doc at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client#import but it seems to be wrong in practice:

  If we use smth like

  ```
  TemplatedStringAsIdentifierWithNoName("{{ .parameters.user_pool_id }}/{{ .parameters.name }}"),
  ```

  it will fail with
  ```
  cannot run refresh: refresh failed: reading Amazon Cognito IDP (Identity Provider) User Pool Client (us-west-1_dMnICLKVB/): InvalidParameterException: 1 validation error detected: Value 'us-west-1_dMnICLKVB/' at 'clientId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w+]+
  ```

  It proves that the import doc deviates from reality and fails its own provider validation.

* It is possible that we observe the bug in the underlying terraform aws provider.

* This fix provides best possible solution without the fix of underlying provider and associated costs.

* Fixes #752

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
e2e with example from `examples/cognitoidp/userpooluicustomization.yaml`

I will also execute uptest separately below