### PR TITLE
added endpoint and arn to docdb cluster secret

### DIFF
--- a/config/docdb/config.go
+++ b/config/docdb/config.go
@@ -7,6 +7,16 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_docdb_cluster", func(r *config.Resource) {
 		config.MoveToStatus(r.TerraformResource, "cluster_members")
 		r.UseAsync = true
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["endpoint"].(string); ok {
+				conn["endpoint"] = []byte(a)
+			}
+			if a, ok := attr["arn"].(string); ok {
+				conn["arn"] = []byte(a)
+			}
+			return conn, nil
+		}
 	})
 
 	p.AddResourceConfigurator("aws_docdb_cluster_instance", func(r *config.Resource) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Added the Docdb cluster endpoint and arn to the connection details so that the value will appear in the secret created by writeConnectionSecretToRef

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

manually:
```
> kubectl get secrets/my-docdb
NAME       TYPE                                DATA   AGE
my-docdb   connection.crossplane.io/v1alpha1   3      6m1s

> kubectl get secrets/my-docdb --template={{.data.endpoint}} | base64 -D                                                                             
docdb-demo-lnj42.cluster-c3kmasxmrnwp.eu-west-1.docdb.amazonaws.com

> kubectl get secrets/my-docdb --template={{.data.arn}} | base64 -D                                                                           
arn:aws:rds:eu-west-2:<account-id>:cluster:docdb-demo-lnj42
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
