### PR TITLE
rds.cluster: add ability to auto-generate password in referenced secret

### DIFF
--- a/apis/rds/v1beta1/zz_cluster_types.go
+++ b/apis/rds/v1beta1/zz_cluster_types.go
@@ -330,6 +330,13 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	AllocatedStorage *float64 `json:"allocatedStorage,omitempty" tf:"allocated_storage,omitempty"`
 
+	// Password for the master DB user. Note that this may show up in
+	// logs, and it will be stored in the state file. Cannot be set if manage_master_user_password is set to true.
+	// If true, the password will be auto-generated and stored in the Secret referenced by the passwordSecretRef field.
+	// +upjet:crd:field:TFTag=-
+	// +kubebuilder:validation:Optional
+	AutoGeneratePassword *bool `json:"autoGeneratePassword,omitempty" tf:"-"`
+
 	// Enable to allow major engine version upgrades when changing engine versions. Defaults to false.
 	// +kubebuilder:validation:Optional
 	AllowMajorVersionUpgrade *bool `json:"allowMajorVersionUpgrade,omitempty" tf:"allow_major_version_upgrade,omitempty"`

--- a/apis/rds/v1beta1/zz_generated.deepcopy.go
+++ b/apis/rds/v1beta1/zz_generated.deepcopy.go
@@ -2424,6 +2424,11 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		*out = new(float64)
 		**out = **in
 	}
+	if in.AutoGeneratePassword != nil {
+		in, out := &in.AutoGeneratePassword, &out.AutoGeneratePassword
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AllowMajorVersionUpgrade != nil {
 		in, out := &in.AllowMajorVersionUpgrade, &out.AllowMajorVersionUpgrade
 		*out = new(bool)

--- a/examples/rds/cluster.yaml
+++ b/examples/rds/cluster.yaml
@@ -9,6 +9,7 @@ spec:
     region: us-west-1
     engine: aurora-postgresql
     masterUsername: cpadmin
+    autoGeneratePassword: true
     masterPasswordSecretRef:
       name: sample-cluster-password
       namespace: upbound-system
@@ -17,12 +18,3 @@ spec:
   writeConnectionSecretToRef:
     name: sample-rds-cluster-secret
     namespace: upbound-system
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: sample-cluster-password
-  namespace: upbound-system
-type: Opaque
-stringData:
-  password: TestPass0!

--- a/package/crds/rds.aws.upbound.io_clusters.yaml
+++ b/package/crds/rds.aws.upbound.io_clusters.yaml
@@ -80,6 +80,13 @@ spec:
                       immediately, or during the next maintenance window. Default
                       is false. See Amazon RDS Documentation for more information.
                     type: boolean
+                  autoGeneratePassword:
+                    description: Password for the master DB user. Note that this may
+                      show up in logs, and it will be stored in the state file. Cannot
+                      be set if manage_master_user_password is set to true. If true,
+                      the password will be auto-generated and stored in the Secret
+                      referenced by the masterPasswordSecretRef field.
+                    type: boolean
                   availabilityZones:
                     description: List of EC2 Availability Zones for the DB cluster
                       storage where DB cluster instances can be created. We recommend
@@ -355,9 +362,11 @@ spec:
                     type: boolean
                   masterPasswordSecretRef:
                     description: Password for the master DB user. Note that this may
-                      show up in logs, and it will be stored in the state file. Please
-                      refer to the RDS Naming Constraints. Cannot be set if manage_master_user_password
-                      is set to true.
+                      show up in logs, and it will be stored in the state file. Cannot
+                      be set if manage_master_user_password is set to true. Password
+                      for the master DB user. If you set autoGeneratePassword to true,
+                      the Secret referenced here will be created or updated with generated
+                      password if it does not already contain one.
                     properties:
                       key:
                         description: The key to select.


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Adds the ability to auto-generate password for the rds cluster. This was already added for the RDS instance in the PR [#628](https://github.com/upbound/provider-aws/pull/628). Users need to opt-in by setting autoGeneratePassword as true while creating RDS cluster and should have a Secret reference. It will create if the referenced Secret does not exist and it will populate if it doesn't have the password for the given key.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Unit tests, local end-to-end test.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
