### PR TITLE
feat(renovate): add uptest, up and golangcilint for renovate pr

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,5 +114,45 @@
       ],
       "pinDigests": true
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Bump up version in the Makefile",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "UP_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "upbound/up",
+    }, {
+      "customType": "regex",
+      "description": "Bump uptest version in the Makefile",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "UPTEST_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "upbound/uptest",
+    }, {
+      "customType": "regex",
+      "description": "Bump kind version in the Makefile",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "KIND_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "kubernetes-sigs/kind",
+    }, {
+      "customType": "regex",
+      "description": "Bump golangci-lint version in workflows and the Makefile",
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$","^Makefile$"],
+      "matchStrings": [
+        "GOLANGCILINT_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "golangci/golangci-lint",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- automatic PRs for up version upgrades
- automatic PRs for kind version upgrades
- automatic PRs for uptest version upgrades
- automatic PRs for golangcilint version upgrades

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
local dry-run

```
RENOVATE_CONFIG_FILE=.github/renovate.json5 \
    npx renovate \
      --token=$GITHUB_TOKEN \
      --schedule="" \
      --dry-run=full \
      upbound/provider-aws
```

```
[...]
 INFO: Dependency extraction complete (repository=upbound/provider-aws, baseBranch=main)
       "stats": {
         "managers": {
           "dockerfile": {"fileCount": 1, "depCount": 2},
           "github-actions": {"fileCount": 11, "depCount": 23},
           "gomod": {"fileCount": 1, "depCount": 205},
           "regex": {"fileCount": 3, "depCount": 3}
         },
         "total": {"fileCount": 16, "depCount": 233}
       }
[...]
 INFO: DRY-RUN: Would commit files to branch renovate/kubernetes-sigs-kind-0.x (repository=upbound/provider-aws, baseBranch=main, branch=renovate/kubernetes-sigs-kind-0.x)
 INFO: DRY-RUN: Would commit files to branch renovate/upbound-up-0.x (repository=upbound/provider-aws, baseBranch=main, branch=renovate/upbound-up-0.x)
 INFO: DRY-RUN: Would commit files to branch renovate/upbound-uptest-0.x (repository=upbound/provider-aws, baseBranch=main, branch=renovate/upbound-uptest-0.x)
[...]
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
