### PR TITLE
Uptest family providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,12 +193,14 @@ uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 uptest-local:
 	@$(WARN) "this target is deprecated, please use 'make uptest' instead"
 
-build-monolith:
-	@$(MAKE) build SUBPACKAGES=monolith LOAD_MONOLITH=true
+build.%:
+	@$(MAKE) build SUBPACKAGES=$* LOAD_PACKAGES=true
 
-local-deploy: build-monolith controlplane.up local.xpkg.deploy.provider.$(PROJECT_NAME)-monolith
+XPKG_SKIP_DEP_RESOLUTION := true
+
+local-deploy.%: controlplane.up local.xpkg.deploy.provider.$(PROJECT_NAME)-%
 	@$(INFO) running locally built provider
-	@$(KUBECTL) wait provider.pkg $(PROJECT_NAME)-monolith --for condition=Healthy --timeout 5m
+	$(KUBECTL) wait provider.pkg $(PROJECT_NAME)-$* --for condition=Healthy --timeout 5m
 	@$(KUBECTL) -n upbound-system wait --for=condition=Available deployment --all --timeout=5m
 	@$(OK) running locally built provider
 

--- a/cluster/images/provider-aws/Makefile
+++ b/cluster/images/provider-aws/Makefile
@@ -25,10 +25,10 @@ img.build:
 	@$(INFO) Family base image to build: $(IMAGE)
 	@$(INFO) Building image $${IMAGE}; \
 	$(MAKE) BUILD_ARGS="--load ${BUILD_ARGS}" IMAGE=$${IMAGE} XPKG_REG_ORGS=$(XPKG_REG_ORGS) img.build.shared; \
-	if [[ "$${LOAD_MONOLITH}" == "true" ]]; then \
-	  $(MAKE) batch-process SUBPACKAGES=monolith BATCH_PLATFORMS=$(PLATFORM) BUILD_ONLY=true STORE_PACKAGE=monolith && \
-	  export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-monolith-$(VERSION).xpkg") && \
-	  docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-monolith-$(ARCH); \
+	if [[ "$${LOAD_PACKAGES}" == "true" ]]; then \
+	  $(MAKE) batch-process SUBPACKAGES=$(SUBPACKAGES) BATCH_PLATFORMS=$(PLATFORM) BUILD_ONLY=true STORE_PACKAGE=$(SUBPACKAGES) && \
+	  export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-$(SUBPACKAGES)-$(VERSION).xpkg") && \
+	  docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-$(SUBPACKAGES)-$(ARCH); \
 	fi || $(FAIL)
 	@$(OK) docker build $${IMAGE};
 

--- a/cluster/images/provider-aws/Makefile
+++ b/cluster/images/provider-aws/Makefile
@@ -26,11 +26,13 @@ img.build:
 	@$(INFO) Building image $${IMAGE}; \
 	$(MAKE) BUILD_ARGS="--load ${BUILD_ARGS}" IMAGE=$${IMAGE} XPKG_REG_ORGS=$(XPKG_REG_ORGS) img.build.shared; \
 	if [[ "$${LOAD_PACKAGES}" == "true" ]]; then \
-	  $(MAKE) batch-process SUBPACKAGES=$(SUBPACKAGES) BATCH_PLATFORMS=$(PLATFORM) BUILD_ONLY=true STORE_PACKAGE=$(SUBPACKAGES) && \
-	  export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-$(SUBPACKAGES)-$(VERSION).xpkg") && \
-	  docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-$(SUBPACKAGES)-$(ARCH); \
+		$(MAKE) batch-process SUBPACKAGES="$(SUBPACKAGES)" BATCH_PLATFORMS=$(PLATFORM) BUILD_ONLY=true STORE_PACKAGES="$$(tr ' ' ',' <<< "$(SUBPACKAGES)")" && \
+		for s in $(SUBPACKAGES); do \
+			export t=$$(docker load -qi "$(XPKG_OUTPUT_DIR)/$(PLATFORM)/$(PROJECT_NAME)-$${s}-$(VERSION).xpkg") && \
+			docker tag $${t##*:} $(BUILD_REGISTRY)/$(PROJECT_NAME)-$${s}-$(ARCH); \
+		done; \
 	fi || $(FAIL)
-	@$(OK) docker build $${IMAGE};
+	@$(OK) docker build $${IMAGE}
 
 img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
@@ -59,11 +61,11 @@ ifeq (-,$(findstring -,$(VERSION)))
     DEP_CONSTRAINT = >= 0.0.0-0
 endif
 BUILD_ONLY ?= false
-STORE_PACKAGE ?= ""
+STORE_PACKAGES ?= ""
 batch-process: $(UP)
-	@$(INFO) Batch processing smaller provider packages for: $(SUBPACKAGES)
+	@$(INFO) Batch processing smaller provider packages for: "$(SUBPACKAGES)"
 	@mkdir -p "$(XPKG_OUTPUT_DIR)/$(PLATFORM)" && \
-	$(UP) xpkg batch --smaller-providers $$(echo -n $(SUBPACKAGES) | tr ' ' ',') \
+	$(UP) xpkg batch --smaller-providers "$$(tr ' ' ',' <<< "$(SUBPACKAGES)")" \
 		--family-base-image $(BUILD_REGISTRY)/$(PROJECT_NAME) \
 		--platform $(BATCH_PLATFORMS) \
 		--provider-name $(PROJECT_NAME) \
@@ -71,7 +73,7 @@ batch-process: $(UP)
 		--package-repo-override monolith=$(PROJECT_NAME) --package-repo-override config=provider-family-$(PROVIDER_NAME) \
 		--provider-bin-root $(OUTPUT_DIR)/bin \
 		--output-dir $(XPKG_OUTPUT_DIR) \
-		--store-packages $(STORE_PACKAGE) \
+		--store-packages "$(STORE_PACKAGES)" \
 		--build-only=$(BUILD_ONLY) \
 		--examples-root $(ROOT_DIR)/examples \
 		--examples-group-override monolith=* --examples-group-override config=providerconfig \
@@ -82,4 +84,4 @@ batch-process: $(UP)
 		--template-var XpkgRegOrg=$(XPKG_REG_ORGS) --template-var DepConstraint="$(DEP_CONSTRAINT)" --template-var ProviderName=$(PROVIDER_NAME) \
 		--concurrency $(CONCURRENCY) \
 		--push-retry 10 || $(FAIL)
-	@$(OK) Done processing smaller provider packages for: $(SUBPACKAGES)
+	@$(OK) Done processing smaller provider packages for: "$(SUBPACKAGES)"


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Depends on: https://github.com/upbound/build/pull/241

Currently when an e2e test is triggered in `upbound/provider-aws`, the test is run with the monolithic provider (`upbound/provider-aws`) package built from the feature branch.

This omits the family resource providers (not a problem from the resource configuration validation perspective because both the monolith and the corresponding resource provider utilize the same resource configuration) but the built family resource package itself is not tested).

Another issue that's the main motion of the proposed changes in this PR is that the number of CRDs installed with the monolithic package cause noise in the tests (pod restarts, timeouts at various levels, etc.). 

This PR proposes to switch to the family resource providers when running uptests in this repo.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested locally by running:
```bash
...
export UPTEST_EXAMPLE_LIST="examples/iam/role.yaml,,examples/iam/user.yaml,,examples/iam/policy.yaml,,examples/ec2/vpc.yaml,"
make e2e
```
Note: Common dependencies in the above example manifest list may cause testing issues unrelated to this PR. cc. @turkenf, who also confirmed similar findings with the dependencies. We've long been discussing a shared catalog of dependencies from which dependencies can be injected into the dependent example manifests with the help of an uptest preprocessor. This is not in the scope of this PR as mentioned.

Also tested with the following uptest runs:
- https://github.com/upbound/provider-aws/actions/runs/6382820488: Single API group (`ec2`)
- https://github.com/upbound/provider-aws/actions/runs/6383043228: Multiple API groups (`ec2`, `iam`), one group per file
- https://github.com/upbound/provider-aws/actions/runs/6383230674: Multiple API groups (`ec2`, `iam`, `sfn`), where a single example manifest file contains the two groups `iam` and `sfn`:
```
...
17:10:35 [ .. ] Building and deploying resource providers for the short API groups: config,ec2,sfn,iam,
...
17:11:19 [ .. ] Batch processing smaller provider packages for: config ec2 sfn iam 
...
17:12:47 [ OK ] deploying provider package provider-aws-config v0.0.0-3.gcc29e5c
...
17:13:02 [ OK ] deploying provider package provider-aws-ec2 v0.0.0-3.gcc29e5c
...
17:13:26 [ OK ] deploying provider package provider-aws-sfn v0.0.0-3.gcc29e5c
...
17:13:43 [ OK ] deploying provider package provider-aws-iam v0.0.0-3.gcc29e5c
...
```

Also verified the metadata of the provider packages produced by:
```bash
make SUBPACKAGES="iam config" BRANCH_NAME=main XPKG_REG_ORGS=index.docker.io/ulucinar build.all publish
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
