### PR TITLE
Consume the reusable workflows from upbound/uptest@standard-runners

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   backport:
-    uses: upbound/uptest/.github/workflows/provider-backport.yml@main
+    uses: upbound/uptest/.github/workflows/provider-backport.yml@standard-runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    uses: upbound/uptest/.github/workflows/provider-ci.yml@main
+    uses: upbound/uptest/.github/workflows/provider-ci.yml@standard-runners
     with:
       go-version: "1.21"
       golangci-skip: true # we will run the linter via "make lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       go-version: "1.21"
       golangci-skip: true # we will run the linter via "make lint"
+      cleanup-disk: true
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
       UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -4,4 +4,4 @@ on: issue_comment
 
 jobs:
   comment-commands:
-    uses: upbound/uptest/.github/workflows/provider-commands.yml@main
+    uses: upbound/uptest/.github/workflows/provider-commands.yml@standard-runners

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   e2e:
-    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
+    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@standard-runners
     with:
       go-version: 1.21
     secrets:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,7 @@ jobs:
     uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@standard-runners
     with:
       go-version: 1.21
+      cleanup-disk: true
     secrets:
       UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
       UPTEST_DATASOURCE: ${{ secrets.UPTEST_DATASOURCE }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   community-issue-triage:
-    uses: upbound/uptest/.github/workflows/issue-triage.yml@main
+    uses: upbound/uptest/.github/workflows/issue-triage.yml@standard-runners
     secrets:
       UPBOUND_BOT_GITHUB_TOKEN: ${{ secrets.UPBOUND_COMMUNITY_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   open-bump-pr:
-    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@main
+    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@standard-runners
     with:
       provider-source: hashicorp/aws
       go-version: 1.21

--- a/.github/workflows/publish-service-artifacts.yml
+++ b/.github/workflows/publish-service-artifacts.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   publish-service-artifacts:
-    uses: upbound/uptest/.github/workflows/provider-publish-service-artifacts.yml@main
+    uses: upbound/uptest/.github/workflows/provider-publish-service-artifacts.yml@standard-runners
     with:
       subpackages: ${{ github.event.inputs.subpackages }}
       size: ${{ github.event.inputs.size }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -40,7 +40,7 @@ jobs:
           echo "We are going to scan the last ${supported_releases_number} releases for: ${images}"
 
   scan:
-    uses: upbound/uptest/.github/workflows/scan.yml@main
+    uses: upbound/uptest/.github/workflows/scan.yml@standard-runners
     needs:
       - setup-vars
     with:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   tag:
-    uses: upbound/uptest/.github/workflows/provider-tag.yml@main
+    uses: upbound/uptest/.github/workflows/provider-tag.yml@standard-runners
     with:
       version: ${{ github.event.inputs.version }}
       message: ${{ github.event.inputs.message }}

--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-docs:
-    uses: upbound/uptest/.github/workflows/provider-updoc.yml@main
+    uses: upbound/uptest/.github/workflows/provider-updoc.yml@standard-runners
     with:
       providers: "monolith config"
       go-version: 1.21


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Relevant PR: https://github.com/upbound/uptest/pull/184

This PR replaces the larger runners we are using for the:
- `e2e`, `publish-service-artifacts` workflows
- `lint`, `publish-artifacts` jobs
to the standard `ubuntu-22.04` workflow runners. This will also allow us to check whether any CI jobs need larger runners in this repo.

Unfortunately, the `e2e` workflow (`uptest`) running on the standard runner cannot be tested with this PR. I'm planning to test the `e2e` workflow on a separate repository. We have switched to the family providers in `uptest` runs, so I hope there's no need for the larger runners for `uptest` runs. This also depends on the time given to the `e2e` workflow and the resource providers needed to run a test.

Another test we need to do is the `publish-service-artifacts` workflow that we use to build the family packages and push them to the Upbound package registry. Building and pushing a larger number of provider packages from a single job requires more resources on the runner. Another parameter affecting the compute resources we consume on the workflow runners is the package size and recently, we have reduced the resource provider package size considerably by removing the Terraform CLI and Terraform provider. Although we have control over how many provider packages will be processed per CI child action, increasing the child action count increases the load on the package registry, as these children are currently run in parallel. We could run these child actions sequentially if needed, at the expense of increased release build & push time. We would like to experiment on these parameters using the standard runners once this PR is merged.

Another job of interest is the `local-deploy` job as it builds and deploys the monolith on a kind cluster. The monolith is heavy on the CPU and the memory the API server process consumes. We will be able to test it with this PR.

This PR also enables the `Cleanup Disk` step for the jobs in `e2e` & `CI` workflows.

Btw, the `lint` job is already failing on the larger `Ubuntu-Jumbo-Runner` workflow runner because currently it consumes ~40GB of memory. So it should fail with the smaller standard runners that we are switching to with this PR. We are working on this. This PR is for checking the rest of the CI jobs on the standard runners.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested via the following CI run: https://github.com/upbound/provider-aws/actions/runs/8248588907/job/22559239426?pr=1180