### PR TITLE
[docdb]: add master_password to Cluster connection secret

### DIFF
--- a/config/docdb/config.go
+++ b/config/docdb/config.go
@@ -15,6 +15,9 @@ func Configure(p *config.Provider) {
 			if a, ok := attr["arn"].(string); ok {
 				conn["arn"] = []byte(a)
 			}
+			if a, ok := attr["master_password"].(string); ok {
+				conn["password"] = []byte(a)
+			}
 			return conn, nil
 		}
 		r.References["db_cluster_parameter_group_name"] = config.Reference{

--- a/examples/docdb/cluster.yaml
+++ b/examples/docdb/cluster.yaml
@@ -7,6 +7,9 @@ metadata:
     testing.upbound.io/example-name: docdb
   name: my-docdb-cluster
 spec:
+  writeConnectionSecretToRef:
+    name: docdb-cluster-secret
+    namespace: upbound-system
   forProvider:
     region: us-west-2
     engine: "docdb"


### PR DESCRIPTION

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
* Add `master_password` to Cluster connection secret as `password` field
* Extend uptest example
* Fixes #1077


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
 k apply -f examples/docdb/cluster.yaml
k get managed
NAME                                                 READY   SYNCED   EXTERNAL-NAME   AGE
clusterparametergroup.docdb.aws.upbound.io/example   True    True     example         10m

NAME                                            READY   SYNCED   EXTERNAL-NAME      AGE
cluster.docdb.aws.upbound.io/my-docdb-cluster   True    True     my-docdb-cluster   10m

k get secret -A
...
upbound-system   docdb-cluster-secret                              connection.crossplane.io/v1alpha1   4      3m27s

k view-secret -n upbound-system docdb-cluster-secret
Multiple sub keys found. Specify another argument, one of:
-> arn
-> attribute.master_password
-> endpoint
-> password

k view-secret -n upbound-system docdb-cluster-secret password
Upboundtest!%
```

+ uptest below
