### PR TITLE
fix(userdata): remove user_data and switch user_data_base64 to sensitive

### DIFF
--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -14797,16 +14797,6 @@ func (in *InstanceInitParameters) DeepCopyInto(out *InstanceInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.UserData != nil {
-		in, out := &in.UserData, &out.UserData
-		*out = new(string)
-		**out = **in
-	}
-	if in.UserDataBase64 != nil {
-		in, out := &in.UserDataBase64, &out.UserDataBase64
-		*out = new(string)
-		**out = **in
-	}
 	if in.UserDataReplaceOnChange != nil {
 		in, out := &in.UserDataReplaceOnChange, &out.UserDataReplaceOnChange
 		*out = new(bool)
@@ -15560,11 +15550,6 @@ func (in *InstanceObservation) DeepCopyInto(out *InstanceObservation) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.UserDataBase64 != nil {
-		in, out := &in.UserDataBase64, &out.UserDataBase64
-		*out = new(string)
-		**out = **in
-	}
 	if in.UserDataReplaceOnChange != nil {
 		in, out := &in.UserDataReplaceOnChange, &out.UserDataReplaceOnChange
 		*out = new(bool)
@@ -15876,14 +15861,9 @@ func (in *InstanceParameters) DeepCopyInto(out *InstanceParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.UserData != nil {
-		in, out := &in.UserData, &out.UserData
-		*out = new(string)
-		**out = **in
-	}
-	if in.UserDataBase64 != nil {
-		in, out := &in.UserDataBase64, &out.UserDataBase64
-		*out = new(string)
+	if in.UserDataBase64SecretRef != nil {
+		in, out := &in.UserDataBase64SecretRef, &out.UserDataBase64SecretRef
+		*out = new(v1.SecretKeySelector)
 		**out = **in
 	}
 	if in.UserDataReplaceOnChange != nil {

--- a/apis/ec2/v1beta1/zz_instance_terraformed.go
+++ b/apis/ec2/v1beta1/zz_instance_terraformed.go
@@ -25,7 +25,7 @@ func (mg *Instance) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this Instance
 func (tr *Instance) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"user_data_base64": "spec.forProvider.userDataBase64SecretRef"}
 }
 
 // GetObservation of this Instance

--- a/apis/ec2/v1beta1/zz_instance_types.go
+++ b/apis/ec2/v1beta1/zz_instance_types.go
@@ -457,12 +457,6 @@ type InstanceInitParameters struct {
 	// Tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command. Valid values are default, dedicated, and host.
 	Tenancy *string `json:"tenancy,omitempty" tf:"tenancy,omitempty"`
 
-	// User data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user_data_base64 instead. Updates to this field will trigger a stop/start of the EC2 instance by default. If the user_data_replace_on_change is set then updates to this field will trigger a destroy and recreate.
-	UserData *string `json:"userData,omitempty" tf:"user_data,omitempty"`
-
-	// Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. Updates to this field will trigger a stop/start of the EC2 instance by default. If the user_data_replace_on_change is set then updates to this field will trigger a destroy and recreate.
-	UserDataBase64 *string `json:"userDataBase64,omitempty" tf:"user_data_base64,omitempty"`
-
 	// When used in combination with user_data or user_data_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set.
 	UserDataReplaceOnChange *bool `json:"userDataReplaceOnChange,omitempty" tf:"user_data_replace_on_change,omitempty"`
 
@@ -750,9 +744,6 @@ type InstanceObservation struct {
 	// User data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user_data_base64 instead. Updates to this field will trigger a stop/start of the EC2 instance by default. If the user_data_replace_on_change is set then updates to this field will trigger a destroy and recreate.
 	UserData *string `json:"userData,omitempty" tf:"user_data,omitempty"`
 
-	// Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. Updates to this field will trigger a stop/start of the EC2 instance by default. If the user_data_replace_on_change is set then updates to this field will trigger a destroy and recreate.
-	UserDataBase64 *string `json:"userDataBase64,omitempty" tf:"user_data_base64,omitempty"`
-
 	// When used in combination with user_data or user_data_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set.
 	UserDataReplaceOnChange *bool `json:"userDataReplaceOnChange,omitempty" tf:"user_data_replace_on_change,omitempty"`
 
@@ -943,13 +934,9 @@ type InstanceParameters struct {
 	// +kubebuilder:validation:Optional
 	Tenancy *string `json:"tenancy,omitempty" tf:"tenancy,omitempty"`
 
-	// User data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user_data_base64 instead. Updates to this field will trigger a stop/start of the EC2 instance by default. If the user_data_replace_on_change is set then updates to this field will trigger a destroy and recreate.
-	// +kubebuilder:validation:Optional
-	UserData *string `json:"userData,omitempty" tf:"user_data,omitempty"`
-
 	// Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. Updates to this field will trigger a stop/start of the EC2 instance by default. If the user_data_replace_on_change is set then updates to this field will trigger a destroy and recreate.
 	// +kubebuilder:validation:Optional
-	UserDataBase64 *string `json:"userDataBase64,omitempty" tf:"user_data_base64,omitempty"`
+	UserDataBase64SecretRef *v1.SecretKeySelector `json:"userDataBase64SecretRef,omitempty" tf:"-"`
 
 	// When used in combination with user_data or user_data_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set.
 	// +kubebuilder:validation:Optional

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -54,6 +54,8 @@ func Configure(p *config.Provider) {
 			},
 		}
 		config.MoveToStatus(r.TerraformResource, "security_groups")
+		r.TerraformResource.Schema["user_data_base64"].Sensitive = true
+		config.MoveToStatus(r.TerraformResource, "user_data")
 	})
 	p.AddResourceConfigurator("aws_eip", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{

--- a/examples/ec2/v1beta1/instance.yaml
+++ b/examples/ec2/v1beta1/instance.yaml
@@ -1,8 +1,7 @@
 apiVersion: ec2.aws.upbound.io/v1beta1
-kind: Instance
+kind: VPC
 metadata:
   annotations:
-    uptest.upbound.io/timeout: "3600"
     meta.upbound.io/example-id: ec2/v1beta1/instance
   labels:
     testing.upbound.io/example-name: sample-instance
@@ -10,20 +9,16 @@ metadata:
 spec:
   forProvider:
     region: us-west-1
-    ami: ami-07b068f843ec78e72
-    instanceType: t2.micro
-    networkInterface:
-    - deviceIndex: 0
-      networkInterfaceIdSelector:
-        matchLabels:
-          testing.upbound.io/example-name: sample-instance
-    creditSpecification:
-    - cpuCredits: unlimited
+    cidrBlock: 172.16.0.0/16
+    enableDnsHostnames: true
+    enableDnsSupport: true
+    tags:
+      Name: DemoVpc
 
 ---
 
 apiVersion: ec2.aws.upbound.io/v1beta1
-kind: NetworkInterface
+kind: InternetGateway
 metadata:
   annotations:
     meta.upbound.io/example-id: ec2/v1beta1/instance
@@ -33,11 +28,11 @@ metadata:
 spec:
   forProvider:
     region: us-west-1
-    subnetIdSelector:
+    tags:
+      Name: DemoIGW
+    vpcIdSelector:
       matchLabels:
         testing.upbound.io/example-name: sample-instance
-    privateIps:
-      - "172.16.10.100"
 
 ---
 
@@ -47,8 +42,8 @@ metadata:
   annotations:
     meta.upbound.io/example-id: ec2/v1beta1/instance
   labels:
-    testing.upbound.io/example-name: sample-instance
-  name: sample-instance
+    testing.upbound.io/example-name: sample-instance-private
+  name: sample-instance-private
 spec:
   forProvider:
     region: us-west-1
@@ -61,7 +56,48 @@ spec:
 ---
 
 apiVersion: ec2.aws.upbound.io/v1beta1
-kind: VPC
+kind: Subnet
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance-public
+  name: sample-instance-public
+spec:
+  forProvider:
+    region: us-west-1
+    availabilityZone: us-west-1b
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+    cidrBlock: 172.16.11.0/24
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: NATGateway
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance
+  name: example
+spec:
+  forProvider:
+    region: us-west-1
+    allocationIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+    subnetIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-public
+    tags:
+      Name: DemoNATGW
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: EIP
 metadata:
   annotations:
     meta.upbound.io/example-id: ec2/v1beta1/instance
@@ -71,6 +107,411 @@ metadata:
 spec:
   forProvider:
     region: us-west-1
-    cidrBlock: 172.16.0.0/16
+    vpc: true
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: RouteTable
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance-private
+  name: sample-instance-private
+spec:
+  forProvider:
+    region: us-west-1
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: RouteTable
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance-public
+  name: sample-instance-public
+spec:
+  forProvider:
+    region: us-west-1
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Route
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance-public
+  name: sample-instance-public
+spec:
+  forProvider:
+    destinationCidrBlock: 0.0.0.0/0
+    gatewayIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+    region: us-west-1
+    routeTableIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-public
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Route
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance-private
+  name: sample-instance-private
+spec:
+  forProvider:
+    destinationCidrBlock: 0.0.0.0/0
+    natGatewayIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+    region: us-west-1
+    routeTableIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-private
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: RouteTableAssociation
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance-private
+  name: sample-instance-private
+spec:
+  forProvider:
+    region: us-west-1
+    routeTableIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-private
+    subnetIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-private
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: RouteTableAssociation
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance-public
+  name: sample-instance-public
+spec:
+  forProvider:
+    region: us-west-1
+    routeTableIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-public
+    subnetIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-public
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: ec2-instance
+  name: ec2-instance
+spec:
+  forProvider:
+    description: ec2-instance
+    name: ec2-instance
+    region: us-west-1
     tags:
-      Name: DemoVpc
+      Name: sg-ec2
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroupEgressRule
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: ec2-instance-443-outbound
+  name: ec2-instance-443-outbound
+spec:
+  forProvider:
+    cidrIpv4: 0.0.0.0/0
+    fromPort: 443
+    ipProtocol: tcp
+    region: us-west-1
+    securityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ec2-instance
+    toPort: 443
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: ec2-endpoint
+  name: ec2-endpoint
+spec:
+  forProvider:
+    description: ec2-endpoint
+    name: ec2-endpoint
+    region: us-west-1
+    tags:
+      Name: sg-ec2
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroupIngressRule
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: ec2-endpoint-443-inbound
+  name: ec2-endpoint-443-inbound
+spec:
+  forProvider:
+    cidrIpv4: 172.16.0.0/16
+    fromPort: 443
+    ipProtocol: tcp
+    region: us-west-1
+    securityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ec2-endpoint
+    toPort: 443
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCEndpoint
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: ec2messages
+  name: ec2messages
+spec:
+  forProvider:
+    region: us-west-1
+    serviceName: com.amazonaws.us-west-1.ec2messages
+    vpcEndpointType: Interface
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCEndpoint
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: ssmmessages
+  name: ssmmessages
+spec:
+  forProvider:
+    region: us-west-1
+    serviceName: com.amazonaws.us-west-1.ssmmessages
+    vpcEndpointType: Interface
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCEndpoint
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: ssm
+  name: ssm
+spec:
+  forProvider:
+    region: us-west-1
+    serviceName: com.amazonaws.us-west-1.ssm
+    vpcEndpointType: Interface
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCEndpointSecurityGroupAssociation
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sg-ec2messages-vpcendpoint
+  name: sg-ec2messages-vpcendpoint
+spec:
+  forProvider:
+    region: us-west-1
+    securityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ec2-endpoint
+    vpcEndpointIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ec2messages
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCEndpointSecurityGroupAssociation
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sg-ssmmessages-vpcendpoint
+  name: sg-ssmmessages-vpcendpoint
+spec:
+  forProvider:
+    region: us-west-1
+    securityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ec2-endpoint
+    vpcEndpointIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ssmmessages
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPCEndpointSecurityGroupAssociation
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sg-ssm-vpcendpoint
+  name: sg-ssm-vpcendpoint
+spec:
+  forProvider:
+    region: us-west-1
+    securityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ec2-endpoint
+    vpcEndpointIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ssm
+
+---
+
+
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance
+  name: sample-instance
+spec:
+  forProvider:
+    managedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
+
+---
+
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: InstanceProfile
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance
+  name: sample-instance
+spec:
+  forProvider:
+    roleSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance
+
+---
+
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    uptest.upbound.io/timeout: "3600"
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance
+  name: sample-instance
+spec:
+  forProvider:
+    region: us-west-1
+    ami: ami-015e832ac6a60f0de
+    instanceType: t2.micro
+    vpcSecurityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: ec2-instance
+    subnetIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-instance-private
+    iamInstanceProfile: sample-instance
+    userDataBase64SecretRef:
+      key: userdata
+      name: instance-user-data
+      namespace: upbound-system
+    creditSpecification:
+    - cpuCredits: unlimited
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ec2/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: sample-instance
+  name: instance-user-data
+  namespace: upbound-system
+type: Opaque
+stringData:
+  userdata: ICAgICMhL2Jpbi9iYXNoCiAgICBzdWRvIGFwdC1nZXQgdXBkYXRlCg==

--- a/package/crds/ec2.aws.upbound.io_instances.yaml
+++ b/package/crds/ec2.aws.upbound.io_instances.yaml
@@ -865,15 +865,7 @@ spec:
                       hardware. The host tenancy is not supported for the import-instance
                       command. Valid values are default, dedicated, and host.
                     type: string
-                  userData:
-                    description: User data to provide when launching the instance.
-                      Do not pass gzip-compressed data via this argument; see user_data_base64
-                      instead. Updates to this field will trigger a stop/start of
-                      the EC2 instance by default. If the user_data_replace_on_change
-                      is set then updates to this field will trigger a destroy and
-                      recreate.
-                    type: string
-                  userDataBase64:
+                  userDataBase64SecretRef:
                     description: Can be used instead of user_data to pass base64-encoded
                       binary data directly. Use this instead of user_data whenever
                       the value is not a valid UTF-8 string. For example, gzip-encoded
@@ -882,7 +874,21 @@ spec:
                       of the EC2 instance by default. If the user_data_replace_on_change
                       is set then updates to this field will trigger a destroy and
                       recreate.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   userDataReplaceOnChange:
                     description: When used in combination with user_data or user_data_base64
                       will trigger a destroy and recreate when set to true. Defaults
@@ -1786,24 +1792,6 @@ spec:
                       hardware. The host tenancy is not supported for the import-instance
                       command. Valid values are default, dedicated, and host.
                     type: string
-                  userData:
-                    description: User data to provide when launching the instance.
-                      Do not pass gzip-compressed data via this argument; see user_data_base64
-                      instead. Updates to this field will trigger a stop/start of
-                      the EC2 instance by default. If the user_data_replace_on_change
-                      is set then updates to this field will trigger a destroy and
-                      recreate.
-                    type: string
-                  userDataBase64:
-                    description: Can be used instead of user_data to pass base64-encoded
-                      binary data directly. Use this instead of user_data whenever
-                      the value is not a valid UTF-8 string. For example, gzip-encoded
-                      user data must be base64-encoded and passed via this argument
-                      to avoid corruption. Updates to this field will trigger a stop/start
-                      of the EC2 instance by default. If the user_data_replace_on_change
-                      is set then updates to this field will trigger a destroy and
-                      recreate.
-                    type: string
                   userDataReplaceOnChange:
                     description: When used in combination with user_data or user_data_base64
                       will trigger a destroy and recreate when set to true. Defaults
@@ -2633,16 +2621,6 @@ spec:
                       Do not pass gzip-compressed data via this argument; see user_data_base64
                       instead. Updates to this field will trigger a stop/start of
                       the EC2 instance by default. If the user_data_replace_on_change
-                      is set then updates to this field will trigger a destroy and
-                      recreate.
-                    type: string
-                  userDataBase64:
-                    description: Can be used instead of user_data to pass base64-encoded
-                      binary data directly. Use this instead of user_data whenever
-                      the value is not a valid UTF-8 string. For example, gzip-encoded
-                      user data must be base64-encoded and passed via this argument
-                      to avoid corruption. Updates to this field will trigger a stop/start
-                      of the EC2 instance by default. If the user_data_replace_on_change
                       is set then updates to this field will trigger a destroy and
                       recreate.
                     type: string


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

- Remove the `user_data` attribute from `aws_instance` because it has encoding problems (The `user_data` attribute on `aws_instance` has always been defined with a special `StateFunc` `<<EOF ... >>`)
 
- Instead, use `user_data_base64` and mark it as sensitive since it can include sensitive info like keys or API tokens, and it takes input from Kubernetes secrets.
- Update the example that we can connect use SSM Connect to check the user-data.txt on an EC2 instance.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1109

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

![image](https://github.com/upbound/provider-aws/assets/21083497/2251ec71-fed3-484e-ba71-ce615842c6d2)

```
kubectl get managed
NAME                                               READY   SYNCED   EXTERNAL-NAME                       AGE
route.ec2.aws.upbound.io/sample-instance-private   True    True     r-rtb-02c0d8aec6c5cc51b1080289494   7m49s
route.ec2.aws.upbound.io/sample-instance-public    True    True     r-rtb-00486f2b3b2d5de091080289494   7m49s

NAME                                     READY   SYNCED   EXTERNAL-NAME                AGE
eip.ec2.aws.upbound.io/sample-instance   True    True     eipalloc-07d53fc98d0d94ea4   7m49s

NAME                                          READY   SYNCED   EXTERNAL-NAME         AGE
instance.ec2.aws.upbound.io/sample-instance   True    True     i-0e3cbe60e415e8ed2   7m49s

NAME                                                 READY   SYNCED   EXTERNAL-NAME           AGE
internetgateway.ec2.aws.upbound.io/sample-instance   True    True     igw-0bb15566dbaf40181   7m49s

NAME                                    READY   SYNCED   EXTERNAL-NAME           AGE
natgateway.ec2.aws.upbound.io/example   True    True     nat-080c050eaec2489a1   7m49s

NAME                                                               READY   SYNCED   EXTERNAL-NAME                AGE
routetableassociation.ec2.aws.upbound.io/sample-instance-private   True    True     rtbassoc-0711b53b0c4434edc   7m49s
routetableassociation.ec2.aws.upbound.io/sample-instance-public    True    True     rtbassoc-06a8de24d103e8c85   7m49s

NAME                                                    READY   SYNCED   EXTERNAL-NAME           AGE
routetable.ec2.aws.upbound.io/sample-instance-private   True    True     rtb-02c0d8aec6c5cc51b   7m49s
routetable.ec2.aws.upbound.io/sample-instance-public    True    True     rtb-00486f2b3b2d5de09   7m49s

NAME                                                                   READY   SYNCED   EXTERNAL-NAME           AGE
securitygroupegressrule.ec2.aws.upbound.io/ec2-instance-443-outbound   True    True     sgr-0ba17697a5e2f9952   7m49s

NAME                                                                   READY   SYNCED   EXTERNAL-NAME           AGE
securitygroupingressrule.ec2.aws.upbound.io/ec2-endpoint-443-inbound   True    True     sgr-06e952c213434ed4d   7m49s

NAME                                            READY   SYNCED   EXTERNAL-NAME          AGE
securitygroup.ec2.aws.upbound.io/ec2-endpoint   True    True     sg-07e2062a45b6dfc49   7m49s
securitygroup.ec2.aws.upbound.io/ec2-instance   True    True     sg-0f1636ed5da2b8634   7m49s

NAME                                                READY   SYNCED   EXTERNAL-NAME              AGE
subnet.ec2.aws.upbound.io/sample-instance-private   True    True     subnet-0e0e6764869309358   7m49s
subnet.ec2.aws.upbound.io/sample-instance-public    True    True     subnet-0f1922dcfeba4e573   7m49s

NAME                                         READY   SYNCED   EXTERNAL-NAME            AGE
vpcendpoint.ec2.aws.upbound.io/ec2messages   True    True     vpce-0a0a0cfb52e9843aa   7m49s
vpcendpoint.ec2.aws.upbound.io/ssm           True    True     vpce-08ab6ba10b373c7bc   7m49s
vpcendpoint.ec2.aws.upbound.io/ssmmessages   True    True     vpce-0b81871da9d1d12f6   7m49s

NAME                                                                                READY   SYNCED   EXTERNAL-NAME                        AGE
vpcendpointsecuritygroupassociation.ec2.aws.upbound.io/sg-ec2messages-vpcendpoint   True    True     a-vpce-0a0a0cfb52e9843aa4026951556   7m49s
vpcendpointsecuritygroupassociation.ec2.aws.upbound.io/sg-ssm-vpcendpoint           True    True     a-vpce-08ab6ba10b373c7bc4026951556   7m49s
vpcendpointsecuritygroupassociation.ec2.aws.upbound.io/sg-ssmmessages-vpcendpoint   True    True     a-vpce-0b81871da9d1d12f64026951556   7m49s

NAME                                     READY   SYNCED   EXTERNAL-NAME           AGE
vpc.ec2.aws.upbound.io/sample-instance   True    True     vpc-013e3ee886a92717a   7m49s

NAME                                                 READY   SYNCED   EXTERNAL-NAME     AGE
instanceprofile.iam.aws.upbound.io/sample-instance   True    True     sample-instance   7m49s

NAME                                      READY   SYNCED   EXTERNAL-NAME     AGE
role.iam.aws.upbound.io/sample-instance   True    True     sample-instance   7m49s
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
