### PR TITLE
DocDB: add `dbClusterParameterGroupName` Selector for Cluster

### DIFF
--- a/apis/docdb/v1beta1/zz_cluster_types.go
+++ b/apis/docdb/v1beta1/zz_cluster_types.go
@@ -33,7 +33,16 @@ type ClusterInitParameters struct {
 	BackupRetentionPeriod *float64 `json:"backupRetentionPeriod,omitempty" tf:"backup_retention_period,omitempty"`
 
 	// A cluster parameter group to associate with the cluster.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/docdb/v1beta1.ClusterParameterGroup
 	DBClusterParameterGroupName *string `json:"dbClusterParameterGroupName,omitempty" tf:"db_cluster_parameter_group_name,omitempty"`
+
+	// Reference to a ClusterParameterGroup in docdb to populate dbClusterParameterGroupName.
+	// +kubebuilder:validation:Optional
+	DBClusterParameterGroupNameRef *v1.Reference `json:"dbClusterParameterGroupNameRef,omitempty" tf:"-"`
+
+	// Selector for a ClusterParameterGroup in docdb to populate dbClusterParameterGroupName.
+	// +kubebuilder:validation:Optional
+	DBClusterParameterGroupNameSelector *v1.Selector `json:"dbClusterParameterGroupNameSelector,omitempty" tf:"-"`
 
 	// A DB subnet group to associate with this DB instance.
 	DBSubnetGroupName *string `json:"dbSubnetGroupName,omitempty" tf:"db_subnet_group_name,omitempty"`
@@ -236,8 +245,17 @@ type ClusterParameters struct {
 	BackupRetentionPeriod *float64 `json:"backupRetentionPeriod,omitempty" tf:"backup_retention_period,omitempty"`
 
 	// A cluster parameter group to associate with the cluster.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/docdb/v1beta1.ClusterParameterGroup
 	// +kubebuilder:validation:Optional
 	DBClusterParameterGroupName *string `json:"dbClusterParameterGroupName,omitempty" tf:"db_cluster_parameter_group_name,omitempty"`
+
+	// Reference to a ClusterParameterGroup in docdb to populate dbClusterParameterGroupName.
+	// +kubebuilder:validation:Optional
+	DBClusterParameterGroupNameRef *v1.Reference `json:"dbClusterParameterGroupNameRef,omitempty" tf:"-"`
+
+	// Selector for a ClusterParameterGroup in docdb to populate dbClusterParameterGroupName.
+	// +kubebuilder:validation:Optional
+	DBClusterParameterGroupNameSelector *v1.Selector `json:"dbClusterParameterGroupNameSelector,omitempty" tf:"-"`
 
 	// A DB subnet group to associate with this DB instance.
 	// +kubebuilder:validation:Optional

--- a/apis/docdb/v1beta1/zz_generated.deepcopy.go
+++ b/apis/docdb/v1beta1/zz_generated.deepcopy.go
@@ -69,6 +69,16 @@ func (in *ClusterInitParameters) DeepCopyInto(out *ClusterInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DBClusterParameterGroupNameRef != nil {
+		in, out := &in.DBClusterParameterGroupNameRef, &out.DBClusterParameterGroupNameRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DBClusterParameterGroupNameSelector != nil {
+		in, out := &in.DBClusterParameterGroupNameSelector, &out.DBClusterParameterGroupNameSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DBSubnetGroupName != nil {
 		in, out := &in.DBSubnetGroupName, &out.DBSubnetGroupName
 		*out = new(string)
@@ -1199,6 +1209,16 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		in, out := &in.DBClusterParameterGroupName, &out.DBClusterParameterGroupName
 		*out = new(string)
 		**out = **in
+	}
+	if in.DBClusterParameterGroupNameRef != nil {
+		in, out := &in.DBClusterParameterGroupNameRef, &out.DBClusterParameterGroupNameRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DBClusterParameterGroupNameSelector != nil {
+		in, out := &in.DBClusterParameterGroupNameSelector, &out.DBClusterParameterGroupNameSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DBSubnetGroupName != nil {
 		in, out := &in.DBSubnetGroupName, &out.DBSubnetGroupName

--- a/apis/docdb/v1beta1/zz_generated.resolvers.go
+++ b/apis/docdb/v1beta1/zz_generated.resolvers.go
@@ -25,6 +25,22 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.DBClusterParameterGroupName),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.ForProvider.DBClusterParameterGroupNameRef,
+		Selector:     mg.Spec.ForProvider.DBClusterParameterGroupNameSelector,
+		To: reference.To{
+			List:    &ClusterParameterGroupList{},
+			Managed: &ClusterParameterGroup{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.DBClusterParameterGroupName")
+	}
+	mg.Spec.ForProvider.DBClusterParameterGroupName = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.DBClusterParameterGroupNameRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.KMSKeyID),
 		Extract:      reference.ExternalName(),
 		Reference:    mg.Spec.ForProvider.KMSKeyIDRef,
@@ -55,6 +71,22 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 	}
 	mg.Spec.ForProvider.VPCSecurityGroupIds = reference.ToPtrValues(mrsp.ResolvedValues)
 	mg.Spec.ForProvider.VPCSecurityGroupIDRefs = mrsp.ResolvedReferences
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.DBClusterParameterGroupName),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.InitProvider.DBClusterParameterGroupNameRef,
+		Selector:     mg.Spec.InitProvider.DBClusterParameterGroupNameSelector,
+		To: reference.To{
+			List:    &ClusterParameterGroupList{},
+			Managed: &ClusterParameterGroup{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.DBClusterParameterGroupName")
+	}
+	mg.Spec.InitProvider.DBClusterParameterGroupName = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.DBClusterParameterGroupNameRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.KMSKeyID),

--- a/config/docdb/config.go
+++ b/config/docdb/config.go
@@ -17,6 +17,9 @@ func Configure(p *config.Provider) {
 			}
 			return conn, nil
 		}
+		r.References["db_cluster_parameter_group_name"] = config.Reference{
+			TerraformName: "aws_docdb_cluster_parameter_group",
+		}
 	})
 
 	p.AddResourceConfigurator("aws_docdb_cluster_instance", func(r *config.Resource) {

--- a/examples/docdb/cluster.yaml
+++ b/examples/docdb/cluster.yaml
@@ -18,6 +18,9 @@ spec:
     masterUsername: foo
     preferredBackupWindow: 07:00-09:00
     skipFinalSnapshot: true
+    dbClusterParameterGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: docdb-cluster-test
 
 ---
 
@@ -33,3 +36,22 @@ metadata:
 type: Opaque
 stringData:
   password: "Upboundtest!"
+
+---
+
+apiVersion: docdb.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: docdb/v1beta1/cluster
+  labels:
+    testing.upbound.io/example-name: docdb-cluster-test
+  name: example
+spec:
+  forProvider:
+    description: docdb cluster parameter group
+    family: docdb5.0
+    parameter:
+    - name: tls
+      value: enabled
+    region: us-west-2

--- a/package/crds/docdb.aws.upbound.io_clusters.yaml
+++ b/package/crds/docdb.aws.upbound.io_clusters.yaml
@@ -85,6 +85,81 @@ spec:
                   dbClusterParameterGroupName:
                     description: A cluster parameter group to associate with the cluster.
                     type: string
+                  dbClusterParameterGroupNameRef:
+                    description: Reference to a ClusterParameterGroup in docdb to
+                      populate dbClusterParameterGroupName.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  dbClusterParameterGroupNameSelector:
+                    description: Selector for a ClusterParameterGroup in docdb to
+                      populate dbClusterParameterGroupName.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   dbSubnetGroupName:
                     description: A DB subnet group to associate with this DB instance.
                     type: string
@@ -371,6 +446,81 @@ spec:
                   dbClusterParameterGroupName:
                     description: A cluster parameter group to associate with the cluster.
                     type: string
+                  dbClusterParameterGroupNameRef:
+                    description: Reference to a ClusterParameterGroup in docdb to
+                      populate dbClusterParameterGroupName.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  dbClusterParameterGroupNameSelector:
+                    description: Selector for a ClusterParameterGroup in docdb to
+                      populate dbClusterParameterGroupName.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   dbSubnetGroupName:
                     description: A DB subnet group to associate with this DB instance.
                     type: string


### PR DESCRIPTION

### Description of your changes

Add `dbClusterParameterGroupNameSelector` to DocDB Cluster

* Add reference configuration
* Add generated files
* Extend uptest example

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

uptest below
