### PR TITLE
feat(auth): disable configuring auth with Secrets

### DIFF
--- a/package/auth.yaml
+++ b/package/auth.yaml
@@ -1,29 +1,6 @@
 version: '2023-01-30'
 discriminant: spec.credentials.source
 sources:
-- name: Secret
-  docs: |
-    # Storing Credentials as a Kubernetes Secret
-
-    AWS credentials may be supplied as a Kubernetes `Secret`. Credentials will
-    be stored in this control plane and will only be accessible to installed
-    providers.
-
-    Credentials should be provided in the following format:
-    ```
-    [default]
-    aws_access_key_id = <aws_access_key>
-    aws_secret_access_key = <aws_secret_key>
-    ```
-
-    See the [AWS
-    documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)
-    for more information on how to generate credentials.
-  additionalResources:
-  - type: Secret
-    ref: spec.credentials.secretRef
-  showFields:
-  - spec.credentials.secretRef
 - name: Upbound
   docs: |
     # OpenID Connect (OIDC)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

A follow up to https://github.com/upbound/provider-gcp/pull/329 disabling Secrets as a path of auth.yaml configuration 

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
