### PR TITLE
(bugfix) Fix cognito user pool client orphaned resources

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2677,7 +2677,8 @@ var CLIReconciledExternalNameConfigs = map[string]config.ExternalName{
 // which introduces the concept of a null value as distinct from a zero value.
 func cognitoUserPoolClient() config.ExternalName {
 	e := config.IdentifierFromProvider
-	e.IdentifierFields = []string{"user_pool_id"}
+	// TODO: Uncomment when it's acceptable to remove fields from spec.initProvider (major release)
+	//e.IdentifierFields = []string{"user_pool_id"}
 	e.GetIDFn = func(ctx context.Context, externalName string, parameters map[string]interface{}, cfg map[string]interface{}) (string, error) {
 		if externalName == "" {
 			return "invalidnonemptystring", nil

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2659,12 +2659,35 @@ var CLIReconciledExternalNameConfigs = map[string]config.ExternalName{
 	"aws_vpc_security_group_egress_rule": vpcSecurityGroupRule(),
 	// Imported by using the id: sgr-02108b27edd666983
 	"aws_vpc_security_group_ingress_rule": vpcSecurityGroupRule(),
-	// us-west-2_abc123/3ho4ek12345678909nh3fmhpko
-	"aws_cognito_user_pool_client": FormattedIdentifierFromProvider("", "name"),
+	// Cognito User Pool clients can be imported using the user pool id and client id separated by a slash (/)
+	// However, the terraform id is just the client id.
+	"aws_cognito_user_pool_client": cognitoUserPoolClient(),
 	// simpledb
 	//
 	// SimpleDB Domains can be imported using the name
 	"aws_simpledb_domain": config.NameAsIdentifier,
+}
+
+// cognitoUserPoolClient
+// Note(mbbush) This resource has some unexpected behaviors that make it impossible to write a completely correct
+// ExternalName config. Specifically, the terraform id returned in the terraform state is not the same as the
+// identifier used to import it. Additionally, if the terraform id set to an empty string, the terraform
+// provider passes the empty string through to the aws query during refresh, which returns an api error.
+// This could be related to the fact that this resource is implemented using the terraform plugin framework,
+// which introduces the concept of a null value as distinct from a zero value.
+func cognitoUserPoolClient() config.ExternalName {
+	e := config.IdentifierFromProvider
+	e.IdentifierFields = []string{"user_pool_id"}
+	e.GetIDFn = func(ctx context.Context, externalName string, parameters map[string]interface{}, cfg map[string]interface{}) (string, error) {
+		if externalName == "" {
+			return "invalidnonemptystring", nil
+		}
+		// Ideally, we'd return parameters.user_pool_id/external_name if this is invoked during a call to terraform import,
+		// and the externalName if this is invoked during a call to terraform refresh. But I don't know how to distinguish
+		// between them inside this function.
+		return externalName, nil
+	}
+	return e
 }
 
 func lambdaFunctionURL() config.ExternalName {

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2678,7 +2678,7 @@ var CLIReconciledExternalNameConfigs = map[string]config.ExternalName{
 func cognitoUserPoolClient() config.ExternalName {
 	e := config.IdentifierFromProvider
 	// TODO: Uncomment when it's acceptable to remove fields from spec.initProvider (major release)
-	//e.IdentifierFields = []string{"user_pool_id"}
+	// e.IdentifierFields = []string{"user_pool_id"}
 	e.GetIDFn = func(ctx context.Context, externalName string, parameters map[string]interface{}, cfg map[string]interface{}) (string, error) {
 		if externalName == "" {
 			return "invalidnonemptystring", nil

--- a/examples/cognitoidp/userpoolclient-with-dashes.yaml
+++ b/examples/cognitoidp/userpoolclient-with-dashes.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPool
+metadata:
+  annotations:
+    uptest.upbound.io/timeout: "900"
+  labels:
+    testing.upbound.io/example-name: example-with-dashes
+  name: example-with-dashes
+spec:
+  forProvider:
+    name: example
+    region: us-west-1
+
+---
+
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPoolClient
+metadata:
+  annotations:
+    uptest.upbound.io/timeout: "900"
+  labels:
+    testing.upbound.io/example-name: example-with-dashes
+  name: example-with-dashes
+spec:
+  forProvider:
+    name: name-that-doesnt-match-id-regex
+    region: us-west-1
+    userPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-with-dashes
+

--- a/examples/cognitoidp/userpoolclient.yaml
+++ b/examples/cognitoidp/userpoolclient.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPool
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    name: example
+    region: us-west-1
+
+---
+
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPoolClient
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    name: example
+    region: us-west-1
+    userPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+

--- a/examples/cognitoidp/userpooluicustomization.yaml
+++ b/examples/cognitoidp/userpooluicustomization.yaml
@@ -56,7 +56,7 @@ metadata:
   name: main
 spec:
   forProvider:
-    domain: example-domain
+    domain: ${Rand.RFC1123Subdomain}
     region: us-west-1
     userPoolIdSelector:
       matchLabels:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The cognito idp user pool client is one of the handful of resources in terraform-provider-aws v4.67.0 that use the terraform plugin framework, and therefore that we still reconcile by forking a CLI terraform process. 

There are three problems with the cognito user pool client:
1. Creation fails if the `spec.forProvider.name` doesn't match the regex for the `clientId`
2. Whenever the provider pod restarts, crossplane will either create a duplicate resource, orphaning the existing one, or get into a Synced: False state, depending on whether `spec.forProvider.name` matches the `clientId` regex. 
3. Observe-only resources fail, because `terraform import` expects an argument that is not the same as the terraform id. 

This PR fixes the first two issues, and makes the third issue no worse. 

### Context

This resource has two idiosyncrasies that make it difficult. 

1. Calling `terraform apply -refresh-only` with an id of `""` returns an error, because the terraform provider passes through the empty-string id to the aws sdk, which (correctly) complains that trying to find a user pool client with id `""` is invalid. I suspect this is *because* the resource uses the terraform plugin framework, which introduced the concept of a null value as distinct from a zero value. I suspect that if we had some way to specify a null value for the id, it would work fine, but the type in upjet is `string` not `*string` so I don't see how to do that without major changes. Maybe the upjet developers will need to add a transformation layer from zero values back to null when integrating with the terraform provider framework, or perhaps they'll come up with a better idea. 

2. The argument needed to `terraform import` the resource is different than the terraform id, but the terraform id is needed to run `terraform apply -refresh-only`. The provider uses `terraform import` for resources with management policy `Observe` and `terraform apply -refresh-only` for other management policies. Unless someone has a clever way to identify which case we're in, in the context of an external name configuration, we can only support one of these use cases.

#762 was an attempt to work around the `"id":""` issue, but it introduced new problems.

My solution for the first issue is to simply use a static client id of "invalidnonemptystring", which satisfies the client id regex `[\w+]+`, so doesn't cause an error when we run `terraform apply -refresh-only`, but also doesn't match any actual existing client id (the aws-generated ids that I've seen are all 26 lowercase alphanumeric characters long). This feels like getting the right result by doing the wrong thing, but I can't think of any actual problems it would cause, nor can I come up with a better idea. 

For the second issue, I've chosen to write an external name config that supports assuming full control of existing resources, and does not support observing existing resources only, as that seems like the lesser of two evils (especially since it's necessary for recovering from a provider pod crash restart). It also has the advantage of keeping the terraform id set to the value of the terraform id (except when we don't have an id, so set it to `"invalidnonemptystring"` to get the necessary NotFound response). 

Ultimately I hope that when we reconcile this through the terraform plugin framework, we'll be able to ignore the format expected by `terraform import` and just use the id and user pool id parameters. It looks like that's exactly the implementation used in the `Read` method on the terraform provider. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #828 
Fixes #807 
Fixes #1049 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Uptest passes. It did not pass on `main` with the previous config, because the import step resulted in creating a second user pool client. 

Creating an observe-only resource fails. This is not a regression, as it fails in the same way with the current version of the provider, and I don't believe it is fixable without breaking other, more important functionality.

The external name format is remaining the same: the alphanumeric client id. 

When I ran uptest locally for the existing `examples/cognitoidp/userpooluicustomization.yaml`, I got an error about the domain already being registered, so I updated the example to use a random domain name and now it passes consistently. 