### PR TITLE
Revert upjet changes around calculating instance diff in 0.47

### DIFF
--- a/examples/elasticache/replicationgroup.yaml
+++ b/examples/elasticache/replicationgroup.yaml
@@ -16,6 +16,7 @@ spec:
     parameterGroupName: default.redis7
     port: 6379
     preferredCacheClusterAzs:
-      - us-west-1a
-      - us-west-1b
-    region: us-west-1
+      - us-east-2a
+      - us-east-2b
+    region: us-east-2
+    engineVersion: "7.1"

--- a/go.mod
+++ b/go.mod
@@ -213,3 +213,5 @@ require (
 replace golang.org/x/exp => golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 
 replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20231026091456-f2d38ee240d7
+
+replace github.com/crossplane/upjet => github.com/mbbush/upjet v0.0.0-20240123213939-7cbf31737861

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/smithy-go v1.13.5
 	github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a2f5
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
-	github.com/crossplane/upjet v1.1.0-rc.0.0.20231227120826-4cb45f9104ac
+	github.com/crossplane/upjet v1.1.0-rc.0.0.20231226094952-fb8acdbaec54
 	github.com/go-ini/ini v1.46.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/terraform-json v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,6 @@ github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a
 github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a2f5/go.mod h1:pgt7PaTvvOQz3jILyxbCaeleU9MrAqKaNoPJavhGBgM=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
-github.com/crossplane/upjet v1.1.0-rc.0.0.20231226094952-fb8acdbaec54 h1:uTK0QsKg3cM0/La5DvJlqlZwK+ueD3joYsVam63Ik9M=
-github.com/crossplane/upjet v1.1.0-rc.0.0.20231226094952-fb8acdbaec54/go.mod h1:t9etxIdYaxgyvFPBToikm5zBHi8RIpX8N4mTH77lQFM=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -384,6 +382,8 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mbbush/upjet v0.0.0-20240123213939-7cbf31737861 h1:vwMPKijPK5/ZzlHTBbZEUewJWtISHFHA3CuHjcOsdfM=
+github.com/mbbush/upjet v0.0.0-20240123213939-7cbf31737861/go.mod h1:t9etxIdYaxgyvFPBToikm5zBHi8RIpX8N4mTH77lQFM=
 github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a
 github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a2f5/go.mod h1:pgt7PaTvvOQz3jILyxbCaeleU9MrAqKaNoPJavhGBgM=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
-github.com/crossplane/upjet v1.1.0-rc.0.0.20231227120826-4cb45f9104ac h1:T1MTxsPAE/Cs0/EAGjeC29H9O/rO81yol2/5qGsf888=
-github.com/crossplane/upjet v1.1.0-rc.0.0.20231227120826-4cb45f9104ac/go.mod h1:t9etxIdYaxgyvFPBToikm5zBHi8RIpX8N4mTH77lQFM=
+github.com/crossplane/upjet v1.1.0-rc.0.0.20231226094952-fb8acdbaec54 h1:uTK0QsKg3cM0/La5DvJlqlZwK+ueD3joYsVam63Ik9M=
+github.com/crossplane/upjet v1.1.0-rc.0.0.20231226094952-fb8acdbaec54/go.mod h1:t9etxIdYaxgyvFPBToikm5zBHi8RIpX8N4mTH77lQFM=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This rolls back the upjet version in the provider-aws release-0.47 branch to resolve errors thrown when calculating instance diffs. 

Somewhere in https://github.com/crossplane/upjet/pull/317, https://github.com/crossplane/upjet/pull/319 and/or https://github.com/crossplane/upjet/pull/324 there was a change introduced in upjet related to calculating terraform instance diffs, that was included in provider-aws 0.47.0, and which seems to be the cause of errors relating to nil/zero values on several different resources.

Unfortunately, a linear revert to an earlier commit in the `main` branch on upjet won't work, because there was a forwards-incompatible schema change that would be a breaking change to revert (and is unrelated to this issue). 

I opened https://github.com/crossplane/upjet/pull/333, to roll back upjet to that commit, and then built this off of that revision.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1071 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Uptest