### PR TITLE
[Backport release-0.47] Make endpoint provider configuration value single-element list

### DIFF
--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -199,7 +199,7 @@ func DefaultTerraformSetupBuilder(_ context.Context, pc *v1beta1.ProviderConfig,
 				for _, service := range pc.Spec.Endpoint.Services {
 					endpoints[service] = aws.ToString(pc.Spec.Endpoint.URL.Static)
 				}
-				ps.Configuration[keyEndpoints] = endpoints
+				ps.Configuration[keyEndpoints] = []any{endpoints}
 			}
 		}
 	}


### PR DESCRIPTION
# Description
Backport of #1066 to `release-0.47`.

Uptest Run: https://github.com/upbound/provider-aws/actions/runs/7929858398