### PR TITLE
Added queue url to the connection details. Added writeConnectionSecre…

### DIFF
--- a/config/sqs/config.go
+++ b/config/sqs/config.go
@@ -18,8 +18,8 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_sqs_queue", func(r *config.Resource) {
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}
-			if a, ok := attr["id"].(string); ok {
-				conn["queue_url"] = []byte(a)
+			if a, ok := attr["url"].(string); ok {
+				conn["url"] = []byte(a)
 			}
 			return conn, nil
 		}

--- a/config/sqs/config.go
+++ b/config/sqs/config.go
@@ -16,6 +16,13 @@ func Configure(p *config.Provider) {
 	})
 
 	p.AddResourceConfigurator("aws_sqs_queue", func(r *config.Resource) {
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["id"].(string); ok {
+				conn["queue_url"] = []byte(a)
+			}
+			return conn, nil
+		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"name_prefix"},
 		}

--- a/examples/sqs/queue.yaml
+++ b/examples/sqs/queue.yaml
@@ -14,3 +14,6 @@ spec:
     region: us-west-1
     tags:
       Environment: production
+  writeConnectionSecretToRef:
+    name: "sqs-example"
+    namespace: "upbound-system"


### PR DESCRIPTION
### Description of your changes

Added the SQS queue url to the connection details so that the value will appear in the secret created by `writeConnectionSecretToRef`

Fixes #730

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with [uptest](https://github.com/upbound/provider-aws/pull/769/checks?sha=d6f5ef5784c93d8743bb41e892fe5586f4bab5bb) and manually:

```shell
❯ k get secrets/sqs-example -n upbound-system
NAME          TYPE                                DATA   AGE
sqs-example   connection.crossplane.io/v1alpha1   1      6m21s

❯ k get secrets/sqs-example -n upbound-system --template={{.data.url}} | base64 -D
https://sqs.us-west-1.amazonaws.com/xxxxxxxxx/upbound-sqs
```