### PR TITLE
Improve example manifests for rds group

### DIFF
--- a/examples/rds/clusteractivitystream.yaml
+++ b/examples/rds/clusteractivitystream.yaml
@@ -1,27 +1,70 @@
 apiVersion: rds.aws.upbound.io/v1beta1
 kind: ClusterActivityStream
 metadata:
-  name: default
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Cluster, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/clusteractivitystream
+  labels:
+    testing.upbound.io/example-name: default-cas
+  name: default-cas
 spec:
   forProvider:
-    kmsKeyIdRef:
-      name: default
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: default-cas
     mode: async
     region: us-west-1
-    resourceArnRef:
-      name: example
+    resourceArnSelector:
+      matchLabels:
+        testing.upbound.io/example-name: default-cas
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Cluster
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusteractivitystream
+  labels:
+    testing.upbound.io/example-name: default-cas
+  name: example-cas
+spec:
+  forProvider:
+    region: us-west-1
+    engine: aurora-postgresql
+    masterUsername: cpadmin
+    masterPasswordSecretRef:
+      name: sample-cluster-password
+      namespace: upbound-system
+      key: password
+    skipFinalSnapshot: true
+  writeConnectionSecretToRef:
+    name: sample-rds-cluster-secret
+    namespace: upbound-system
+
 ---
 
 apiVersion: kms.aws.upbound.io/v1beta1
 kind: Key
 metadata:
-  name: default
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource is a dependency of ClusterActivityStream, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/clusteractivitystream
+  labels:
+    testing.upbound.io/example-name: default-cas
+  name: default-cas
 spec:
   forProvider:
     description: AWS KMS Key to encrypt Database Activity Stream
     region: us-west-1
 
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusteractivitystream
+  name: sample-cluster-password
+  namespace: upbound-system
+type: Opaque
+stringData:
+  password: TestPass0!

--- a/examples/rds/clusterendpoint.yaml
+++ b/examples/rds/clusterendpoint.yaml
@@ -1,12 +1,52 @@
 apiVersion: rds.aws.upbound.io/v1beta1
 kind: ClusterEndpoint
 metadata:
-  name: example
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Cluster, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/clusterendpoint
+  labels:
+    testing.upbound.io/example-name: eligible
+  name: eligible
 spec:
   forProvider:
     region: us-west-1
-    clusterIdentifierRef:
-      name: example
     customEndpointType: READER
+    clusterIdentifierSelector:
+      matchLabels:
+        testing.upbound.io/example-name: default-ce
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Cluster
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusterendpoint
+  labels:
+    testing.upbound.io/example-name: default-ce
+  name: example-ce
+spec:
+  forProvider:
+    region: us-west-1
+    engine: aurora-postgresql
+    masterUsername: cpadmin
+    masterPasswordSecretRef:
+      name: sample-cluster-password
+      namespace: upbound-system
+      key: password
+    skipFinalSnapshot: true
+  writeConnectionSecretToRef:
+    name: sample-rds-cluster-secret
+    namespace: upbound-system
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusterendpoint
+  name: sample-cluster-password
+  namespace: upbound-system
+type: Opaque
+stringData:
+  password: TestPass0!

--- a/examples/rds/clusterparametergroup.yaml
+++ b/examples/rds/clusterparametergroup.yaml
@@ -1,7 +1,11 @@
 apiVersion: rds.aws.upbound.io/v1beta1
 kind: ClusterParameterGroup
 metadata:
-  name: example
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusterparametergroup
+  labels:
+    testing.upbound.io/example-name: default
+  name: example-cpg
 spec:
   forProvider:
     region: us-west-1

--- a/examples/rds/clusterroleassociation.yaml
+++ b/examples/rds/clusterroleassociation.yaml
@@ -1,12 +1,60 @@
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ClusterRoleAssociation
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusterroleassociation
+  labels:
+    testing.upbound.io/example-name: example
+  name: example-cra
+spec:
+  forProvider:
+    region: us-west-1
+    dbClusterIdentifierSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-cra
+    featureName: s3Import
+    roleArnSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-cra
+
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Cluster
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusterroleassociation
+  labels:
+    testing.upbound.io/example-name: example-cra
+  name: example-cluster-cra
+spec:
+  forProvider:
+    region: us-west-1
+    engine: aurora-postgresql
+    masterUsername: cpadmin
+    masterPasswordSecretRef:
+      name: sample-cluster-password
+      namespace: upbound-system
+      key: password
+    skipFinalSnapshot: true
+  writeConnectionSecretToRef:
+    name: sample-rds-cluster-secret
+    namespace: upbound-system
+
+
+---
+
 apiVersion: iam.aws.upbound.io/v1beta1
 kind: Policy
 metadata:
-  name: sample-s3-policy
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource is a dependency of ClusterRoleAssociation, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/clusterroleassociation
+  labels:
+    testing.upbound.io/example-name: example-cra
+  name: sample-policy-cra
 spec:
   forProvider:
-    name: sample-s3-policy
     policy: |
       {
           "Version": "2012-10-17",
@@ -27,9 +75,11 @@ spec:
 apiVersion: iam.aws.upbound.io/v1beta1
 kind: Role
 metadata:
-  name: sample-db-role
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource is a dependency of ClusterRoleAssociation, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/clusterroleassociation
+  labels:
+    testing.upbound.io/example-name: example-cra
+  name: sample-role-cra
 spec:
   forProvider:
     assumeRolePolicy: |
@@ -52,29 +102,27 @@ spec:
 apiVersion: iam.aws.upbound.io/v1beta1
 kind: RolePolicyAttachment
 metadata:
-  name: sample-role-attach
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource is a dependency of ClusterRoleAssociation, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/clusterroleassociation
+  labels:
+    testing.upbound.io/example-name: example-cra
+  name: sample-role-attach-cra
 spec:
   forProvider:
     policyArnRef:
-      name: sample-s3-policy
+      name: sample-policy-cra
     roleRef:
-      name: sample-db-role
+      name: sample-role-cra
 
 ---
 
-apiVersion: rds.aws.upbound.io/v1beta1
-kind: ClusterRoleAssociation
+apiVersion: v1
+kind: Secret
 metadata:
-  name: example
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Cluster, which needs manual intervention."
-spec:
-  forProvider:
-    region: us-west-1
-    dbClusterIdentifierRef:
-      name: example
-    featureName: s3Import
-    roleArnRef:
-      name: sample-db-role
+    meta.upbound.io/example-id: rds/v1beta1/clusterroleassociation
+  name: sample-cluster-password
+  namespace: upbound-system
+type: Opaque
+stringData:
+  password: TestPass0!

--- a/examples/rds/clustersnapshot.yaml
+++ b/examples/rds/clustersnapshot.yaml
@@ -3,12 +3,50 @@ kind: ClusterSnapshot
 metadata:
   annotations:
     meta.upbound.io/example-id: rds/v1beta1/clustersnapshot
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Cluster, which needs manual intervention."
   labels:
     testing.upbound.io/example-name: example
-  name: example
+  name: example-cs
 spec:
   forProvider:
-    dbClusterIdentifier: database-1
+    dbClusterIdentifierSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-cs
     dbClusterSnapshotIdentifier: resourcetestsnapshot1234
     region: us-west-1
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Cluster
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clustersnapshot
+  labels:
+    testing.upbound.io/example-name: example-cs
+  name: example-cs
+spec:
+  forProvider:
+    region: us-west-1
+    engine: aurora-postgresql
+    masterUsername: cpadmin
+    masterPasswordSecretRef:
+      name: sample-cluster-password
+      namespace: upbound-system
+      key: password
+    skipFinalSnapshot: true
+  writeConnectionSecretToRef:
+    name: sample-rds-cluster-secret
+    namespace: upbound-system
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clustersnapshot
+  name: sample-cluster-password
+  namespace: upbound-system
+type: Opaque
+stringData:
+  password: TestPass0!

--- a/examples/rds/dbinstanceautomatedbackupsreplication.yaml
+++ b/examples/rds/dbinstanceautomatedbackupsreplication.yaml
@@ -3,12 +3,45 @@ kind: DBInstanceAutomatedBackupsReplication
 metadata:
   annotations:
     meta.upbound.io/example-id: rds/v1beta1/dbinstanceautomatedbackupsreplication
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Instance, which needs manual intervention."
   labels:
-    testing.upbound.io/example-name: default
-  name: default
+    testing.upbound.io/example-name: example
+  name: example-dbiabr
 spec:
   forProvider:
     region: us-east-2
     retentionPeriod: 7
-    sourceDbInstanceArn: arn-for-db-instance
+    sourceDbInstanceArnSelector:
+      matchLabels:
+        testing.upbound.io/example-name: default-test
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/dbinstanceautomatedbackupsreplication
+    uptest.upbound.io/timeout: "3600"
+  labels:
+    testing.upbound.io/example-name: default-test
+  name: default-dbiabr
+spec:
+  forProvider:
+    backupRetentionPeriod: 7
+    allocatedStorage: 10
+    dbName: mydb
+    engine: mysql
+    engineVersion: "5.7"
+    instanceClass: db.t3.micro
+    parameterGroupName: default.mysql5.7
+    autoGeneratePassword: true
+    passwordSecretRef:
+      key: password
+      name: example-dbinstance
+      namespace: upbound-system
+    region: us-west-1
+    skipFinalSnapshot: true
+    username: foo
+  writeConnectionSecretToRef:
+    name: example-dbinstance-out
+    namespace: default

--- a/examples/rds/dbsnapshotcopy.yaml
+++ b/examples/rds/dbsnapshotcopy.yaml
@@ -3,28 +3,86 @@ kind: DBSnapshotCopy
 metadata:
   annotations:
     meta.upbound.io/example-id: rds/v1beta1/dbsnapshotcopy
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Instance, which needs manual intervention."
   labels:
     testing.upbound.io/example-name: example
-  name: example
+  name: example-ssc
 spec:
   forProvider:
     region: us-west-1
     sourceDbSnapshotIdentifierSelector:
       matchLabels:
-        testing.upbound.io/example-name: example
+        testing.upbound.io/example-name: example-ssc
     targetDbSnapshotIdentifier: testsnapshot1234-copy
+
 ---
+
 apiVersion: rds.aws.upbound.io/v1beta1
 kind: Snapshot
 metadata:
   annotations:
     meta.upbound.io/example-id: rds/v1beta1/dbsnapshotcopy
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Instance, which needs manual intervention."
   labels:
-    testing.upbound.io/example-name: example
-  name: example
+    testing.upbound.io/example-name: example-ssc
+  name: example-ssc
 spec:
   forProvider:
-    dbInstanceIdentifier: database-1
     region: us-west-1
+    dbInstanceIdentifierSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-dbinstance-ssc
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/dbsnapshotcopy
+    uptest.upbound.io/timeout: "3600"
+  labels:
+    testing.upbound.io/example-name: example-dbinstance-ssc
+  name: example-dbinstance-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    dbName: example
+    region: us-west-1
+    allocatedStorage: 20
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 14
+    instanceClass: db.t3.micro
+    engine: postgres
+    engineVersion: "13.7"
+    username: adminuser
+    autoGeneratePassword: true
+    passwordSecretRef:
+      key: password
+      name: example-dbinstance
+      namespace: upbound-system
+    backupWindow: "09:46-10:16"
+    maintenanceWindow: "Mon:00:00-Mon:03:00"
+    publiclyAccessible: false
+    skipFinalSnapshot: true
+    storageEncrypted: true
+    storageType: gp2
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-key-ssc
+  writeConnectionSecretToRef:
+    name: example-dbinstance-out
+    namespace: default
+
+---
+
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/dbsnapshotcopy
+  labels:
+    testing.upbound.io/example-name: sample-key-ssc
+  name: sample-key-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7

--- a/examples/rds/instanceroleassociation.yaml
+++ b/examples/rds/instanceroleassociation.yaml
@@ -1,14 +1,145 @@
 apiVersion: rds.aws.upbound.io/v1beta1
 kind: InstanceRoleAssociation
 metadata:
-  name: example
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Instance, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/instanceroleassociation
+  labels:
+    testing.upbound.io/example-name: example-instanceroleassociation
+  name: example-ira
 spec:
   forProvider:
-    dbInstanceIdentifierRef:
-      name: example-dbinstance
+    dbInstanceIdentifierSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-dbinstance-ira
     featureName: s3Import
     region: us-west-1
-    roleArnRef:
-      name: sample-db-role
+    roleArnSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instanceroleassociation
+    uptest.upbound.io/timeout: "3600"
+  labels:
+    testing.upbound.io/example-name: example-dbinstance-ira
+  name: example-dbinstance-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    dbName: example
+    region: us-west-1
+    allocatedStorage: 20
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 14
+    instanceClass: db.t3.micro
+    engine: postgres
+    engineVersion: "13.7"
+    username: adminuser
+    autoGeneratePassword: true
+    passwordSecretRef:
+      key: password
+      name: example-dbinstance
+      namespace: upbound-system
+    backupWindow: "09:46-10:16"
+    maintenanceWindow: "Mon:00:00-Mon:03:00"
+    publiclyAccessible: false
+    skipFinalSnapshot: true
+    storageEncrypted: true
+    storageType: gp2
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-key-ira
+  writeConnectionSecretToRef:
+    name: example-dbinstance-out
+    namespace: default
+
+---
+
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instanceroleassociation
+  labels:
+    testing.upbound.io/example-name: sample-key-ira
+  name: sample-key-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7
+
+---
+
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: RolePolicyAttachment
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instanceroleassociation
+  labels:
+    testing.upbound.io/example-name: example
+  name: sample-role-attach-ira
+spec:
+  forProvider:
+    policyArnRef:
+      name: sample-policy-ira
+    roleRef:
+      name: sample-role-ira
+
+---
+
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instanceroleassociation
+  labels:
+    testing.upbound.io/example-name: example
+  name: sample-role-ira
+spec:
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "rds.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
+
+---
+
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instanceroleassociation
+  labels:
+    testing.upbound.io/example-name: example
+  name: sample-policy-ira
+spec:
+  forProvider:
+    policy: |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:*",
+                "s3-object-lambda:*"
+              ],
+              "Resource": "*"
+            }
+          ]
+      }

--- a/examples/rds/snapshot.yaml
+++ b/examples/rds/snapshot.yaml
@@ -1,11 +1,70 @@
 apiVersion: rds.aws.upbound.io/v1beta1
 kind: Snapshot
 metadata:
-  name: example
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource has a reference to Instance, which needs manual intervention."
+    meta.upbound.io/example-id: rds/v1beta1/snapshot
+  labels:
+    testing.upbound.io/example-name: example-snapshot
+  name: example-snapshot
 spec:
   forProvider:
     region: us-west-1
-    dbInstanceIdentifierRef:
+    dbInstanceIdentifierSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-dbinstance-snapshot
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/snapshot
+    uptest.upbound.io/timeout: "3600"
+  labels:
+    testing.upbound.io/example-name: example-dbinstance-snapshot
+  name: example-dbinstance-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    dbName: example
+    region: us-west-1
+    allocatedStorage: 20
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 14
+    instanceClass: db.t3.micro
+    engine: postgres
+    engineVersion: "13.7"
+    username: adminuser
+    autoGeneratePassword: true
+    passwordSecretRef:
+      key: password
       name: example-dbinstance
+      namespace: upbound-system
+    backupWindow: "09:46-10:16"
+    maintenanceWindow: "Mon:00:00-Mon:03:00"
+    publiclyAccessible: false
+    skipFinalSnapshot: true
+    storageEncrypted: true
+    storageType: gp2
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-key-snapshot
+  writeConnectionSecretToRef:
+    name: example-dbinstance-out
+    namespace: default
+
+---
+
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/snapshot
+  labels:
+    testing.upbound.io/example-name: sample-key-snapshot
+  name: sample-key-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    region: us-west-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7


### PR DESCRIPTION
### Description of your changes

This PR fixes example manifests and makes them uptestable for the following resources in `rds` group:

- `Snapshot`
- `InstanceRoleAssociation`
- `ClusterRoleAssociation`
- `ClusterActivityStream`
- `ClusterEndpoint`
- `ClusterParameterGroup`
- `ClusterSnapshot`
- `DBInstanceAutomatedBackupsReplication`
- `DBSnapshotCopy`

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with uptest in comments below.