### PR TITLE
Add "branch_name", "version" and "regorg" parameters to the "Publish Service Artifacts" workflow

### DIFF
--- a/.github/workflows/publish-service-artifacts.yml
+++ b/.github/workflows/publish-service-artifacts.yml
@@ -15,6 +15,18 @@ on:
         description: "Number of parallel package builds within each build job"
         default: '1'
         required: false
+      regorg:
+        description: 'Package registry and organization where the packages will be pushed or (e.g. xpkg.upbound.io/upbound)'
+        default: 'xpkg.upbound.io/upbound'
+        required: false
+      branch_name:
+        description: "Branch name to use while publishing the packages (e.g. main)"
+        default: ''
+        required: false
+      version:
+        description: "Version string to use while publishing the packages (e.g. v1.0.0-alpha.1)"
+        default: ''
+        required: false
 
 jobs:
   publish-service-artifacts:
@@ -23,6 +35,9 @@ jobs:
       subpackages: ${{ github.event.inputs.subpackages }}
       size: ${{ github.event.inputs.size }}
       concurrency: ${{ github.event.inputs.concurrency }}
+      regorg: ${{ github.event.inputs.regorg }}
+      branch_name: ${{ github.event.inputs.branch_name }}
+      version: ${{ github.event.inputs.version }}
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR_RC }}
       UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW_RC }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR parameterizes the image registry and repo, the branch name and the version used for building and publishing the provider packages so that we can still use the reusable workflow `Provider Publish Service Artifacts` for publishing packages to repositories other than `xpkg.upbound.io/upbound` and with customizable version strings.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Parts of the underlying reusable workflow has been tested in another organization. The calling workflow has not been tested.