### PR TITLE
Make `assume_role_with_web_identity` provider configuration value a list

### DIFF
--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -130,23 +130,29 @@ func pushDownTerraformSetupBuilder(ctx context.Context, c client.Client, pc *v1b
 		if pc.Spec.Credentials.WebIdentity == nil {
 			return errors.New(`spec.credentials.webIdentity of ProviderConfig cannot be nil when the credential source is "WebIdentity"`)
 		}
-		ps.Configuration[keyAssumeRoleWithWebIdentity] = map[string]any{
+		webIdentityConfig := map[string]any{
 			keyRoleArn:              aws.ToString(pc.Spec.Credentials.WebIdentity.RoleARN),
 			keyWebIdentityTokenFile: os.Getenv(envWebIdentityTokenFile),
 		}
 		if pc.Spec.Credentials.WebIdentity.RoleSessionName != "" {
-			ps.Configuration[keySessionName] = pc.Spec.Credentials.WebIdentity.RoleSessionName
+			webIdentityConfig[keySessionName] = pc.Spec.Credentials.WebIdentity.RoleSessionName
+		}
+		ps.Configuration[keyAssumeRoleWithWebIdentity] = []any{
+			webIdentityConfig,
 		}
 	case authKeyUpbound:
 		if pc.Spec.Credentials.Upbound == nil || pc.Spec.Credentials.Upbound.WebIdentity == nil {
 			return errors.New(`spec.credentials.upbound.webIdentity of ProviderConfig cannot be nil when the credential source is "Upbound"`)
 		}
-		ps.Configuration[keyAssumeRoleWithWebIdentity] = map[string]any{
+		webIdentityConfig := map[string]any{
 			keyRoleArn:              aws.ToString(pc.Spec.Credentials.Upbound.WebIdentity.RoleARN),
 			keyWebIdentityTokenFile: upboundProviderIdentityTokenFile,
 		}
 		if pc.Spec.Credentials.Upbound.WebIdentity.RoleSessionName != "" {
-			ps.Configuration[keySessionName] = pc.Spec.Credentials.Upbound.WebIdentity.RoleSessionName
+			webIdentityConfig[keySessionName] = pc.Spec.Credentials.Upbound.WebIdentity.RoleSessionName
+		}
+		ps.Configuration[keyAssumeRoleWithWebIdentity] = []any{
+			webIdentityConfig,
 		}
 	case authKeySecret:
 		data, err := resource.CommonCredentialExtractor(ctx, s, c, pc.Spec.Credentials.CommonCredentialSelectors)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1054 

The Terraform provider schema declares `assume_role_with_web_identity` as a [list](https://github.com/hashicorp/terraform-provider-aws/blob/7aea0db5fac1691f3528e89a483424ae310b18dc/internal/provider/provider.go#L672), whereas we prepare a [map](https://github.com/upbound/provider-aws/blob/8f8e547a8fbba3cac6e3b1ffe137478818b4b06e/internal/clients/aws.go#L133). The theory is that `sts.AssumeRoleWithWebIdentity` is thus not configured properly for the no-fork external client and as a last resort, the provider tries to access the IMDS to authenticate its requests. This PR changes the configuration value from a map to a list as expected by the corresponding Terraform provider schema.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

TODO:
- [x] We need to validate this in Upbound Cloud
- [x] We need to test whether the CLI-based external client can still reconcile with the `WebIdentity` provider configuration
- [x] We also need to understand how the `WebIdentity` configuration still works (via the environment variables) although it doesn't conform to the declared schema either
- [x] We had better test the other provider configurations as well