### PR TITLE
fix Secret/secretmanager.aws custom diff logic when replica config is empty

### DIFF
--- a/config/secretsmanager/config.go
+++ b/config/secretsmanager/config.go
@@ -35,13 +35,25 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				return diff, nil
 			}
 
+			resData, err := schema.InternalMap(r.TerraformResource.SchemaMap()).Data(state, diff)
+			if err != nil {
+				return nil, errors.New("could not construct resource data")
+			}
+
+			// do not customize diff if replica field has no change
+			if !resData.HasChange("replica") {
+				return diff, nil
+			}
 			currentReplicaSet, ok := r.TerraformResource.Data(state).Get("replica").(*schema.Set)
 			if !ok {
 				return nil, errors.New("could not read \"replica\" from state")
 			}
+
 			nisReplica, ok := config.Get("replica")
 			if !ok {
-				return nil, errors.New("could not read replica block from config")
+				// config is empty for replica, no need for custom diff logic
+				// this is already handled correctly with the built-in diff logic
+				return diff, nil
 			}
 			desiredReplicaList := nisReplica.([]interface{})
 			// this is the hash implementation of *schema.Set, which is unexported

--- a/examples/secretsmanager/v1beta1/secret-withreplica.yaml
+++ b/examples/secretsmanager/v1beta1/secret-withreplica.yaml
@@ -4,11 +4,13 @@ metadata:
   name: example-withreplica
   annotations:
     meta.upbound.io/example-id: secretsmanager/v1beta1/secret
+    uptest.upbound.io/update-parameter: '{"tags":{"updated-by":"crossplane"}}'
   labels:
     testing.upbound.io/example-name: secretsmanager
 spec:
   forProvider:
     name: example-withreplica-${Rand.RFC1123Subdomain}
+    recoveryWindowInDays: 0
     region: us-west-1
     replica:
       - region: us-west-2

--- a/examples/secretsmanager/v1beta1/secret.yaml
+++ b/examples/secretsmanager/v1beta1/secret.yaml
@@ -4,9 +4,11 @@ metadata:
   name: example
   annotations:
     meta.upbound.io/example-id: secretsmanager/v1beta1/secret
+    uptest.upbound.io/update-parameter: '{"tags":{"updated-by":"crossplane"}}'
   labels:
     testing.upbound.io/example-name: secretsmanager
 spec:
   forProvider:
     name: example-${Rand.RFC1123Subdomain}
     region: us-west-1
+    recoveryWindowInDays: 0


### PR DESCRIPTION
### Description of your changes

Fixes the custom diff logic (introduced at https://github.com/upbound/provider-aws/pull/1107) for `replica` attribute when it is not specified in the config and the diff does not involve `replica` field. The custom diff function is triggered for any update diff, and the current logic tries to read the `replica` field unconditionally. When `replica` is not specified in config, the get operation fails the whole custom diff function, therefore the Observe operation.

This change fixes the custom diff logic by: 
- early exit with no error when there is no change/diff involved for `replica`. We only need to change
- early exit with no error if `replica` attibute is not specified in the MR spec. This is already handled properly by the regular diff and needs no customization.
 
Fixes #1128 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with the spec at #1128
