### PR TITLE
Add an example manifest for ReplicationGroup.elasticache with "engineVersion"

### DIFF
--- a/examples/elasticache/v1beta1/replicationgroup-engineVersion.yaml
+++ b/examples/elasticache/v1beta1/replicationgroup-engineVersion.yaml
@@ -9,12 +9,11 @@ metadata:
   name: example-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
+    engineVersion: "7.1"
     automaticFailoverEnabled: true
     description: example description
     nodeType: cache.m4.large
     numCacheClusters: 2
+    parameterGroupName: default.redis7
     port: 6379
-    preferredCacheClusterAzs:
-      - us-west-1a
-      - us-west-1b
     region: us-west-1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/smithy-go v1.19.0
 	github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a2f5
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
-	github.com/crossplane/upjet v1.1.0-rc.0.0.20240130134554-62169a1988bf
+	github.com/crossplane/upjet v1.1.0-rc.0.0.20240131173221-3c2fda9d6737
 	github.com/go-ini/ini v1.46.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/terraform-json v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a
 github.com/crossplane/crossplane-runtime v1.15.0-rc.0.0.20231215091746-d23a82b3a2f5/go.mod h1:pgt7PaTvvOQz3jILyxbCaeleU9MrAqKaNoPJavhGBgM=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
-github.com/crossplane/upjet v1.1.0-rc.0.0.20240130134554-62169a1988bf h1:Jh9qOgjgIpVyUmG887QmockrttJrKZfFDHAd4DXrLO8=
-github.com/crossplane/upjet v1.1.0-rc.0.0.20240130134554-62169a1988bf/go.mod h1:vBJuP6Ua4ssZNONpMnkCJG6K3arL5LHVOXkAiL6RO2g=
+github.com/crossplane/upjet v1.1.0-rc.0.0.20240131173221-3c2fda9d6737 h1:L2qEPKaQxbaiHcFIJb54y8AfuBHfbUDaWvQ6p8+MzF8=
+github.com/crossplane/upjet v1.1.0-rc.0.0.20240131173221-3c2fda9d6737/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds a new example manifest for the `ReplicationGroup.elasticache` resource with an explicit `engineVersion` as a regression test for #1071. We keep the original example manifest, which does not mention an explicit engine version, and thus requires less maintenance on our side (e.g., when the explicitly referenced engine version is no longer available).

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Via uptest runs:
- Manifest with engine version: https://github.com/upbound/provider-aws/actions/runs/7730125050
- Generic manifest: https://github.com/upbound/provider-aws/actions/runs/7730127617