### PR TITLE
update ci runners for lint and check-diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           make schema-version-diff
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
@@ -105,7 +105,7 @@ jobs:
         run: make lint
 
   check-diff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:


### PR DESCRIPTION
### Description of your changes

Update runners on lint and check-diff to ubuntu-latest-16-cores in order to address disk space issues.  This is a similar configuration to the v2 branch https://github.com/crossplane-contrib/provider-upjet-aws/blob/crossplane-v2/.github/workflows/ci.yml#L60. 


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
