### PR TITLE
Resolve name collision between S3 and Lightsail in quickstart

### DIFF
--- a/docs/family/Configuration.md
+++ b/docs/family/Configuration.md
@@ -59,8 +59,8 @@ Verify the configuration with `kubectl get providers`.
 
 ```shell
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.40.0       6m39s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.40.0   6m30s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0       6m39s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.41.0   6m30s
 ```
 
 View the Crossplane [Provider CRD

--- a/docs/family/Quickstart.md
+++ b/docs/family/Quickstart.md
@@ -79,8 +79,8 @@ After installing the provider, verify the install with `kubectl get providers`.
 
 ```shell
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.40.0       6m39s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.40.0   6m30s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0       6m39s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.41.0   6m30s
 ```
 
 It may take up to 5 minutes to report `HEALTHY`.

--- a/docs/monolith/Configuration.md
+++ b/docs/monolith/Configuration.md
@@ -58,7 +58,7 @@ Verify the configuration with `kubectl get providers`.
 ```shell
 $ kubectl get providers
 NAME           INSTALLED   HEALTHY   PACKAGE                                       AGE
-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v0.40.0  62s
+provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v0.41.0  62s
 ```
 
 View the Crossplane [Provider CRD

--- a/docs/monolith/Quickstart.md
+++ b/docs/monolith/Quickstart.md
@@ -73,7 +73,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws:v0.21.0
+  package: xpkg.upbound.io/upbound/provider-aws:v0.41.0
 EOF
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Installed --timeout=180s
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Healthy --timeout=180s

--- a/docs/monolith/Quickstart.md
+++ b/docs/monolith/Quickstart.md
@@ -116,9 +116,9 @@ spec:
 EOF
 
 printf "Checking AWS bucket creation (this only takes a minute)...\n"
-kubectl wait "$(kubectl get buckets -o name)" --for=condition=Ready --timeout=180s
+kubectl wait "$(kubectl get buckets.s3 -o name)" --for=condition=Ready --timeout=180s
 
-kubectl get buckets
+kubectl get buckets.s3
 ```
 
 Your Kubernetes cluster created this AWS S3 bucket.
@@ -363,10 +363,10 @@ spec:
 EOF
 ```
 
-Use `kubectl get buckets` to verify bucket creation.
+Use `kubectl get buckets.s3` to verify bucket creation.
 
 ```shell
-$ kubectl get buckets
+$ kubectl get buckets.s3
 NAME                           READY   SYNCED   EXTERNAL-NAME                  AGE
 upbound-bucket-fb8360b455dd9   True    True     upbound-bucket-fb8360b455dd9   8s
 ```
@@ -423,12 +423,12 @@ providerconfig.aws.upbound.io/my-config   114s
 
 ### Delete the managed resource
 Remove the managed resource by using `kubectl delete -f` with the same `Bucket`
-object file. Verify removal of the bucket with `kubectl get buckets`
+object file. Verify removal of the bucket with `kubectl get buckets.s3`
 
 ```shell
 $ kubectl delete -f bucket.yml
 bucket.s3.aws.upbound.io "upbound-bucket-fb8360b455dd9" deleted
 
-$ kubectl get buckets
+$ kubectl get buckets.s3
 No resources found
 ```

--- a/docs/quickstart.sh
+++ b/docs/quickstart.sh
@@ -61,6 +61,6 @@ spec:
 EOF
 
 printf "Checking AWS bucket creation (this only takes a minute)...\n"
-kubectl wait "$(kubectl get buckets -o name)" --for=condition=Ready --timeout=180s
+kubectl wait "$(kubectl get buckets.s3 -o name)" --for=condition=Ready --timeout=180s
 
-kubectl get buckets
+kubectl get buckets.s3

--- a/docs/quickstart.sh
+++ b/docs/quickstart.sh
@@ -18,7 +18,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws:v0.21.0
+  package: xpkg.upbound.io/upbound/provider-aws:v0.41.0
 EOF
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Installed --timeout=180s
 kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Healthy --timeout=180s


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fix #590: S3 and Lightsail APIs have their own “buckets” resources. Quickstart document creates an S3 bucket. When `kubectl get buckets` command is run, though, Lightsail resources are listed. Such behavior confuses users, especially newcomers to crossplane, who expect to see their S3 buckets instead. 

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

I couldn't run `make reviewable test`, because of [IS#737](https://github.com/upbound/provider-aws/issues/737). I hope that updating only documentation won't cause any problems.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I've followed quickstart document and manually run shell commands. I've used a local [kind](https://kind.sigs.k8s.io) cluster.
