### PR TITLE
Reconcile aws_appconfig_environment using the TF SDK-based external client

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -1767,6 +1767,9 @@ var NoForkExternalNameConfigs = map[string]config.ExternalName{
 	// AppConfig Extension Associations can be imported using their extension association ID
 	// ID is a provider-generated
 	"aws_appconfig_extension_association": config.IdentifierFromProvider,
+	// AppConfig Environments can be imported by using the environment ID and application ID separated by a colon (:)
+	// terraform-plugin-framework
+	"aws_appconfig_environment": config.IdentifierFromProvider,
 
 	// appintegrations
 	//
@@ -2654,9 +2657,6 @@ var CLIReconciledExternalNameConfigs = map[string]config.ExternalName{
 	"aws_vpc_security_group_egress_rule": vpcSecurityGroupRule(),
 	// Imported by using the id: sgr-02108b27edd666983
 	"aws_vpc_security_group_ingress_rule": vpcSecurityGroupRule(),
-	// AppConfig Environments can be imported by using the environment ID and application ID separated by a colon (:)
-	// terraform-plugin-framework
-	"aws_appconfig_environment": config.IdentifierFromProvider,
 	// us-west-2_abc123/3ho4ek12345678909nh3fmhpko
 	"aws_cognito_user_pool_client": FormattedIdentifierFromProvider("", "name"),
 	// simpledb

--- a/internal/controller/appconfig/environment/zz_controller.go
+++ b/internal/controller/appconfig/environment/zz_controller.go
@@ -20,7 +20,7 @@ import (
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	tjcontroller "github.com/crossplane/upjet/pkg/controller"
 	"github.com/crossplane/upjet/pkg/controller/handler"
-	"github.com/crossplane/upjet/pkg/terraform"
+	"github.com/crossplane/upjet/pkg/metrics"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	v1beta1 "github.com/upbound/provider-aws/apis/appconfig/v1beta1"
@@ -39,14 +39,18 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))
 	}
 	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", v1beta1.Environment_GroupVersionKind)))
-	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta1.Environment_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler))
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta1.Environment_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))
 	opts := []managed.ReconcilerOption{
-		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["aws_appconfig_environment"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(eventHandler),
-			tjcontroller.WithCallbackProvider(ac),
-		)),
+		managed.WithExternalConnecter(
+			tjcontroller.NewNoForkAsyncConnector(mgr.GetClient(), o.OperationTrackerStore, o.SetupFn, o.Provider.Resources["aws_appconfig_environment"],
+				tjcontroller.WithNoForkAsyncLogger(o.Logger),
+				tjcontroller.WithNoForkAsyncConnectorEventHandler(eventHandler),
+				tjcontroller.WithNoForkAsyncCallbackProvider(ac),
+				tjcontroller.WithNoForkAsyncMetricRecorder(metrics.NewMetricRecorder(v1beta1.Environment_GroupVersionKind, mgr, o.PollInterval)),
+				tjcontroller.WithNoForkAsyncManagementPolicies(o.Features.Enabled(features.EnableBetaManagementPolicies)))),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
-		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(o.WorkspaceStore, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
+		managed.WithFinalizer(tjcontroller.NewNoForkFinalizer(o.OperationTrackerStore, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3 * time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
`aws_appconfig_environment` is a [terraform-plugin-sdk](https://github.com/hashicorp/terraform-plugin-sdk) resource which we are currently reconciling using the CLI-based reconciler. This PR changes its external client to [`controller.noForkAsyncExternal`](https://github.com/crossplane/upjet/blob/807fb9dd9553ae41106c8c083d374af8c98ee45a/pkg/controller/external_async_nofork.go#L99) so that it's reconciled under the new architecture.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Via uptest: https://github.com/upbound/provider-aws/actions/runs/7291718665