### PR TITLE
Fix MetricFilter.cloudwatchlogs external-name configuration

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -1029,7 +1029,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	//
 	// Cloudwatch Log Groups can be imported using the name
 	"aws_cloudwatch_log_group": config.NameAsIdentifier,
-	// CloudWatch Log Metric Filter can be imported using the log_group_name:name
+	// CloudWatch Log Metric Filter can be imported using its name
 	"aws_cloudwatch_log_metric_filter": config.NameAsIdentifier,
 	// CloudWatch query definitions can be imported using the query definition ARN.
 	"aws_cloudwatch_query_definition": config.IdentifierFromProvider,

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -1030,7 +1030,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// Cloudwatch Log Groups can be imported using the name
 	"aws_cloudwatch_log_group": config.NameAsIdentifier,
 	// CloudWatch Log Metric Filter can be imported using the log_group_name:name
-	"aws_cloudwatch_log_metric_filter": config.TemplatedStringAsIdentifier("name", "{{ .parameters.log_group_name }}:{{ .external_name }}"),
+	"aws_cloudwatch_log_metric_filter": config.NameAsIdentifier,
 	// CloudWatch query definitions can be imported using the query definition ARN.
 	"aws_cloudwatch_query_definition": config.IdentifierFromProvider,
 	// Cloudwatch Log Stream can be imported using the stream's log_group_name and name

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -72,8 +72,8 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// Case4: Imported by using the API identifier, route identifier and route
 	// response identifier.
 	"aws_apigatewayv2_route_response": TemplatedStringAsIdentifierWithNoName("{{ .parameters.api_id }}/{{ .parameters.route_id }}/{{ .external_name }}"),
-	// Imported by using the API identifier and stage name.
-	"aws_apigatewayv2_stage": config.TemplatedStringAsIdentifier("name", "{{ .parameters.api_id }}/{{ .external_name }}"),
+	// Imported by the stage name.
+	"aws_apigatewayv2_stage": config.NameAsIdentifier,
 	// aws_apigatewayv2_vpc_link can be imported by using the VPC Link id
 	"aws_apigatewayv2_vpc_link": config.IdentifierFromProvider,
 

--- a/examples/apigatewayv2/stage.yaml
+++ b/examples/apigatewayv2/stage.yaml
@@ -1,0 +1,30 @@
+apiVersion: apigatewayv2.aws.upbound.io/v1beta1
+kind: Stage
+metadata:
+  name: example
+  annotations:
+    meta.upbound.io/example-id: apigatewayv2/v1beta1/stage
+  labels:
+    upjet.upbound.io/test-group: apigatewayv2-http
+spec:
+  forProvider:
+    region: us-west-1
+    apiIdSelector:
+      matchLabels:
+        upjet.upbound.io/test-group: apigatewayv2-http
+
+---
+
+apiVersion: apigatewayv2.aws.upbound.io/v1beta1
+kind: API
+metadata:
+  name: auth-api
+  annotations:
+    meta.upbound.io/example-id: apigatewayv2/v1beta1/stage
+  labels:
+    upjet.upbound.io/test-group: apigatewayv2-http
+spec:
+  forProvider:
+    region: us-west-1
+    name: test-http-api
+    protocolType: HTTP


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Sets the external-name configuration of the `MetricFilter.cloudwatchlogs` resource to `config.NameAsIdentifier`. Reconciliation of the resource currently fails as follows:
```yaml
- lastTransitionTime: "2023-10-31T15:07:53Z"
    message: 'observe failed: cannot run refresh: refresh failed: reading CloudWatch
      Logs Metric Filter (dada:yada): InvalidParameterException: 1 validation error
      detected: Value ''dada:yada'' at ''filterNamePrefix'' failed to satisfy constraint:
      Member must satisfy regular expression pattern: [^:*]*: '
    reason: ReconcileError
    status: "False"
    type: Synced
```

This PR also adds an example manifest for the `Stage.apigatewayv2` resource. Import tests for this resource are failing as follows:
```yaml
- lastTransitionTime: "2023-10-31T17:07:24Z"
    logger.go:42: 17:09:25 | case/2-import |       message: 'apply failed: creating API Gateway v2 stage: ConflictException: Stage
    logger.go:42: 17:09:25 | case/2-import |         already exists: '
    logger.go:42: 17:09:25 | case/2-import |       reason: ApplyFailure
    logger.go:42: 17:09:25 | case/2-import |       status: "False"
    logger.go:42: 17:09:25 | case/2-import |       type: LastAsyncOperation
```

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Via uptest:
- `MetricFilter.cloudwatchlogs` -> https://github.com/upbound/provider-aws/actions/runs/6709180831
- `Stage.apigatewayv2` -> https://github.com/upbound/provider-aws/actions/runs/6710429121