### PR TITLE
rds.cluster: add ability to auto-generate password in referenced secret

### DIFF
--- a/apis/rds/v1beta1/zz_cluster_terraformed.go
+++ b/apis/rds/v1beta1/zz_cluster_terraformed.go
@@ -25,7 +25,7 @@ func (mg *Cluster) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this Cluster
 func (tr *Cluster) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"master_password": "spec.forProvider.masterPasswordSecretRef", "password": "spec.forProvider.passwordSecretRef"}
+	return map[string]string{"master_password": "spec.forProvider.masterPasswordSecretRef"}
 }
 
 // GetObservation of this Cluster

--- a/apis/rds/v1beta1/zz_cluster_terraformed.go
+++ b/apis/rds/v1beta1/zz_cluster_terraformed.go
@@ -25,7 +25,7 @@ func (mg *Cluster) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this Cluster
 func (tr *Cluster) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"master_password": "spec.forProvider.masterPasswordSecretRef"}
+	return map[string]string{"master_password": "spec.forProvider.masterPasswordSecretRef", "password": "spec.forProvider.passwordSecretRef"}
 }
 
 // GetObservation of this Cluster

--- a/apis/rds/v1beta1/zz_cluster_types.go
+++ b/apis/rds/v1beta1/zz_cluster_types.go
@@ -423,6 +423,11 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	ApplyImmediately *bool `json:"applyImmediately,omitempty" tf:"apply_immediately,omitempty"`
 
+	// If true, the password will be auto-generated and stored in the Secret referenced by the masterPasswordSecretRef field.
+	// +upjet:crd:field:TFTag=-
+	// +kubebuilder:validation:Optional
+	AutoGeneratePassword *bool `json:"autoGeneratePassword,omitempty" tf:"-"`
+
 	// List of EC2 Availability Zones for the DB cluster storage where DB cluster instances can be created.
 	// We recommend specifying 3 AZs or using the  if necessary.
 	// A maximum of 3 AZs can be configured.
@@ -574,6 +579,10 @@ type ClusterParameters struct {
 	// Network type of the cluster. Valid values: IPV4, DUAL.
 	// +kubebuilder:validation:Optional
 	NetworkType *string `json:"networkType,omitempty" tf:"network_type,omitempty"`
+
+	// Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one.
+	// +kubebuilder:validation:Optional
+	PasswordSecretRef *v1.SecretKeySelector `json:"passwordSecretRef,omitempty" tf:"-"`
 
 	// Port on which the DB accepts connections
 	// +kubebuilder:validation:Optional

--- a/apis/rds/v1beta1/zz_cluster_types.go
+++ b/apis/rds/v1beta1/zz_cluster_types.go
@@ -580,10 +580,6 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	NetworkType *string `json:"networkType,omitempty" tf:"network_type,omitempty"`
 
-	// Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one.
-	// +kubebuilder:validation:Optional
-	PasswordSecretRef *v1.SecretKeySelector `json:"passwordSecretRef,omitempty" tf:"-"`
-
 	// Port on which the DB accepts connections
 	// +kubebuilder:validation:Optional
 	Port *float64 `json:"port,omitempty" tf:"port,omitempty"`

--- a/apis/rds/v1beta1/zz_generated.deepcopy.go
+++ b/apis/rds/v1beta1/zz_generated.deepcopy.go
@@ -2677,6 +2677,11 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AutoGeneratePassword != nil {
+		in, out := &in.AutoGeneratePassword, &out.AutoGeneratePassword
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AvailabilityZones != nil {
 		in, out := &in.AvailabilityZones, &out.AvailabilityZones
 		*out = make([]*string, len(*in))
@@ -2868,6 +2873,11 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 	if in.NetworkType != nil {
 		in, out := &in.NetworkType, &out.NetworkType
 		*out = new(string)
+		**out = **in
+	}
+	if in.PasswordSecretRef != nil {
+		in, out := &in.PasswordSecretRef, &out.PasswordSecretRef
+		*out = new(v1.SecretKeySelector)
 		**out = **in
 	}
 	if in.Port != nil {

--- a/apis/rds/v1beta1/zz_generated.deepcopy.go
+++ b/apis/rds/v1beta1/zz_generated.deepcopy.go
@@ -2875,11 +2875,6 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.PasswordSecretRef != nil {
-		in, out := &in.PasswordSecretRef, &out.PasswordSecretRef
-		*out = new(v1.SecretKeySelector)
-		**out = **in
-	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
 		*out = new(float64)

--- a/config/common/common_test.go
+++ b/config/common/common_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,10 +85,52 @@ func TestPasswordGenerator(t *testing.T) {
 				},
 			},
 		},
+		"ClusterSecretAlreadyFull": {
+			reason: "Should be no-op if the Secret already has password.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("needs to be secret")
+						}
+						s.Data = map[string][]byte{
+							"password": []byte("foo"),
+						}
+						return nil
+					},
+				},
+				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"masterPasswordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+						},
+					},
+				},
+			},
+		},
 		"NoSecretReference": {
 			reason: "Should be no-op if the secret reference is not given.",
 			args: args{
 				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"another": "field",
+						},
+					},
+				},
+			},
+		},
+		"NoClusterSecretReference": {
+			reason: "Should be no-op if the secret reference is not given.",
+			args: args{
+				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
 				mg: &ujfake.Terraformed{
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
@@ -119,6 +161,27 @@ func TestPasswordGenerator(t *testing.T) {
 				},
 			},
 		},
+		"ClusterToggleNotSet": {
+			reason: "Should be no-op if the toggle is not set at all.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				},
+				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
+				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"masterPasswordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+						},
+					},
+				},
+			},
+		},
 		"ToggleFalse": {
 			reason: "Should be no-op if the toggle is set to false.",
 			args: args{
@@ -131,6 +194,28 @@ func TestPasswordGenerator(t *testing.T) {
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"passwordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+							"autoGeneratePassword": false,
+						},
+					},
+				},
+			},
+		},
+		"ClusterToggleFalse": {
+			reason: "Should be no-op if the toggle is set to false.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				},
+				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
+				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"masterPasswordSecretRef": map[string]any{
 								"name":      "foo",
 								"namespace": "bar",
 								"key":       "password",
@@ -183,6 +268,48 @@ func TestPasswordGenerator(t *testing.T) {
 				},
 			},
 		},
+		"ClusterSecretGenerateAndApply": {
+			reason: "Should apply if we generate, set the content of an already existing secret.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("needs to be secret")
+						}
+						s.CreationTimestamp = metav1.Time{Time: time.Now()}
+						return nil
+					},
+					MockPatch: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("needs to be secret")
+						}
+						if len(s.Data["password"]) == 0 {
+							return errors.New("password is not set")
+						}
+						if len(s.OwnerReferences) != 0 {
+							return errors.New("owner references should not be set if secret already exists")
+						}
+						return nil
+					},
+				},
+				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
+				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
+				mg: &ujfake.Terraformed{
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"masterPasswordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+							"autoGeneratePassword": true,
+						},
+					},
+				},
+			},
+		},
 		"GenerateAndCreate": {
 			reason: "Should create if we generate, set the content and there is no secret in place.",
 			args: args{
@@ -214,6 +341,47 @@ func TestPasswordGenerator(t *testing.T) {
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"passwordSecretRef": map[string]any{
+								"name":      "foo",
+								"namespace": "bar",
+								"key":       "password",
+							},
+							"autoGeneratePassword": true,
+						},
+					},
+				},
+			},
+		},
+		"ClusterSecretGenerateAndCreate": {
+			reason: "Should create if we generate, set the content and there is no secret in place.",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+					MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("needs to be secret")
+						}
+						if len(s.Data["password"]) == 0 {
+							return errors.New("password is not set")
+						}
+						if len(s.OwnerReferences) == 1 &&
+							s.OwnerReferences[0].Name == "foo-mgd" {
+							return nil
+						}
+						return errors.New("owner references should be set if secret is created")
+					},
+				},
+				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
+				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
+				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "foo-mgd",
+						},
+					},
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"masterPasswordSecretRef": map[string]any{
 								"name":      "foo",
 								"namespace": "bar",
 								"key":       "password",

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -70,12 +70,6 @@ func Configure(p *config.Provider) {
 				"spec.forProvider.masterPasswordSecretRef",
 				"spec.forProvider.autoGeneratePassword",
 			))
-		r.TerraformResource.Schema["password"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Optional:    true,
-			Sensitive:   true,
-			Description: "Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one.",
-		}
 	})
 
 	p.AddResourceConfigurator("aws_rds_cluster_instance", func(r *config.Resource) {

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -76,10 +76,6 @@ func Configure(p *config.Provider) {
 			Sensitive:   true,
 			Description: "Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one.",
 		}
-		r.TerraformResource.Schema["password"].Description = "Password for the " +
-			"master DB user. If you set autoGeneratePassword to true, the Secret" +
-			" referenced here will be created or updated with generated password" +
-			" if it does not already contain one."
 	})
 
 	p.AddResourceConfigurator("aws_rds_cluster_instance", func(r *config.Resource) {

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -57,6 +57,29 @@ func Configure(p *config.Provider) {
 			"MasterUserSecretInitParameters":     "ClusterMasterUserSecretInitParameters",
 			"MasterUserSecretObservation":        "ClusterMasterUserSecretObservation",
 		}
+		desc, _ := comments.New("If true, the password will be auto-generated and"+
+			" stored in the Secret referenced by the masterPasswordSecretRef field.",
+			comments.WithTFTag("-"))
+		r.TerraformResource.Schema["auto_generate_password"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: desc.String(),
+		}
+		r.InitializerFns = append(r.InitializerFns,
+			common.PasswordGenerator(
+				"spec.forProvider.masterPasswordSecretRef",
+				"spec.forProvider.autoGeneratePassword",
+			))
+		r.TerraformResource.Schema["password"] = &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "Password for the master DB user. If you set autoGeneratePassword to true, the Secret referenced here will be created or updated with generated password if it does not already contain one.",
+		}
+		r.TerraformResource.Schema["password"].Description = "Password for the " +
+			"master DB user. If you set autoGeneratePassword to true, the Secret" +
+			" referenced here will be created or updated with generated password" +
+			" if it does not already contain one."
 	})
 
 	p.AddResourceConfigurator("aws_rds_cluster_instance", func(r *config.Resource) {

--- a/package/crds/rds.aws.upbound.io_clusters.yaml
+++ b/package/crds/rds.aws.upbound.io_clusters.yaml
@@ -86,6 +86,11 @@ spec:
                       immediately, or during the next maintenance window. Default
                       is false. See Amazon RDS Documentation for more information.
                     type: boolean
+                  autoGeneratePassword:
+                    description: If true, the password will be auto-generated and
+                      stored in the Secret referenced by the masterPasswordSecretRef
+                      field.
+                    type: boolean
                   availabilityZones:
                     description: |-
                       List of EC2 Availability Zones for the DB cluster storage where DB cluster instances can be created.
@@ -481,6 +486,25 @@ spec:
                     description: 'Network type of the cluster. Valid values: IPV4,
                       DUAL.'
                     type: string
+                  passwordSecretRef:
+                    description: Password for the master DB user. If you set autoGeneratePassword
+                      to true, the Secret referenced here will be created or updated
+                      with generated password if it does not already contain one.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   port:
                     description: Port on which the DB accepts connections
                     type: number

--- a/package/crds/rds.aws.upbound.io_clusters.yaml
+++ b/package/crds/rds.aws.upbound.io_clusters.yaml
@@ -486,25 +486,6 @@ spec:
                     description: 'Network type of the cluster. Valid values: IPV4,
                       DUAL.'
                     type: string
-                  passwordSecretRef:
-                    description: Password for the master DB user. If you set autoGeneratePassword
-                      to true, the Secret referenced here will be created or updated
-                      with generated password if it does not already contain one.
-                    properties:
-                      key:
-                        description: The key to select.
-                        type: string
-                      name:
-                        description: Name of the secret.
-                        type: string
-                      namespace:
-                        description: Namespace of the secret.
-                        type: string
-                    required:
-                    - key
-                    - name
-                    - namespace
-                    type: object
                   port:
                     description: Port on which the DB accepts connections
                     type: number


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Adds the ability to auto-generate password for the rds cluster. This was already added for the RDS instance in the PR [#628](https://github.com/upbound/provider-aws/pull/628). Users need to opt-in by setting autoGeneratePassword as true while creating RDS cluster and should have a Secret reference. It will create if the referenced Secret does not exist and it will populate if it doesn't have the password for the given key.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Unit tests, local end-to-end test.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
