### PR TITLE
Make endpoints provider configuration value single-element list

### DIFF
--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -199,7 +199,7 @@ func DefaultTerraformSetupBuilder(_ context.Context, pc *v1beta1.ProviderConfig,
 				for _, service := range pc.Spec.Endpoint.Services {
 					endpoints[service] = aws.ToString(pc.Spec.Endpoint.URL.Static)
 				}
-				ps.Configuration[keyEndpoints] = endpoints
+				ps.Configuration[keyEndpoints] = []any{endpoints}
 			}
 		}
 	}


### PR DESCRIPTION
### Description of your changes
Fixes #1063 

The Terraform provider schema declares `endpoints` as a [single element set of key-value map](https://github.com/hashicorp/terraform-provider-aws/blob/7aea0db5fac1691f3528e89a483424ae310b18dc/internal/provider/provider.go#L741), whereas we prepare a [key-value map](https://github.com/upbound/provider-aws/blob/8f8e547a8fbba3cac6e3b1ffe137478818b4b06e/internal/clients/aws.go#L196) in the TF provider configuration block. 
This was being properly handled by terraform CLI based external clients, and no-fork clients that used to configure AWS client directly (`0.44.0` and `0.45.0`). 
Starting from `0.46.0` we switched to [native provider's `Configure` method](https://github.com/upbound/provider-aws/blob/8f8e547a8fbba3cac6e3b1ffe137478818b4b06e/internal/clients/aws.go#L225), which is strict about the type, and expects a Go Slice to satisfy the `Set` schema for `endpoints`

This PR changes the configuration value from a map to a single element slice which consist of the map as expected by the corresponding Terraform provider schema.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with a localstack deployment in a Kind cluster, with the provider config supplied at issue #1063 that has custom endpoints config.
