### PR TITLE
Demonstrate broken cognito user pool client

### DIFF
--- a/examples/cognitoidp/userpoolclient-observe.yaml
+++ b/examples/cognitoidp/userpoolclient-observe.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPool
+metadata:
+  annotations:
+    uptest.upbound.io/timeout: "900"
+  labels:
+    testing.upbound.io/example-name: observe
+  name: observe
+spec:
+  forProvider:
+    name: example
+    region: us-west-1
+
+---
+
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPoolClient
+metadata:
+  annotations:
+    uptest.upbound.io/timeout: "900"
+    crossplane.io/external-name: anything
+  labels:
+    testing.upbound.io/example-name: observe
+  name: observe
+spec:
+  managementPolicies:
+    - Observe
+  forProvider:
+    name: name
+    region: us-west-1
+    userPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: observe
+

--- a/examples/cognitoidp/userpoolclient-with-dashes.yaml
+++ b/examples/cognitoidp/userpoolclient-with-dashes.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPool
+metadata:
+  annotations:
+    uptest.upbound.io/timeout: "900"
+  labels:
+    testing.upbound.io/example-name: example-with-dashes
+  name: example-with-dashes
+spec:
+  forProvider:
+    name: example
+    region: us-west-1
+
+---
+
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPoolClient
+metadata:
+  annotations:
+    uptest.upbound.io/timeout: "900"
+  labels:
+    testing.upbound.io/example-name: example-with-dashes
+  name: example-with-dashes
+spec:
+  forProvider:
+    name: name-that-doesnt-match-id-regex
+    region: us-west-1
+    userPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-with-dashes
+

--- a/examples/cognitoidp/userpoolclient.yaml
+++ b/examples/cognitoidp/userpoolclient.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPool
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    name: example
+    region: us-west-1
+
+---
+
+apiVersion: cognitoidp.aws.upbound.io/v1beta1
+kind: UserPoolClient
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    name: example
+    region: us-west-1
+    userPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+

--- a/examples/cognitoidp/userpooluicustomization.yaml
+++ b/examples/cognitoidp/userpooluicustomization.yaml
@@ -56,7 +56,7 @@ metadata:
   name: main
 spec:
   forProvider:
-    domain: example-domain
+    domain: ${Rand.RFC1123Subdomain}
     region: us-west-1
     userPoolIdSelector:
       matchLabels:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This is not intended to be merged, but just to demonstrate the current broken behavior which is fixed in #1021 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

There are currently three problems with the external name config of the cognito user pool client, which make it extremely difficult, if not impossible, to use this managed resource.

These snippets all come from the uptest logs on this PR.

1. If you choose a `spec.forProvider.name` that doesn't match the regex AWS expects for the user pool client id (which is `[\w+]+`), then you can't even create the resource, because you get a validation error from the workaround added in #762. 

```
 - apiVersion: cognitoidp.aws.upbound.io/v1beta1
   kind: UserPoolClient
   metadata:
     annotations:
       upjet.upbound.io/test: "true"
       uptest.upbound.io/timeout: "900"
     creationTimestamp: "2023-12-30T00:15:23Z"
     generation: 2
     labels:
       testing.upbound.io/example-name: example-with-dashes
     name: example-with-dashes
     resourceVersion: "1059"
     uid: eb790400-a467-402f-be88-df62d1237479
   spec:
     deletionPolicy: Delete
     forProvider:
       name: name-that-doesnt-match-id-regex
       region: us-west-1
       userPoolId: us-west-1_bxeePoTeV
       userPoolIdRef:
         name: example-with-dashes
       userPoolIdSelector:
         matchLabels:
           testing.upbound.io/example-name: example-with-dashes
     managementPolicies:
     - '*'
     providerConfigRef:
       name: default
   status:
     atProvider: {}
     conditions:
     - lastTransitionTime: "2023-12-30T00:15:30Z"
       message: 'observe failed: cannot run refresh: refresh failed: reading Amazon
         Cognito IDP (Identity Provider) User Pool Client (name-that-doesnt-match-id-regex):
         InvalidParameterException: 1 validation error detected: Value ''name-that-doesnt-match-id-regex''
         at ''clientId'' failed to satisfy constraint: Member must satisfy regular
         expression pattern: [\w+]+'
       reason: ReconcileError
       status: "False"
       type: Synced
```
2. If the `status.conditions` information is lost, as is done deliberately in the uptest import step to simulate a provider pod restart, the managed resource creates an entirely new resource in AWS, orphaning the original resource. I've seen this behavior in my own AWS account, where I can see both user pool clients in the aws console, and the uptest logs show it happening here (the `old-id` annotation is set to the value of the id returned in the original `apply` step.)
```
2023-12-29T23:15:14.0755917Z     logger.go:42: 23:15:14 | case/2-import | - apiVersion: cognitoidp.aws.upbound.io/v1beta1
2023-12-29T23:15:14.0756802Z     logger.go:42: 23:15:14 | case/2-import |   kind: UserPoolClient
2023-12-29T23:15:14.0757513Z     logger.go:42: 23:15:14 | case/2-import |   metadata:
2023-12-29T23:15:14.0758206Z     logger.go:42: 23:15:14 | case/2-import |     annotations:
2023-12-29T23:15:14.0759200Z     logger.go:42: 23:15:14 | case/2-import |       crossplane.io/external-create-pending: "2023-12-29T23:14:46Z"
2023-12-29T23:15:14.0760409Z     logger.go:42: 23:15:14 | case/2-import |       crossplane.io/external-create-succeeded: "2023-12-29T23:14:46Z"
2023-12-29T23:15:14.0761623Z     logger.go:42: 23:15:14 | case/2-import |       crossplane.io/external-name: 44d13ks1tqdupfioc7usjoi8ao
2023-12-29T23:15:14.0763206Z     logger.go:42: 23:15:14 | case/2-import |       upjet.crossplane.io/provider-meta: ""
2023-12-29T23:15:14.0764691Z     logger.go:42: 23:15:14 | case/2-import |       upjet.upbound.io/test: "true"
2023-12-29T23:15:14.0766468Z     logger.go:42: 23:15:14 | case/2-import |       uptest-old-id: 44d13ks1tqdupfioc7usjoi8ao
2023-12-29T23:15:14.0768340Z     logger.go:42: 23:15:14 | case/2-import |     creationTimestamp: "2023-12-29T23:14:39Z"
2023-12-29T23:15:14.0769842Z     logger.go:42: 23:15:14 | case/2-import |     finalizers:
2023-12-29T23:15:14.0771443Z     logger.go:42: 23:15:14 | case/2-import |     - finalizer.managedresource.crossplane.io
2023-12-29T23:15:14.0772978Z     logger.go:42: 23:15:14 | case/2-import |     generation: 4
2023-12-29T23:15:14.0774290Z     logger.go:42: 23:15:14 | case/2-import |     labels:
2023-12-29T23:15:14.0775585Z     logger.go:42: 23:15:14 | case/2-import |       testing.upbound.io/example-name: example
2023-12-29T23:15:14.0776456Z     logger.go:42: 23:15:14 | case/2-import |     name: example
2023-12-29T23:15:14.0777244Z     logger.go:42: 23:15:14 | case/2-import |     resourceVersion: "1074"
2023-12-29T23:15:14.0778534Z     logger.go:42: 23:15:14 | case/2-import |     uid: ef566213-9990-48ae-b947-7b5c02666115
2023-12-29T23:15:14.0779578Z     logger.go:42: 23:15:14 | case/2-import |   spec:
2023-12-29T23:15:14.0780897Z     logger.go:42: 23:15:14 | case/2-import |     deletionPolicy: Delete
2023-12-29T23:15:14.0782275Z     logger.go:42: 23:15:14 | case/2-import |     forProvider:
2023-12-29T23:15:14.0783665Z     logger.go:42: 23:15:14 | case/2-import |       authSessionValidity: 3
2023-12-29T23:15:14.0785174Z     logger.go:42: 23:15:14 | case/2-import |       enableTokenRevocation: true
2023-12-29T23:15:14.0786556Z     logger.go:42: 23:15:14 | case/2-import |       name: example
2023-12-29T23:15:14.0787962Z     logger.go:42: 23:15:14 | case/2-import |       refreshTokenValidity: 30
2023-12-29T23:15:14.0789728Z     logger.go:42: 23:15:14 | case/2-import |       region: us-west-1
2023-12-29T23:15:14.0791294Z     logger.go:42: 23:15:14 | case/2-import |       userPoolId: us-west-1_dNZY4RC9q
2023-12-29T23:15:14.0792790Z     logger.go:42: 23:15:14 | case/2-import |       userPoolIdRef:
2023-12-29T23:15:14.0794155Z     logger.go:42: 23:15:14 | case/2-import |         name: example
2023-12-29T23:15:14.0795569Z     logger.go:42: 23:15:14 | case/2-import |       userPoolIdSelector:
2023-12-29T23:15:14.0796964Z     logger.go:42: 23:15:14 | case/2-import |         matchLabels:
2023-12-29T23:15:14.0798585Z     logger.go:42: 23:15:14 | case/2-import |           testing.upbound.io/example-name: example
2023-12-29T23:15:14.0800157Z     logger.go:42: 23:15:14 | case/2-import |     initProvider: {}
2023-12-29T23:15:14.0801523Z     logger.go:42: 23:15:14 | case/2-import |     managementPolicies:
2023-12-29T23:15:14.0802799Z     logger.go:42: 23:15:14 | case/2-import |     - '*'
2023-12-29T23:15:14.0804100Z     logger.go:42: 23:15:14 | case/2-import |     providerConfigRef:
2023-12-29T23:15:14.0805467Z     logger.go:42: 23:15:14 | case/2-import |       name: default
2023-12-29T23:15:14.0806705Z     logger.go:42: 23:15:14 | case/2-import |   status:
2023-12-29T23:15:14.0807923Z     logger.go:42: 23:15:14 | case/2-import |     atProvider:
2023-12-29T23:15:14.0809326Z     logger.go:42: 23:15:14 | case/2-import |       accessTokenValidity: 0
2023-12-29T23:15:14.0811050Z     logger.go:42: 23:15:14 | case/2-import |       allowedOauthFlowsUserPoolClient: false
2023-12-29T23:15:14.0812716Z     logger.go:42: 23:15:14 | case/2-import |       authSessionValidity: 3
2023-12-29T23:15:14.0814226Z     logger.go:42: 23:15:14 | case/2-import |       defaultRedirectUri: ""
2023-12-29T23:15:14.0816017Z     logger.go:42: 23:15:14 | case/2-import |       enablePropagateAdditionalUserContextData: false
2023-12-29T23:15:14.0818002Z     logger.go:42: 23:15:14 | case/2-import |       enableTokenRevocation: true
2023-12-29T23:15:14.0819679Z     logger.go:42: 23:15:14 | case/2-import |       id: 44d13ks1tqdupfioc7usjoi8ao
2023-12-29T23:15:14.0821543Z     logger.go:42: 23:15:14 | case/2-import |       idTokenValidity: 0
2023-12-29T23:15:14.0822939Z     logger.go:42: 23:15:14 | case/2-import |       name: example
2023-12-29T23:15:14.0824475Z     logger.go:42: 23:15:14 | case/2-import |       preventUserExistenceErrors: ""
2023-12-29T23:15:14.0826040Z     logger.go:42: 23:15:14 | case/2-import |       refreshTokenValidity: 30
2023-12-29T23:15:14.0827650Z     logger.go:42: 23:15:14 | case/2-import |       userPoolId: us-west-1_dNZY4RC9q
2023-12-29T23:15:14.0829118Z     logger.go:42: 23:15:14 | case/2-import |     conditions: []
```
```
2023-12-29T23:15:25.5836234Z     logger.go:42: 23:15:25 | case/2-import | - apiVersion: cognitoidp.aws.upbound.io/v1beta1
2023-12-29T23:15:25.5837116Z     logger.go:42: 23:15:25 | case/2-import |   kind: UserPoolClient
2023-12-29T23:15:25.5837815Z     logger.go:42: 23:15:25 | case/2-import |   metadata:
2023-12-29T23:15:25.5838500Z     logger.go:42: 23:15:25 | case/2-import |     annotations:
2023-12-29T23:15:25.5839490Z     logger.go:42: 23:15:25 | case/2-import |       crossplane.io/external-create-pending: "2023-12-29T23:15:24Z"
2023-12-29T23:15:25.5840686Z     logger.go:42: 23:15:25 | case/2-import |       crossplane.io/external-create-succeeded: "2023-12-29T23:15:24Z"
2023-12-29T23:15:25.5841835Z     logger.go:42: 23:15:25 | case/2-import |       crossplane.io/external-name: 44d13ks1tqdupfioc7usjoi8ao
2023-12-29T23:15:25.5842865Z     logger.go:42: 23:15:25 | case/2-import |       upjet.crossplane.io/provider-meta: ""
2023-12-29T23:15:25.5843785Z     logger.go:42: 23:15:25 | case/2-import |       upjet.upbound.io/test: "true"
2023-12-29T23:15:25.5844929Z     logger.go:42: 23:15:25 | case/2-import |       uptest-old-id: 44d13ks1tqdupfioc7usjoi8ao
2023-12-29T23:15:25.5845921Z     logger.go:42: 23:15:25 | case/2-import |     creationTimestamp: "2023-12-29T23:14:39Z"
2023-12-29T23:15:25.5846740Z     logger.go:42: 23:15:25 | case/2-import |     finalizers:
2023-12-29T23:15:25.5847610Z     logger.go:42: 23:15:25 | case/2-import |     - finalizer.managedresource.crossplane.io
2023-12-29T23:15:25.5848441Z     logger.go:42: 23:15:25 | case/2-import |     generation: 4
2023-12-29T23:15:25.5849121Z     logger.go:42: 23:15:25 | case/2-import |     labels:
2023-12-29T23:15:25.5849958Z     logger.go:42: 23:15:25 | case/2-import |       testing.upbound.io/example-name: example
2023-12-29T23:15:25.5850789Z     logger.go:42: 23:15:25 | case/2-import |     name: example
2023-12-29T23:15:25.5851560Z     logger.go:42: 23:15:25 | case/2-import |     resourceVersion: "1250"
2023-12-29T23:15:25.5852468Z     logger.go:42: 23:15:25 | case/2-import |     uid: ef566213-9990-48ae-b947-7b5c02666115
2023-12-29T23:15:25.5853242Z     logger.go:42: 23:15:25 | case/2-import |   spec:
2023-12-29T23:15:25.5853974Z     logger.go:42: 23:15:25 | case/2-import |     deletionPolicy: Delete
2023-12-29T23:15:25.5854723Z     logger.go:42: 23:15:25 | case/2-import |     forProvider:
2023-12-29T23:15:25.5855648Z     logger.go:42: 23:15:25 | case/2-import |       authSessionValidity: 3
2023-12-29T23:15:25.5856649Z     logger.go:42: 23:15:25 | case/2-import |       enableTokenRevocation: true
2023-12-29T23:15:25.5858269Z     logger.go:42: 23:15:25 | case/2-import |       name: example
2023-12-29T23:15:25.5859632Z     logger.go:42: 23:15:25 | case/2-import |       refreshTokenValidity: 30
2023-12-29T23:15:25.5861054Z     logger.go:42: 23:15:25 | case/2-import |       region: us-west-1
2023-12-29T23:15:25.5862482Z     logger.go:42: 23:15:25 | case/2-import |       userPoolId: us-west-1_dNZY4RC9q
2023-12-29T23:15:25.5864131Z     logger.go:42: 23:15:25 | case/2-import |       userPoolIdRef:
2023-12-29T23:15:25.5865434Z     logger.go:42: 23:15:25 | case/2-import |         name: example
2023-12-29T23:15:25.5866684Z     logger.go:42: 23:15:25 | case/2-import |       userPoolIdSelector:
2023-12-29T23:15:25.5868022Z     logger.go:42: 23:15:25 | case/2-import |         matchLabels:
2023-12-29T23:15:25.5869657Z     logger.go:42: 23:15:25 | case/2-import |           testing.upbound.io/example-name: example
2023-12-29T23:15:25.5871014Z     logger.go:42: 23:15:25 | case/2-import |     initProvider: {}
2023-12-29T23:15:25.5871785Z     logger.go:42: 23:15:25 | case/2-import |     managementPolicies:
2023-12-29T23:15:25.5872495Z     logger.go:42: 23:15:25 | case/2-import |     - '*'
2023-12-29T23:15:25.5873212Z     logger.go:42: 23:15:25 | case/2-import |     providerConfigRef:
2023-12-29T23:15:25.5873954Z     logger.go:42: 23:15:25 | case/2-import |       name: default
2023-12-29T23:15:25.5874634Z     logger.go:42: 23:15:25 | case/2-import |   status:
2023-12-29T23:15:25.5875301Z     logger.go:42: 23:15:25 | case/2-import |     atProvider:
2023-12-29T23:15:25.5876080Z     logger.go:42: 23:15:25 | case/2-import |       accessTokenValidity: 0
2023-12-29T23:15:25.5877010Z     logger.go:42: 23:15:25 | case/2-import |       allowedOauthFlowsUserPoolClient: false
2023-12-29T23:15:25.5877906Z     logger.go:42: 23:15:25 | case/2-import |       authSessionValidity: 3
2023-12-29T23:15:25.5878714Z     logger.go:42: 23:15:25 | case/2-import |       defaultRedirectUri: ""
2023-12-29T23:15:25.5879702Z     logger.go:42: 23:15:25 | case/2-import |       enablePropagateAdditionalUserContextData: false
2023-12-29T23:15:25.5880688Z     logger.go:42: 23:15:25 | case/2-import |       enableTokenRevocation: true
2023-12-29T23:15:25.5881579Z     logger.go:42: 23:15:25 | case/2-import |       id: 44d13ks1tqdupfioc7usjoi8ao
2023-12-29T23:15:25.5882401Z     logger.go:42: 23:15:25 | case/2-import |       idTokenValidity: 0
2023-12-29T23:15:25.5883159Z     logger.go:42: 23:15:25 | case/2-import |       name: example
2023-12-29T23:15:25.5884691Z     logger.go:42: 23:15:25 | case/2-import |       preventUserExistenceErrors: ""
2023-12-29T23:15:25.5886152Z     logger.go:42: 23:15:25 | case/2-import |       refreshTokenValidity: 30
2023-12-29T23:15:25.5887637Z     logger.go:42: 23:15:25 | case/2-import |       userPoolId: us-west-1_dNZY4RC9q
2023-12-29T23:15:25.5888956Z     logger.go:42: 23:15:25 | case/2-import |     conditions:
2023-12-29T23:15:25.5890390Z     logger.go:42: 23:15:25 | case/2-import |     - lastTransitionTime: "2023-12-29T23:15:24Z"
2023-12-29T23:15:25.5891785Z     logger.go:42: 23:15:25 | case/2-import |       reason: Creating
2023-12-29T23:15:25.5893000Z     logger.go:42: 23:15:25 | case/2-import |       status: "False"
2023-12-29T23:15:25.5894165Z     logger.go:42: 23:15:25 | case/2-import |       type: Ready
2023-12-29T23:15:25.5895572Z     logger.go:42: 23:15:25 | case/2-import |     - lastTransitionTime: "2023-12-29T23:15:24Z"
2023-12-29T23:15:25.5897043Z     logger.go:42: 23:15:25 | case/2-import |       reason: ReconcileSuccess
2023-12-29T23:15:25.5938875Z     logger.go:42: 23:15:25 | case/2-import |       status: "True"
2023-12-29T23:15:25.5940111Z     logger.go:42: 23:15:25 | case/2-import |       type: Synced
```
(it shouldn't have `reason: Creating`)
```
2023-12-29T23:15:34.7002935Z     logger.go:42: 23:15:34 | case/2-import | - apiVersion: cognitoidp.aws.upbound.io/v1beta1
2023-12-29T23:15:34.7003812Z     logger.go:42: 23:15:34 | case/2-import |   kind: UserPoolClient
2023-12-29T23:15:34.7004788Z     logger.go:42: 23:15:34 | case/2-import |   metadata:
2023-12-29T23:15:34.7005604Z     logger.go:42: 23:15:34 | case/2-import |     annotations:
2023-12-29T23:15:34.7006603Z     logger.go:42: 23:15:34 | case/2-import |       crossplane.io/external-create-pending: "2023-12-29T23:15:24Z"
2023-12-29T23:15:34.7007792Z     logger.go:42: 23:15:34 | case/2-import |       crossplane.io/external-create-succeeded: "2023-12-29T23:15:24Z"
2023-12-29T23:15:34.7008960Z     logger.go:42: 23:15:34 | case/2-import |       crossplane.io/external-name: 6n608g0e9s95uf85r82gv5u7eb
2023-12-29T23:15:34.7009979Z     logger.go:42: 23:15:34 | case/2-import |       upjet.crossplane.io/provider-meta: ""
2023-12-29T23:15:34.7010894Z     logger.go:42: 23:15:34 | case/2-import |       upjet.upbound.io/test: "true"
2023-12-29T23:15:34.7011852Z     logger.go:42: 23:15:34 | case/2-import |       uptest-old-id: 44d13ks1tqdupfioc7usjoi8ao
2023-12-29T23:15:34.7012850Z     logger.go:42: 23:15:34 | case/2-import |     creationTimestamp: "2023-12-29T23:14:39Z"
2023-12-29T23:15:34.7013657Z     logger.go:42: 23:15:34 | case/2-import |     finalizers:
2023-12-29T23:15:34.7014530Z     logger.go:42: 23:15:34 | case/2-import |     - finalizer.managedresource.crossplane.io
2023-12-29T23:15:34.7015374Z     logger.go:42: 23:15:34 | case/2-import |     generation: 4
2023-12-29T23:15:34.7016049Z     logger.go:42: 23:15:34 | case/2-import |     labels:
2023-12-29T23:15:34.7017152Z     logger.go:42: 23:15:34 | case/2-import |       testing.upbound.io/example-name: example
2023-12-29T23:15:34.7018764Z     logger.go:42: 23:15:34 | case/2-import |     name: example
2023-12-29T23:15:34.7019917Z     logger.go:42: 23:15:34 | case/2-import |     resourceVersion: "1282"
2023-12-29T23:15:34.7021309Z     logger.go:42: 23:15:34 | case/2-import |     uid: ef566213-9990-48ae-b947-7b5c02666115
2023-12-29T23:15:34.7022733Z     logger.go:42: 23:15:34 | case/2-import |   spec:
2023-12-29T23:15:34.7023889Z     logger.go:42: 23:15:34 | case/2-import |     deletionPolicy: Delete
2023-12-29T23:15:34.7025037Z     logger.go:42: 23:15:34 | case/2-import |     forProvider:
2023-12-29T23:15:34.7026357Z     logger.go:42: 23:15:34 | case/2-import |       authSessionValidity: 3
2023-12-29T23:15:34.7027864Z     logger.go:42: 23:15:34 | case/2-import |       enableTokenRevocation: true
2023-12-29T23:15:34.7029296Z     logger.go:42: 23:15:34 | case/2-import |       name: example
2023-12-29T23:15:34.7030543Z     logger.go:42: 23:15:34 | case/2-import |       refreshTokenValidity: 30
2023-12-29T23:15:34.7031359Z     logger.go:42: 23:15:34 | case/2-import |       region: us-west-1
2023-12-29T23:15:34.7032209Z     logger.go:42: 23:15:34 | case/2-import |       userPoolId: us-west-1_dNZY4RC9q
2023-12-29T23:15:34.7033023Z     logger.go:42: 23:15:34 | case/2-import |       userPoolIdRef:
2023-12-29T23:15:34.7033783Z     logger.go:42: 23:15:34 | case/2-import |         name: example
2023-12-29T23:15:34.7034557Z     logger.go:42: 23:15:34 | case/2-import |       userPoolIdSelector:
2023-12-29T23:15:34.7035314Z     logger.go:42: 23:15:34 | case/2-import |         matchLabels:
2023-12-29T23:15:34.7036230Z     logger.go:42: 23:15:34 | case/2-import |           testing.upbound.io/example-name: example
2023-12-29T23:15:34.7037096Z     logger.go:42: 23:15:34 | case/2-import |     initProvider: {}
2023-12-29T23:15:34.7037860Z     logger.go:42: 23:15:34 | case/2-import |     managementPolicies:
2023-12-29T23:15:34.7038574Z     logger.go:42: 23:15:34 | case/2-import |     - '*'
2023-12-29T23:15:34.7039294Z     logger.go:42: 23:15:34 | case/2-import |     providerConfigRef:
2023-12-29T23:15:34.7040042Z     logger.go:42: 23:15:34 | case/2-import |       name: default
2023-12-29T23:15:34.7041121Z     logger.go:42: 23:15:34 | case/2-import |   status:
2023-12-29T23:15:34.7042066Z     logger.go:42: 23:15:34 | case/2-import |     atProvider:
2023-12-29T23:15:34.7042864Z     logger.go:42: 23:15:34 | case/2-import |       accessTokenValidity: 0
2023-12-29T23:15:34.7044016Z     logger.go:42: 23:15:34 | case/2-import |       allowedOauthFlowsUserPoolClient: false
2023-12-29T23:15:34.7044920Z     logger.go:42: 23:15:34 | case/2-import |       authSessionValidity: 3
2023-12-29T23:15:34.7045739Z     logger.go:42: 23:15:34 | case/2-import |       defaultRedirectUri: ""
2023-12-29T23:15:34.7046733Z     logger.go:42: 23:15:34 | case/2-import |       enablePropagateAdditionalUserContextData: false
2023-12-29T23:15:34.7047725Z     logger.go:42: 23:15:34 | case/2-import |       enableTokenRevocation: true
2023-12-29T23:15:34.7048607Z     logger.go:42: 23:15:34 | case/2-import |       id: 6n608g0e9s95uf85r82gv5u7eb
2023-12-29T23:15:34.7049432Z     logger.go:42: 23:15:34 | case/2-import |       idTokenValidity: 0
2023-12-29T23:15:34.7050189Z     logger.go:42: 23:15:34 | case/2-import |       name: example
2023-12-29T23:15:34.7051023Z     logger.go:42: 23:15:34 | case/2-import |       preventUserExistenceErrors: ""
2023-12-29T23:15:34.7051895Z     logger.go:42: 23:15:34 | case/2-import |       refreshTokenValidity: 30
2023-12-29T23:15:34.7052792Z     logger.go:42: 23:15:34 | case/2-import |       userPoolId: us-west-1_dNZY4RC9q
2023-12-29T23:15:34.7053573Z     logger.go:42: 23:15:34 | case/2-import |     conditions:
2023-12-29T23:15:34.7054445Z     logger.go:42: 23:15:34 | case/2-import |     - lastTransitionTime: "2023-12-29T23:15:29Z"
2023-12-29T23:15:34.7055311Z     logger.go:42: 23:15:34 | case/2-import |       reason: Available
2023-12-29T23:15:34.7056064Z     logger.go:42: 23:15:34 | case/2-import |       status: "True"
2023-12-29T23:15:34.7056910Z     logger.go:42: 23:15:34 | case/2-import |       type: Ready
2023-12-29T23:15:34.7058480Z     logger.go:42: 23:15:34 | case/2-import |     - lastTransitionTime: "2023-12-29T23:15:24Z"
2023-12-29T23:15:34.7060085Z     logger.go:42: 23:15:34 | case/2-import |       reason: ReconcileSuccess
2023-12-29T23:15:34.7061657Z     logger.go:42: 23:15:34 | case/2-import |       status: "True"
2023-12-29T23:15:34.7062837Z     logger.go:42: 23:15:34 | case/2-import |       type: Synced
2023-12-29T23:15:34.7063821Z     logger.go:42: 23:15:34 | case/2-import |     - lastTransitionTime: "2023-12-29T23:15:25Z"
2023-12-29T23:15:34.7064707Z     logger.go:42: 23:15:34 | case/2-import |       reason: Success
2023-12-29T23:15:34.7065564Z     logger.go:42: 23:15:34 | case/2-import |       status: "True"
2023-12-29T23:15:34.7066501Z     logger.go:42: 23:15:34 | case/2-import |       type: LastAsyncOperation
2023-12-29T23:15:34.7067465Z     logger.go:42: 23:15:34 | case/2-import |     - lastTransitionTime: "2023-12-29T23:15:25Z"
2023-12-29T23:15:34.7068319Z     logger.go:42: 23:15:34 | case/2-import |       reason: Finished
2023-12-29T23:15:34.7069071Z     logger.go:42: 23:15:34 | case/2-import |       status: "True"
2023-12-29T23:15:34.7069832Z     logger.go:42: 23:15:34 | case/2-import |       type: AsyncOperation
2023-12-29T23:15:34.7070751Z     logger.go:42: 23:15:34 | case/2-import |     - lastTransitionTime: "2023-12-29T23:15:33Z"
2023-12-29T23:15:34.7071608Z     logger.go:42: 23:15:34 | case/2-import |       reason: UpToDate
2023-12-29T23:15:34.7072351Z     logger.go:42: 23:15:34 | case/2-import |       status: "True"
2023-12-29T23:15:34.7073069Z     logger.go:42: 23:15:34 | case/2-import |       type: Test
```
It's now successfully created a second user pool client for the same managed resource.

3. Observe-only resources don't work at all. The external name config is using `parameters.name` as the initial value for the terraform id (ignoring the value on the external-name annotation), so there's no way to specify the id used for import. Additionally, for this resource  `terraform import` expects an argument that is not the value of the `id` for this resource. #1021 fixes the first part, but I can't think of any way to fix the second part without breaking FullControl functionality.
```
 - apiVersion: cognitoidp.aws.upbound.io/v1beta1
   kind: UserPoolClient
   metadata:
     annotations:
       crossplane.io/external-name: anything
       upjet.upbound.io/test: "true"
       uptest.upbound.io/timeout: "900"
     creationTimestamp: "2023-12-30T00:15:23Z"
     generation: 2
     labels:
       testing.upbound.io/example-name: observe
     name: observe
     resourceVersion: "1056"
     uid: 941904c6-b49d-47df-9f93-e630ea7ddbe5
   spec:
     deletionPolicy: Delete
     forProvider:
       name: name
       region: us-west-1
       userPoolId: us-west-1_uZEgMJAJX
       userPoolIdRef:
         name: observe
       userPoolIdSelector:
         matchLabels:
           testing.upbound.io/example-name: observe
     managementPolicies:
     - Observe
     providerConfigRef:
       name: default
   status:
     atProvider: {}
     conditions:
     - lastTransitionTime: "2023-12-30T00:15:29Z"
       message: "observe failed: cannot run import: \e[0m\e[1maws_cognito_user_pool_client.observe:
         Importing from ID \"name\"...\e[0m\n\e[31m\e[31m╷\e[0m\e[0m\n\e[31m│\e[0m
         \e[0m\e[1m\e[31mError: \e[0m\e[0m\e[1mResource Import Invalid ID\e[0m\n\e[31m│\e[0m
         \e[0m\n\e[31m│\e[0m \e[0m\e[0mwrong format of import ID (name), use: 'user-pool-id/client-id'\n\e[31m╵\e[0m\e[0m\n\e[0m\e[0m\n:
         import failed"
       reason: ReconcileError
       status: "False"
       type: Synced
```
