### PR TITLE
Use family providers instead of monolith in Uptest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,9 +196,13 @@ uptest-local:
 build-monolith:
 	@$(MAKE) build SUBPACKAGES=monolith LOAD_MONOLITH=true
 
-local-deploy: build-monolith controlplane.up local.xpkg.deploy.provider.$(PROJECT_NAME)-monolith
+local-deploy: controlplane.up
 	@$(INFO) running locally built provider
-	@$(KUBECTL) wait provider.pkg $(PROJECT_NAME)-monolith --for condition=Healthy --timeout 5m
+	for subpackage in $(UPTEST_SUBPACKAGES); do \
+		$(MAKE) build SUBPACKAGES=$$subpackage LOAD_SUBPACKAGE=true; \
+		$(MAKE) local.xpkg.deploy.provider.$(PROJECT_NAME)-$$subpackage; \
+		$(KUBECTL) wait provider.pkg $(PROJECT_NAME)-$$subpackage --for condition=Healthy --timeout 5m; \
+	done
 	@$(KUBECTL) -n upbound-system wait --for=condition=Available deployment --all --timeout=5m
 	@$(OK) running locally built provider
 

--- a/cluster/images/provider-aws/Makefile
+++ b/cluster/images/provider-aws/Makefile
@@ -30,6 +30,13 @@ img.build:
 	  export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-monolith-$(VERSION).xpkg") && \
 	  docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-monolith-$(ARCH); \
 	fi || $(FAIL)
+
+	if [[ "$${LOAD_SUBPACKAGE}" == "true" ]]; then \
+		$(MAKE) batch-process SUBPACKAGES=$(SUBPACKAGES) BATCH_PLATFORMS=$(PLATFORM) BUILD_ONLY=true STORE_PACKAGE=$(SUBPACKAGES) && \
+		export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-$(SUBPACKAGES)-$(VERSION).xpkg") && \
+		docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-$(SUBPACKAGES)-$(ARCH); \
+	fi
+
 	@$(OK) docker build $${IMAGE};
 
 img.build.shared:


### PR DESCRIPTION
### Description of your changes

This PR adds ability to use family providers instead of monolith in Uptest

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally.
