### PR TITLE
Fix trailing apostrophe breaking a hyperlink

### DIFF
--- a/package/auth.yaml
+++ b/package/auth.yaml
@@ -10,7 +10,7 @@ sources:
     provider in your AWS account, then create an IAM role that the AWS provider
     in your control plane can assume. Go through the following steps to add the
     identity provider.
-    1. Open the IAM console at [https://console.aws.amazon.com/iam](https://console.aws.amazon.com/iam').
+    1. Open the IAM console at [https://console.aws.amazon.com/iam](https://console.aws.amazon.com/iam).
     2. Navigate to **Identity Providers** > **Add Provider** and select **OpenID Connect**.
     3. Use `https://proidc.upbound.io` as the **Provider URL** and `sts.amazonaws.com` as the **Audience**.
     4. Select **Add Provider**.


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes https://github.com/upbound/squad-upbound-cloud/issues/1295, where a link in the Upbound console is broken due to an extra character in `auth.yaml`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
N/A