### PR TITLE
add bucket id,arn and regio to writeConnectionSecretToRef

### DIFF
--- a/config/s3/config.go
+++ b/config/s3/config.go
@@ -25,6 +25,19 @@ func Configure(p *config.Provider) {
 		// aws_s3_bucket_server_side_encryption_configuration
 		// aws_s3_bucket_versioning
 		// aws_s3_bucket_website_configuration
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["id"].(string); ok {
+				conn["id"] = []byte(a)
+			}
+			if a, ok := attr["arn"].(string); ok {
+				conn["arn"] = []byte(a)
+			}
+			if a, ok := attr["region"].(string); ok {
+				conn["region"] = []byte(a)
+			}
+			return conn, nil
+		}
 		config.MoveToStatus(r.TerraformResource, "acceleration_status", "acl", "grant", "cors_rule", "lifecycle_rule",
 			"logging", "object_lock_configuration", "policy", "replication_configuration", "request_payer",
 			"server_side_encryption_configuration", "versioning", "website", "arn")


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Added the s3 arn,id and region to the connection details so that the value will appear in the secret created by writeConnectionSecretToRef


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

 #886 
I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with [uptest](https://github.com/upbound/provider-aws/pull/951/checks) and Manually:

```
> kubectl get secrets/test-bucket
NAME          TYPE                                DATA   AGE
test-bucket   connection.crossplane.io/v1alpha1   3      6m31s

> kubectl get secrets/test-bucket --template={{.data.arn}} | base64 -D
arn:aws:s3:::demo-bucket-e34cs

> kubectl get secrets/test-bucket --template={{.data.id}} | base64 -D
demo-bucket-e34cs

> kubectl get secrets/test-bucket --template={{.data.region}} | base64 -D
us-east-1
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
