### PR TITLE
fix: allow using custom AMI

### DIFF
--- a/apis/eks/v1beta1/zz_generated_terraformed.go
+++ b/apis/eks/v1beta1/zz_generated_terraformed.go
@@ -578,6 +578,7 @@ func (tr *NodeGroup) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("ReleaseVersion"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/eks/config.go
+++ b/config/eks/config.go
@@ -50,6 +50,11 @@ func Configure(p *config.Provider) {
 			RefFieldName:      "SubnetIDRefs",
 			SelectorFieldName: "SubnetIDSelector",
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{
+				"release_version",
+			},
+		}
 		r.UseAsync = true
 		r.MetaResource.ArgumentDocs["launch_template.version"] = `- (Required) EC2 Launch Template version number. While the API accepts values like $Default and $Latest, the API will convert the value to the associated version number (e.g., 1). Using the default_version or latest_version attribute of the aws_launch_template resource or data source is recommended for this argument.`
 		r.MetaResource.ArgumentDocs["subnet_ids"] = `- Identifiers of EC2 Subnets to associate with the EKS Node Group. Amazon EKS managed node groups can be launched in both public and private subnets. If you plan to deploy load balancers to a subnet, the private subnet must have tag kubernetes.io/role/internal-elb, the public subnet must have tag kubernetes.io/role/elb.`


### PR DESCRIPTION
## Description of your changes

I want to address the issue described in #976:
ReleaseVersion must not be synced back into the `Kind=NodeGroup` resource,
this is a invalid configuration when using a custom AMI. AWS Error:
```
InvalidParameterException: You cannot specify the field releaseVersion when using custom AMIs.
```

Fixes #976

I have:

- [x] ~~Run `make reviewable test` to ensure this PR is ready for review.~~ My CPU us not able to handle the load, system freezes :cold_face: 

### How has this code been tested

Built a image off my PR and deployed it into a cluster.
I was able to successfully create a EKS NodeGroup with a custom AMI. I also was able to update it a couple of times. This previously failed with the error mentioned in #976.