### PR TITLE
Kinesisanalytics typo fix

### DIFF
--- a/config/kinesisanalyticsv2/config.go
+++ b/config/kinesisanalyticsv2/config.go
@@ -1,4 +1,4 @@
-package kinesisanalytics2
+package kinesisanalyticsv2
 
 import (
 	"github.com/crossplane/upjet/pkg/config"
@@ -6,7 +6,7 @@ import (
 	"github.com/upbound/provider-aws/config/common"
 )
 
-// Configure adds configurations for the kinesisanalytics2 group.
+// Configure adds configurations for the kinesisanalyticsv2 group.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_kinesisanalyticsv2_application", func(r *config.Resource) {
 		r.References["application_configuration.application_code_configuration.code_content.s3_content_location.bucket_arn"] = config.Reference{

--- a/config/provider.go
+++ b/config/provider.go
@@ -65,7 +65,7 @@ import (
 	"github.com/upbound/provider-aws/config/kendra"
 	"github.com/upbound/provider-aws/config/kinesis"
 	"github.com/upbound/provider-aws/config/kinesisanalytics"
-	kinesisanalytics2 "github.com/upbound/provider-aws/config/kinesisanalyticsv2"
+	"github.com/upbound/provider-aws/config/kinesisanalyticsv2"
 	"github.com/upbound/provider-aws/config/kms"
 	"github.com/upbound/provider-aws/config/lakeformation"
 	"github.com/upbound/provider-aws/config/lambda"
@@ -235,7 +235,7 @@ func GetProvider(ctx context.Context, generationProvider bool) (*config.Provider
 		kafka.Configure,
 		kinesis.Configure,
 		kinesisanalytics.Configure,
-		kinesisanalytics2.Configure,
+		kinesisanalyticsv2.Configure,
 		kms.Configure,
 		lakeformation.Configure,
 		lambda.Configure,


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I noticed that for some reason the kinesisanalyticsv2 package was named without the v, unlike all other packages. This seemed unnecessary, so I brought it in line with all the others. 

There was no change to any of the generated code.

- [ ] Run `make check-diff test` to validate that there's no diff in generated code and run unit tests. Linting is currently broken.

### How has this code been tested

If the maintainers agree with me that this is a non-breaking change, I'll run the e2e tests for the kinesisanalyticsv2 resources locally, since they require specific files uploaded to s3.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
