### PR TITLE
[Backport release-0.39] Fix warning title for monolithic provider

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 weight: 2
 ---
-> :warning: **Warning:** The monolithic AWS provider (`upbound/provider-aws`) has been deprecated in favor of the [AWS provider family](https://marketplace.upbound.io/providers/upbound/provider-family-aws/). You can read more about the provider families in our [blog post](https://blog.upbound.io/new-provider-families) and the official documentation for the provider families is [here](https://docs.upbound.io/providers/provider-families/). We will continue support for the monolithic AWS provider until June 12, 2024. And you can find more information on migrating from the monolithic providers to the provider families [here](https://docs.upbound.io/providers/migration/).
+⚠️ **Warning:** The monolithic AWS provider (`upbound/provider-aws`) has been deprecated in favor of the [AWS provider family](https://marketplace.upbound.io/providers/upbound/provider-family-aws/). You can read more about the provider families in our [blog post](https://blog.upbound.io/new-provider-families) and the official documentation for the provider families is [here](https://docs.upbound.io/providers/provider-families/). We will continue support for the monolithic AWS provider until June 12, 2024. And you can find more information on migrating from the monolithic providers to the provider families [here](https://docs.upbound.io/providers/migration/).
 
 # AWS official provider documentation
 Upbound supports and maintains the Upbound AWS official provider.

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -2,7 +2,7 @@
 title: Quickstart
 weight: 1
 ---
-> :warning: **Warning:** The monolithic AWS provider (`upbound/provider-aws`) has been deprecated in favor of the [AWS provider family](https://marketplace.upbound.io/providers/upbound/provider-family-aws/). You can read more about the provider families in our [blog post](https://blog.upbound.io/new-provider-families) and the official documentation for the provider families is [here](https://docs.upbound.io/providers/provider-families/). We will continue support for the monolithic AWS provider until June 12, 2024. And you can find more information on migrating from the monolithic providers to the provider families [here](https://docs.upbound.io/providers/migration/).
+⚠️ **Warning:** The monolithic AWS provider (`upbound/provider-aws`) has been deprecated in favor of the [AWS provider family](https://marketplace.upbound.io/providers/upbound/provider-family-aws/). You can read more about the provider families in our [blog post](https://blog.upbound.io/new-provider-families) and the official documentation for the provider families is [here](https://docs.upbound.io/providers/provider-families/). We will continue support for the monolithic AWS provider until June 12, 2024. And you can find more information on migrating from the monolithic providers to the provider families [here](https://docs.upbound.io/providers/migration/).
 
 # Quickstart
 


### PR DESCRIPTION
(cherry picked from commit ce875a05c2d1757ee6a1aab6f54ee696f3e81be4)

### Description of your changes

Backport of https://github.com/upbound/provider-aws/pull/848 to release-0.39.