### PR TITLE
Add option to skip region validation

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -25,6 +25,11 @@ type ProviderConfigSpec struct {
 	// This can be useful for testing and for AWS API implementations that do not have STS available.
 	// +optional
 	SkipCredsValidation bool `json:"skip_credentials_validation,omitempty"`
+	// Whether to skip validation of provided region name.
+	// Useful for AWS-like implementations that use their own region names or to bypass the validation for
+	// regions that aren't publicly available yet.
+	// +optional
+	SkipRegionValidation bool `json:"skip_region_validation,omitempty"`
 	// Whether to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY.
 	// +optional
 	S3UsePathStyle bool `json:"s3_use_path_style,omitempty"`

--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -38,6 +38,7 @@ const (
 	keySkipCredsValidation       = "skip_credentials_validation"
 	keyS3UsePathStyle            = "s3_use_path_style"
 	keySkipMetadataApiCheck      = "skip_metadata_api_check"
+	keySkipRegionValidation      = "skip_region_validation"
 	keySkipReqAccountId          = "skip_requesting_account_id"
 	keyEndpoints                 = "endpoints"
 )
@@ -182,6 +183,7 @@ func DefaultTerraformSetupBuilder(ctx context.Context, c client.Client, mg resou
 		keySessionToken:         creds.SessionToken,
 		keySkipCredsValidation:  pc.Spec.SkipCredsValidation,
 		keyS3UsePathStyle:       pc.Spec.S3UsePathStyle,
+		keySkipRegionValidation: pc.Spec.SkipRegionValidation,
 		keySkipMetadataApiCheck: pc.Spec.SkipMetadataApiCheck,
 		keySkipReqAccountId:     pc.Spec.SkipReqAccountId,
 	}

--- a/package/crds/aws.upbound.io_providerconfigs.yaml
+++ b/package/crds/aws.upbound.io_providerconfigs.yaml
@@ -297,6 +297,12 @@ spec:
                 description: Whether to skip the AWS Metadata API check Useful for
                   AWS API implementations that do not have a metadata API endpoint.
                 type: boolean
+              skip_region_validation:
+                description: Whether to skip validation of provided region name. Useful
+                  for AWS-like implementations that use their own region names or
+                  to bypass the validation for regions that aren't publicly available
+                  yet.
+                type: boolean
               skip_requesting_account_id:
                 description: Whether to skip requesting the account ID. Useful for
                   AWS API implementations that do not have the IAM, STS API, or metadata


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR adds the `skip_region_validation` field to the AWS ProviderConfig as per https://registry.terraform.io/providers/hashicorp/aws/2.47.0/docs#skip_region_validation



<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #812: Support skipping region validation

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Built custom image using the following:
```
make submodules
export DOCKER_REGISTRY=myregistry/myrepo
export BUILD_REGISTRY=myregistry/myrepo
export XPKG_REG_ORGS=myregistry/myrepo
export REGISTRY_ORGS=myregistry/myrepo
make build.all publish BRANCH_NAME=main SUBPACKAGES="s3 config"
```

Created aws family Provider and s3 Provider using newly built test images:
```
NAME                  INSTALLED   HEALTHY   PACKAGE                                            AGE
provider-aws-family   True        True      myregistry/myrepo/provider-family-aws:v0.37.0      53m
provider-aws-s3       True        True      myregistry/myrepo/provider-aws-s3:v0.37.0-custom.4 53m
```

Deployed Minio object store with a custom region and configured ProviderConfig to point to it:
```
apiVersion: aws.upbound.io/v1beta1
kind: ProviderConfig
metadata:
  name: minio
spec:
  credentials:
    secretRef:
      key: config
      name: minio-credentials
      namespace: mynamespace
    source: Secret
  endpoint:
    hostnameImmutable: true
    services:
    - s3
    - sts
    signingRegion: my-region
    source: Custom
    url:
      static: http://minio.mynamespace.svc.cluster.local:9000
      type: Static
  s3_use_path_style: true
  skip_credentials_validation: true
  skip_metadata_api_check: true
  skip_requesting_account_id: true
  skip_region_validation: true
```

Created an S3 bucket passing the custom region:
```
apiVersion: s3.aws.upbound.io/v1beta1
kind: Bucket
metadata:
  name: my-bucket
spec:
  forProvider:
    region: my-region
```

Observe that bucket is created successfully and there is no `Error: Invalid AWS Region` error as was the case prior to this PR:
```
NAME                 READY   SYNCED   EXTERNAL-NAME        AGE
my-bucket            True    True     my-bucket            5m
```