### PR TITLE
Fix external name configuration of TransitGatewayVPCAttachmentAccepter resource

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -166,7 +166,7 @@ var NoForkExternalNameConfigs = map[string]config.ExternalName{
 	// tgw-attach-12345678
 	"aws_ec2_transit_gateway_vpc_attachment": config.IdentifierFromProvider,
 	// Imported by using the EC2 Transit Gateway Attachment identifier: tgw-attach-12345678
-	"aws_ec2_transit_gateway_vpc_attachment_accepter": FormattedIdentifierFromProvider("", "transit_gateway_attachment_id"),
+	"aws_ec2_transit_gateway_vpc_attachment_accepter": config.IdentifierFromProvider,
 	// Imported using the id: lt-12345678
 	"aws_launch_template": config.IdentifierFromProvider,
 	// Launch configurations can be imported using the name

--- a/examples/ec2/transitgatewayvpcattachmentaccepter.yaml
+++ b/examples/ec2/transitgatewayvpcattachmentaccepter.yaml
@@ -1,6 +1,8 @@
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: TransitGatewayVPCAttachmentAccepter
 metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/transitgatewayvpcattachmentaccepter
   labels:
     testing.upbound.io/example-name: example
   name: example

--- a/examples/ec2/transitgatewayvpcattachmentaccepter.yaml
+++ b/examples/ec2/transitgatewayvpcattachmentaccepter.yaml
@@ -12,3 +12,48 @@ spec:
     transitGatewayAttachmentIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: TransitGatewayVPCAttachment
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    region: us-west-1
+    subnetIdRefs:
+      - name: sample-subnet1
+    transitGatewayId: tgw-07a4690db599a7263
+    vpcIdRef:
+      name: sample-vpc
+  providerConfigRef:
+    name: peer
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  name: sample-vpc
+spec:
+  forProvider:
+    region: us-west-1
+    cidrBlock: 172.16.0.0/16
+    tags:
+      Name: DemoVpc
+  providerConfigRef:
+    name: peer
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Subnet
+metadata:
+  name: sample-subnet1
+spec:
+  forProvider:
+    region: us-west-1
+    availabilityZone: us-west-1a
+    vpcIdRef:
+      name: sample-vpc
+    cidrBlock: 172.16.10.0/24
+  providerConfigRef:
+    name: peer
+


### PR DESCRIPTION
### Description of your changes

Fix external name configuration of TransitGatewayVPCAttachmentAccepter resource

Fixes #816 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally. The issue was reproduced by following the steps in the description of #816. Then after applying the proposed fix in this PR, the issue was resolved.

Uptest: https://github.com/upbound/provider-aws/actions/runs/6980792906