### PR TITLE
fix(aws_cloudwatch_log_group): skip name_prefix lateinit

### DIFF
--- a/config/cloudwatchlogs/config.go
+++ b/config/cloudwatchlogs/config.go
@@ -47,4 +47,12 @@ func Configure(p *config.Provider) {
 			Extractor:     common.PathTerraformIDExtractor,
 		}
 	})
+
+	p.AddResourceConfigurator("aws_cloudwatch_log_group", func(r *config.Resource) {
+		config.MarkAsRequired(r.TerraformResource, "name")
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"name_prefix"},
+		}
+	})
+
 }

--- a/examples/cloudwatchlogs/group.yaml
+++ b/examples/cloudwatchlogs/group.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   forProvider:
     region: us-west-1
+    retentionInDays: 5
     tags:
       Application: serviceA
       Environment: production


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
skip `name_prefix` in `aws_cloudwatch_log_group` and enhance example

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #795

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
create, loop and delete

```
kubectl describe group.cloudwatchlogs.aws.upbound.io/example                            
Name:         example
Namespace:    
Labels:       <none>
Annotations:  crossplane.io/external-create-pending: 2023-07-21T11:29:11+02:00
              crossplane.io/external-create-succeeded: 2023-07-21T11:29:11+02:00
              crossplane.io/external-name: example
              upjet.crossplane.io/provider-meta: null
API Version:  cloudwatchlogs.aws.upbound.io/v1beta1
Kind:         Group
Metadata:
  Creation Timestamp:  2023-07-21T09:29:01Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generation:        2
  Resource Version:  93856
  UID:               552d1988-c4fe-4a47-afe5-47e7c58d4e44
Spec:
  Deletion Policy:  Delete
  For Provider:
    Region:             us-west-1
    Retention In Days:  5
    Tags:
      Application:                  serviceA
      Environment:                  production
      Crossplane - Kind:            group.cloudwatchlogs.aws.upbound.io
      Crossplane - Name:            example
      Crossplane - Providerconfig:  default
  Management Policy:                FullControl
  Provider Config Ref:
    Name:  default
Status:
  At Provider:
    Arn:                arn:aws:logs:us-west-1:609897127049:log-group:example
    Id:                 example
    Kms Key Id:         
    Retention In Days:  5
    Skip Destroy:       false
    Tags:
      Application:                  serviceA
      Environment:                  production
      Crossplane - Kind:            group.cloudwatchlogs.aws.upbound.io
      Crossplane - Name:            example
      Crossplane - Providerconfig:  default
    Tags All:
      Application:                  serviceA
      Environment:                  production
      Crossplane - Kind:            group.cloudwatchlogs.aws.upbound.io
      Crossplane - Name:            example
      Crossplane - Providerconfig:  default
  Conditions:
    Last Transition Time:  2023-07-21T09:29:24Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2023-07-21T09:29:11Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
    Last Transition Time:  2023-07-21T09:29:16Z
    Reason:                Success
    Status:                True
    Type:                  LastAsyncOperation
    Last Transition Time:  2023-07-21T09:29:16Z
    Reason:                Finished
    Status:                True
    Type:                  AsyncOperation
Events:
  Type     Reason                       Age    From                                                       Message
  ----     ------                       ----   ----                                                       -------
  Normal   CreatedExternalResource      4m57s  managed/cloudwatchlogs.aws.upbound.io/v1beta1, kind=group  Successfully requested creation of external resource
  Warning  CannotUpdateManagedResource  4m50s  managed/cloudwatchlogs.aws.upbound.io/v1beta1, kind=group  Operation cannot be fulfilled on groups.cloudwatchlogs.aws.upbound.io "example": the object has been modified; please apply your changes to the latest version and try again
```


tested also in underlaying terraform:
```
552d1988-c4fe-4a47-afe5-47e7c58d4e44 terraform plan                                              
aws_cloudwatch_log_group.example: Refreshing state... [id=example]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
