### PR TITLE
Reclaim disk space in an initial step while running the CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     uses: upbound/uptest/.github/workflows/provider-ci.yml@main
     with:
       go-version: 1.21
+      cleanup-disk: true
     secrets:
       UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
       UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Relevant PR: https://github.com/upbound/uptest/pull/188

This PR enables the disk clean-up step in the CI workflow to fix the failing `check-diff`, `unit-tests` & `local-deploy` jobs in this branch. For more context, please refer to https://github.com/upbound/uptest/pull/188. Please also see this [comment](https://github.com/upbound/provider-aws/pull/1195#issuecomment-1982866839).

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Via the job run [here](https://github.com/upbound/provider-aws/actions/runs/8186204677/job/22384138959?pr=1197) and [here](https://github.com/upbound/provider-aws/actions/runs/8186846228/).