### PR TITLE
Return RDS Instance Endpoint field in the ConnectionSecret without port

### DIFF
--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -108,12 +108,10 @@ func Configure(p *config.Provider) {
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}
-			if a, ok := attr["endpoint"].(string); ok {
-				conn["endpoint"] = []byte(a)
-			}
 			if a, ok := attr["address"].(string); ok {
 				conn["address"] = []byte(a)
 				conn["host"] = []byte(a)
+				conn["endpoint"] = []byte(a)
 			}
 			if a, ok := attr["username"].(string); ok {
 				conn["username"] = []byte(a)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #778: Previously the ConnectionSecret endpoint field contained the hostname including the port.

This is not expected behavior and makes the ConnectionSecret unusable by downstream consumers of the Secret, like
https://github.com/crossplane-contrib/provider-sql, which expect the endpoint and port to be in separate fields.


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

TBD