### PR TITLE
add support for endpoint configuration of no-fork external client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.18.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.12
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3
 	github.com/aws/aws-sdk-go-v2/service/eks v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.11
 	github.com/aws/smithy-go v1.13.5
@@ -39,7 +40,6 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.261 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.29 // indirect

--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -6,10 +6,11 @@ package clients
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"os"
 	"reflect"
 	"unsafe"
+
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 
 	tfawsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -6,6 +6,7 @@ package clients
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"os"
 	"reflect"
 	"unsafe"
@@ -254,9 +255,11 @@ func getAWSConfig(ctx context.Context, c client.Client, mg resource.Managed) (*a
 }
 
 func configureNoForkAWSClient(ctx context.Context, c client.Client, mg resource.Managed, pc *v1beta1.ProviderConfig, ps *terraform.Setup) (xpprovider.AWSConfig, error) { //nolint:gocyclo
-	if len(pc.Spec.AssumeRoleChain) > 1 || pc.Spec.Endpoint != nil {
+	// Terraform AWS provider does not support role chaining via provider configuration
+	// https://github.com/hashicorp/terraform-provider-aws/issues/22728
+	if len(pc.Spec.AssumeRoleChain) > 1 {
 		return xpprovider.AWSConfig{}, errors.New("cannot configure no-fork client because the length of assume role chain array " +
-			"is more than 1 or endpoint configuration is not nil")
+			"is more than 1")
 	}
 
 	cfg, err := getAWSConfig(ctx, c, mg)
@@ -336,5 +339,35 @@ func configureNoForkAWSClient(ctx context.Context, c client.Client, mg resource.
 
 		awsConfig.AssumeRole.Tags = tags
 	}
+
+	if pc.Spec.Endpoint != nil {
+		if pc.Spec.Endpoint.URL.Static != nil {
+			if len(pc.Spec.Endpoint.Services) > 0 && *pc.Spec.Endpoint.URL.Static == "" {
+				return xpprovider.AWSConfig{}, errors.New("endpoint URL cannot be empty")
+			} else {
+				awsConfig.Endpoints = make(map[string]string)
+				for _, service := range pc.Spec.Endpoint.Services {
+					awsConfig.Endpoints[service] = aws.ToString(pc.Spec.Endpoint.URL.Static)
+				}
+			}
+		} else if pc.Spec.Endpoint.URL.Dynamic != nil && cfg.EndpointResolverWithOptions != nil {
+			for _, service := range pc.Spec.Endpoint.Services {
+				svcEndpoint, err := cfg.EndpointResolverWithOptions.ResolveEndpoint(service, cfg.Region, nil)
+				if err != nil {
+					return xpprovider.AWSConfig{}, errors.Wrapf(err, "cannot resolve dynamic endpoint URL for AWS service: %s", service)
+				}
+				awsConfig.Endpoints[service] = svcEndpoint.URL
+			}
+		}
+	}
+
+	awsConfig.SkipCredsValidation = pc.Spec.SkipCredsValidation
+	awsConfig.S3UsePathStyle = pc.Spec.S3UsePathStyle
+	awsConfig.SkipRegionValidation = pc.Spec.SkipRegionValidation
+	if pc.Spec.SkipMetadataApiCheck {
+		awsConfig.EC2MetadataServiceEnableState = imds.ClientDisabled
+	}
+	awsConfig.SkipRequestingAccountId = pc.Spec.SkipReqAccountId
+
 	return awsConfig, nil
 }


### PR DESCRIPTION


### Description of your changes
Adds support for custom endpoint configuration of new architecture external clients. Before this change, custom endpoint configurations were rejected, due to similar implementation with old architecture. However, this limitation is no longer valid for new provider architecture.

Fixes #971 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.
