### PR TITLE
Fix panic when using custom endpoints

### DIFF
--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -175,6 +175,17 @@ func DefaultTerraformSetupBuilder(ctx context.Context, c client.Client, mg resou
 		return errors.Wrap(err, "failed to retrieve aws credentials from aws config")
 	}
 
+	ps.Configuration = map[string]any{
+		keyRegion:               cfg.Region,
+		keyAccessKeyID:          creds.AccessKeyID,
+		keySecretAccessKey:      creds.SecretAccessKey,
+		keySessionToken:         creds.SessionToken,
+		keySkipCredsValidation:  pc.Spec.SkipCredsValidation,
+		keyS3UsePathStyle:       pc.Spec.S3UsePathStyle,
+		keySkipMetadataApiCheck: pc.Spec.SkipMetadataApiCheck,
+		keySkipReqAccountId:     pc.Spec.SkipReqAccountId,
+	}
+
 	if pc.Spec.Endpoint != nil {
 		if pc.Spec.Endpoint.URL.Static != nil {
 			if len(pc.Spec.Endpoint.Services) > 0 && *pc.Spec.Endpoint.URL.Static == "" {
@@ -187,17 +198,6 @@ func DefaultTerraformSetupBuilder(ctx context.Context, c client.Client, mg resou
 				ps.Configuration[keyEndpoints] = endpoints
 			}
 		}
-	}
-
-	ps.Configuration = map[string]any{
-		keyRegion:               cfg.Region,
-		keyAccessKeyID:          creds.AccessKeyID,
-		keySecretAccessKey:      creds.SecretAccessKey,
-		keySessionToken:         creds.SessionToken,
-		keySkipCredsValidation:  pc.Spec.SkipCredsValidation,
-		keyS3UsePathStyle:       pc.Spec.S3UsePathStyle,
-		keySkipMetadataApiCheck: pc.Spec.SkipMetadataApiCheck,
-		keySkipReqAccountId:     pc.Spec.SkipReqAccountId,
 	}
 	return err
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #780: Custom endpoint in the ProviderConfig crashes the provider

Moves the creation of `ps.Configuration` map before the code that assigns entries to it.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Built custom image using the following:
```
make submodules
export DOCKER_REGISTRY=myregistry/myrepo
export BUILD_REGISTRY=myregistry/myrepo
export XPKG_REG_ORGS=myregistry/myrepo
export REGISTRY_ORGS=myregistry/myrepo
make build.all publish BRANCH_NAME=main SUBPACKAGES="s3"
```
Created aws family Provider using released v0.37.0 image and s3 Provider using test image.
```
NAME                  INSTALLED   HEALTHY   PACKAGE                                                                 AGE
provider-aws-family   True        True      myregistry/myrepo/provider-family-aws:v0.37.0      63m
provider-aws-s3       True        True      myregistry/myrepo/provider-aws-s3:v0.37.0-custom   70m
```
Deployed Minio object store and configured ProviderConfig to point to it:
```
apiVersion: aws.upbound.io/v1beta1
kind: ProviderConfig
metadata:
  name: minio
spec:
  credentials:
    secretRef:
      key: config
      name: minio-credentials
      namespace: mynamespace
    source: Secret
  endpoint:
    hostnameImmutable: true
    services:
    - s3
    - sts
    signingRegion: eu-west-2
    source: Custom
    url:
      static: http://minio.mynamespace.svc.cluster.local:9000
      type: Static
  s3_use_path_style: true
  skip_credentials_validation: true
  skip_metadata_api_check: true
  skip_requesting_account_id: true
```
Created an S3 bucket:
```
NAME                 READY   SYNCED   EXTERNAL-NAME        AGE
my-bucket            True    True     my-bucket            31m
```
Validated the bucket was created with AWS CLI:
```
bash-4.2# aws --endpoint-url http://minio.mynamespace.svc.cluster.local:9000/ s3 ls
2023-07-28 16:40:40 my-bucket
```