### PR TITLE
[docdb]: Add autoGeneratePassword capability to Cluster

### DIFF
--- a/apis/docdb/v1beta1/zz_cluster_types.go
+++ b/apis/docdb/v1beta1/zz_cluster_types.go
@@ -250,6 +250,11 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	ApplyImmediately *bool `json:"applyImmediately,omitempty" tf:"apply_immediately,omitempty"`
 
+	// If true, the password will be auto-generated and stored in the Secret referenced by the masterPasswordSecretRef field.
+	// +upjet:crd:field:TFTag=-
+	// +kubebuilder:validation:Optional
+	AutoGeneratePassword *bool `json:"autoGeneratePassword,omitempty" tf:"-"`
+
 	// A list of EC2 Availability Zones that
 	// instances in the DB cluster can be created in.
 	// +kubebuilder:validation:Optional
@@ -319,6 +324,7 @@ type ClusterParameters struct {
 
 	// Password for the master DB user. Note that this may
 	// show up in logs, and it will be stored in the state file. Please refer to the DocumentDB Naming Constraints.
+	// Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one.
 	// +kubebuilder:validation:Optional
 	MasterPasswordSecretRef *v1.SecretKeySelector `json:"masterPasswordSecretRef,omitempty" tf:"-"`
 

--- a/apis/docdb/v1beta1/zz_generated.deepcopy.go
+++ b/apis/docdb/v1beta1/zz_generated.deepcopy.go
@@ -1229,6 +1229,11 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AutoGeneratePassword != nil {
+		in, out := &in.AutoGeneratePassword, &out.AutoGeneratePassword
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AvailabilityZones != nil {
 		in, out := &in.AvailabilityZones, &out.AvailabilityZones
 		*out = make([]*string, len(*in))

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -5,10 +5,21 @@ Copyright 2021 Upbound Inc.
 package common
 
 import (
+	"context"
+
+	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/password"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/upjet/pkg/config"
 	"github.com/crossplane/upjet/pkg/resource"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -26,6 +37,9 @@ const (
 	// VersionV1Beta1 is used for resources that meet the v1beta1 criteria
 	// here: https://github.com/upbound/arch/pull/33
 	VersionV1Beta1 = "v1beta1"
+
+	// ErrGetPasswordSecret is an error string for failing to get password secret
+	ErrGetPasswordSecret = "cannot get password secret"
 )
 
 // ARNExtractor extracts ARN of the resources from "status.atProvider.arn" which
@@ -55,5 +69,60 @@ func TerraformID() reference.ExtractValueFn {
 			return ""
 		}
 		return tr.GetID()
+	}
+}
+
+// PasswordGenerator returns an InitializerFn that will generate a password
+// for a resource if the toggle field is set to true and the secret referenced
+// by the secretRefFieldPath is not found or does not have content corresponding
+// to the password key.
+func PasswordGenerator(secretRefFieldPath, toggleFieldPath string) config.NewInitializerFn { //nolint:gocyclo
+	// NOTE(muvaf): This function is just 1 point over the cyclo limit but there
+	// is no easy way to reduce it without making it harder to read.
+	return func(client client.Client) managed.Initializer {
+		return managed.InitializerFn(func(ctx context.Context, mg xpresource.Managed) error {
+			paved, err := fieldpath.PaveObject(mg)
+			if err != nil {
+				return errors.Wrap(err, "cannot pave object")
+			}
+			sel := &v1.SecretKeySelector{}
+			if err := paved.GetValueInto(secretRefFieldPath, sel); err != nil {
+				return errors.Wrapf(xpresource.Ignore(fieldpath.IsNotFound, err), "cannot unmarshal %s into a secret key selector", secretRefFieldPath)
+			}
+			s := &corev1.Secret{}
+			if err := client.Get(ctx, types.NamespacedName{Namespace: sel.Namespace, Name: sel.Name}, s); xpresource.IgnoreNotFound(err) != nil {
+				return errors.Wrap(err, ErrGetPasswordSecret)
+			}
+			if err == nil && len(s.Data[sel.Key]) != 0 {
+				// Password is already set.
+				return nil
+			}
+			// At this point, either the secret doesn't exist, or it doesn't
+			// have the password filled.
+			if gen, err := paved.GetBool(toggleFieldPath); err != nil || !gen {
+				// If there is error, then we return that.
+				// If the toggle field is not set to true, then we return nil.
+				// Because we don't want to generate a password if the user
+				// doesn't want to.
+				return errors.Wrapf(xpresource.Ignore(fieldpath.IsNotFound, err), "cannot get the value of %s", toggleFieldPath)
+			}
+			pw, err := password.Generate()
+			if err != nil {
+				return errors.Wrap(err, "cannot generate password")
+			}
+			s.SetName(sel.Name)
+			s.SetNamespace(sel.Namespace)
+			if !meta.WasCreated(s) {
+				// We don't want to own the Secret if it is created by someone
+				// else, otherwise the deletion of the managed resource will
+				// delete the Secret that we didn't create in the first place.
+				meta.AddOwnerReference(s, meta.AsOwner(meta.TypedReferenceTo(mg, mg.GetObjectKind().GroupVersionKind())))
+			}
+			if s.Data == nil {
+				s.Data = make(map[string][]byte, 1)
+			}
+			s.Data[sel.Key] = []byte(pw)
+			return errors.Wrap(xpresource.NewAPIPatchingApplicator(client).Apply(ctx, s), "cannot apply password secret")
+		})
 	}
 }

--- a/config/common/common_test.go
+++ b/config/common/common_test.go
@@ -2,7 +2,7 @@
 Copyright 2023 Upbound Inc.
 */
 
-package rds
+package common
 
 import (
 	"context"

--- a/config/common/common_test.go
+++ b/config/common/common_test.go
@@ -53,7 +53,7 @@ func TestPasswordGenerator(t *testing.T) {
 				mg:                 &fake.Managed{},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errGetPasswordSecret),
+				err: errors.Wrap(errBoom, ErrGetPasswordSecret),
 			},
 		},
 		"SecretAlreadyFull": {

--- a/examples/docdb/v1beta1/cluster.yaml
+++ b/examples/docdb/v1beta1/cluster.yaml
@@ -14,6 +14,7 @@ spec:
     region: us-west-2
     engine: "docdb"
     backupRetentionPeriod: 5
+    autoGeneratePassword: true
     masterPasswordSecretRef:
       key: password
       name: docdb-creds
@@ -24,21 +25,6 @@ spec:
     dbClusterParameterGroupNameSelector:
       matchLabels:
         testing.upbound.io/example-name: docdb-cluster-test
-
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  annotations:
-    meta.upbound.io/example-id: docdb/v1beta1/cluster
-  labels:
-    testing.upbound.io/example-name: docdb-creds
-  name: docdb-creds
-  namespace: upbound-system
-type: Opaque
-stringData:
-  password: "Upboundtest!"
 
 ---
 

--- a/package/crds/docdb.aws.upbound.io_clusters.yaml
+++ b/package/crds/docdb.aws.upbound.io_clusters.yaml
@@ -79,6 +79,11 @@ spec:
                       immediately, or during the next maintenance window. Default
                       is false.
                     type: boolean
+                  autoGeneratePassword:
+                    description: If true, the password will be auto-generated and
+                      stored in the Secret referenced by the masterPasswordSecretRef
+                      field.
+                    type: boolean
                   availabilityZones:
                     description: A list of EC2 Availability Zones that instances in
                       the DB cluster can be created in.
@@ -278,7 +283,10 @@ spec:
                   masterPasswordSecretRef:
                     description: Password for the master DB user. Note that this may
                       show up in logs, and it will be stored in the state file. Please
-                      refer to the DocumentDB Naming Constraints.
+                      refer to the DocumentDB Naming Constraints. Password for the
+                      master DB user. If you set autoGeneratePassword to true, the
+                      Secret referenced here will be created or updated with generated
+                      password if it does not already contain one.
                     properties:
                       key:
                         description: The key to select.


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
* Move `PasswordGenerator` function to common location
* Enable `autoGeneratePassword` to docdb `Cluster`
* Fixes https://github.com/upbound/provider-aws/issues/1105

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
k get -f examples/docdb/cluster.yaml
NAME                                            READY   SYNCED   EXTERNAL-NAME      AGE
cluster.docdb.aws.upbound.io/my-docdb-cluster   True    True     my-docdb-cluster   3m11s

NAME                                                 READY   SYNCED   EXTERNAL-NAME   AGE
clusterparametergroup.docdb.aws.upbound.io/example   True    True     example         3m11s

k view-secret -n upbound-system docdb-creds
Choosing key: password
yQgj05GTSj0d9HDodzRZDMcmB2B%

k view-secret -n upbound-system docdb-cluster-secret password
yQgj05GTSj0d9HDodzRZDMcmB2B%
```
