### PR TITLE
ignore cidr_block on lateinitialize to avoid conflicts when using ipam

### DIFF
--- a/apis/ec2/v1beta1/zz_generated_terraformed.go
+++ b/apis/ec2/v1beta1/zz_generated_terraformed.go
@@ -6332,6 +6332,7 @@ func (tr *VPC) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("CidrBlock"))
 	opts = append(opts, resource.WithNameFilter("IPv6CidrBlock"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -325,6 +325,7 @@ func Configure(p *config.Provider) {
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{
 				"ipv6_cidr_block",
+				"cidr_block",
 			},
 		}
 		r.UseAsync = true

--- a/examples/ec2/vpc-ipampool.yaml
+++ b/examples/ec2/vpc-ipampool.yaml
@@ -1,0 +1,81 @@
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/vpc-ipampool
+  name: sample-vpc
+spec:
+  forProvider:
+    region: us-west-1
+    ipv4IpamPoolIdSelector:
+      matchLabels: 
+        testing.upbound.io/example-name: ipampool
+    ipv4NetmaskLength: 28
+    tags:
+      Name: DemoVpc
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCIpamPoolCidr
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/vpc-ipampool
+  labels:
+    testing.upbound.io/example-name: ipampool
+  name: example
+spec:
+  forProvider:
+    cidr: 172.2.0.0/16
+    ipamPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ipampool
+    region: us-west-1
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCIpamPool
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/vpc-ipampool
+  labels:
+    testing.upbound.io/example-name: ipampool
+  name: example
+spec:
+  forProvider:
+    addressFamily: ipv4
+    ipamScopeIdSelector: 
+      matchLabels:
+        testing.upbound.io/example-name: ipampool
+    locale: us-west-1 
+    region: us-west-1
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCIpamScope
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/vpc-ipampool
+  labels:
+    testing.upbound.io/example-name: ipampool
+  name: example
+spec:
+  forProvider:
+    description: Another Scope
+    ipamIdSelector: 
+      matchLabels:
+        testing.upbound.io/example-name: ipampool
+    region: us-west-1
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCIpam
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/vpc-ipampool
+  labels:
+    testing.upbound.io/example-name: ipampool
+  name: main
+spec:
+  forProvider:
+    description: My IPAM
+    operatingRegions:
+    - regionName: us-west-1 
+    region: us-west-1
+    tags:
+      Test: Main


### PR DESCRIPTION
### Description of your changes

When configuring a VPC with an IPAM pool and a netmask length, the ipv4 cidr block must not be late initialized. 
Fixes #879 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Local testing
`uptest e2e examples/ec2/vpc-ipampool.yaml`
