### PR TITLE
fix(iam-role): ignore managed_policy_arns in late init

### DIFF
--- a/apis/iam/v1beta1/zz_generated_terraformed.go
+++ b/apis/iam/v1beta1/zz_generated_terraformed.go
@@ -847,6 +847,7 @@ func (tr *Role) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("ManagedPolicyArns"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/iam/config.go
+++ b/config/iam/config.go
@@ -33,6 +33,9 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_iam_role", func(r *config.Resource) {
 		r.MetaResource.ArgumentDocs["inline_policy"] = `Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. See below. If no blocks are configured, Crossplane will not manage any inline policies in this resource. Configuring one empty block (i.e., inline_policy {}) will cause Crossplane to remove all inline policies added out of band on apply.`
 		r.MetaResource.ArgumentDocs["managed_policy_arns"] = `Set of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, Crossplane will ignore policy attachments to this resource. When configured, Crossplane will align the role's managed policy attachments with this set by attaching or detaching managed policies. Configuring an empty set (i.e., managed_policy_arns = []) will cause Crossplane to remove all managed policy attachments.`
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"managed_policy_arns"},
+		}
 	})
 
 	p.AddResourceConfigurator("aws_iam_instance_profile", func(r *config.Resource) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
description is here: https://github.com/upbound/provider-aws/issues/929#issuecomment-1774063901
skip managed_policy_arns for late init
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #929

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manual: https://github.com/upbound/provider-aws/issues/929#issuecomment-1774063901
Uptest: https://github.com/upbound/provider-aws/actions/runs/6611409372
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
