### PR TITLE
Fix issue 726: Missing selector in Broker resource for selecting security groups 

### DIFF
--- a/apis/mq/v1beta1/zz_broker_types.go
+++ b/apis/mq/v1beta1/zz_broker_types.go
@@ -148,7 +148,18 @@ type BrokerParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
+	// References to SecurityGroup in ec2 to populate securityGroups.
+	// +kubebuilder:validation:Optional
+	SecurityGroupRefs []v1.Reference `json:"securityGroupRefs,omitempty" tf:"-"`
+
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroups.
+	// +kubebuilder:validation:Optional
+	SecurityGroupSelector *v1.Selector `json:"securityGroupSelector,omitempty" tf:"-"`
+
 	// List of security group IDs assigned to the broker.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupRefs
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroups []*string `json:"securityGroups,omitempty" tf:"security_groups,omitempty"`
 

--- a/apis/mq/v1beta1/zz_generated.deepcopy.go
+++ b/apis/mq/v1beta1/zz_generated.deepcopy.go
@@ -337,6 +337,18 @@ func (in *BrokerParameters) DeepCopyInto(out *BrokerParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SecurityGroupRefs != nil {
+		in, out := &in.SecurityGroupRefs, &out.SecurityGroupRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SecurityGroupSelector != nil {
+		in, out := &in.SecurityGroupSelector, &out.SecurityGroupSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]*string, len(*in))

--- a/apis/mq/v1beta1/zz_generated.resolvers.go
+++ b/apis/mq/v1beta1/zz_generated.resolvers.go
@@ -41,6 +41,22 @@ func (mg *Broker) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	}
 	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+		CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.SecurityGroups),
+		Extract:       reference.ExternalName(),
+		References:    mg.Spec.ForProvider.SecurityGroupRefs,
+		Selector:      mg.Spec.ForProvider.SecurityGroupSelector,
+		To: reference.To{
+			List:    &v1beta1.SecurityGroupList{},
+			Managed: &v1beta1.SecurityGroup{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.SecurityGroups")
+	}
+	mg.Spec.ForProvider.SecurityGroups = reference.ToPtrValues(mrsp.ResolvedValues)
+	mg.Spec.ForProvider.SecurityGroupRefs = mrsp.ResolvedReferences
+
+	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 		CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.SubnetIds),
 		Extract:       reference.ExternalName(),
 		References:    mg.Spec.ForProvider.SubnetIDRefs,

--- a/config/mq/config.go
+++ b/config/mq/config.go
@@ -13,6 +13,11 @@ import (
 // Configure adds configurations for rds group.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_mq_broker", func(r *config.Resource) {
+		r.References["security_groups"] = config.Reference{
+			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			RefFieldName:      "SecurityGroupRefs",
+			SelectorFieldName: "SecurityGroupSelector",
+		}
 		r.UseAsync = true
 		// TODO(aru): looks like currently angryjet cannot handle references
 		//  for non-string struct fields. `configuration.revision` is a

--- a/examples-generated/mq/broker.yaml
+++ b/examples-generated/mq/broker.yaml
@@ -18,8 +18,8 @@ spec:
     engineVersion: 5.15.9
     hostInstanceType: mq.t2.micro
     region: us-west-1
-    securityGroups:
-    - ${aws_security_group.test.id}
+    securityGroupRefs:
+    - name: test
     user:
     - passwordSecretRef:
         key: example-key

--- a/examples/mq/broker.yaml
+++ b/examples/mq/broker.yaml
@@ -12,6 +12,8 @@ spec:
     # Details can be found in https://github.com/crossplane/terrajet/issues/280
     brokerName: example-broker
     region: us-west-1
+    securityGroupRefs:
+    - name: example
     engineType: ActiveMQ
     engineVersion: 5.15.9
     hostInstanceType: mq.t2.micro
@@ -21,14 +23,13 @@ spec:
         name: mq-secret
         namespace: upbound-system
       username: admin
-
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
   annotations:
     meta.upbound.io/example-id: mq/v1beta1/broker
+    uptest.upbound.io/pre-delete-hook: testhooks/delete-broker.sh
   labels:
     testing.upbound.io/example-name: mq-secret
   name: mq-secret
@@ -36,3 +37,19 @@ metadata:
 type: Opaque
 stringData:
   password: "Upboundtest!"
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/securitygroup
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    region: us-west-1
+    description: Allow TLS inbound traffic
+    name: allow_tls
+    tags:
+      Name: allow_tls

--- a/examples/mq/testhooks/delete-broker.sh
+++ b/examples/mq/testhooks/delete-broker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+# Delete the broker resource before deleting the secret
+${KUBECTL} delete broker.mq.aws.upbound.io --all

--- a/package/crds/mq.aws.upbound.io_brokers.yaml
+++ b/package/crds/mq.aws.upbound.io_brokers.yaml
@@ -325,6 +325,83 @@ spec:
                     description: Region is the region you'd like your resource to
                       be created in.
                     type: string
+                  securityGroupRefs:
+                    description: References to SecurityGroup in ec2 to populate securityGroups.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: Resolution specifies whether resolution
+                                of this reference is required. The default is 'Required',
+                                which means the reconcile will fail if the reference
+                                cannot be resolved. 'Optional' means this reference
+                                will be a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: Resolve specifies when this reference should
+                                be resolved. The default is 'IfNotPresent', which
+                                will attempt to resolve the reference only when the
+                                corresponding field is not present. Use 'Always' to
+                                resolve the reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  securityGroupSelector:
+                    description: Selector for a list of SecurityGroup in ec2 to populate
+                      securityGroups.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   securityGroups:
                     description: List of security group IDs assigned to the broker.
                     items:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Missing selector in Broker resource for selecting security groups: add selectors for the securityGroup

Now can use next selectors:
securityGroupRefs
securityGroupSelector

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/provider-aws/issues/726

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually
Uptests: https://github.com/upbound/provider-aws/actions/runs/5507977809

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
