### PR TITLE
fix: add namespaced APIs to AWS global groups

### DIFF
--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -50,6 +50,12 @@ var globalResources = map[string]string{
 	"directconnect.aws.upbound.io/GatewayAssociation":   "directconnect",
 	"ec2.aws.upbound.io/SerialConsoleAccess":            "ec2",
 	"s3control.aws.upbound.io/AccountPublicAccessBlock": "s3control",
+	// namespaced apis
+	"backup.aws.m.upbound.io/GlobalSettings":              "backup",
+	"directconnect.aws.m.upbound.io/Gateway":              "directconnect",
+	"directconnect.aws.m.upbound.io/GatewayAssociation":   "directconnect",
+	"ec2.aws.m.upbound.io/SerialConsoleAccess":            "ec2",
+	"s3control.aws.m.upbound.io/AccountPublicAccessBlock": "s3control",
 }
 
 // globalGroups maps Kubernetes API group names to their corresponding AWS service names.
@@ -70,6 +76,21 @@ var globalGroups = map[string]string{
 	"route53recoverycontrolconfig.aws.upbound.io": "route53recoverycontrolconfig",
 	"route53recoveryreadiness.aws.upbound.io":     "route53recoveryreadiness",
 	"waf.aws.upbound.io":                          "waf",
+	// namespaced apis
+	"account.aws.m.upbound.io":                      "account",
+	"budgets.aws.m.upbound.io":                      "budgets",
+	"ce.aws.m.upbound.io":                           "ce",
+	"cloudfront.aws.m.upbound.io":                   "cloudfront",
+	"cur.aws.m.upbound.io":                          "cur",
+	"globalaccelerator.aws.m.upbound.io":            "globalaccelerator",
+	"iam.aws.m.upbound.io":                          "iam",
+	"networkmanager.aws.m.upbound.io":               "networkmanager",
+	"organizations.aws.m.upbound.io":                "organizations",
+	"rolesanywhere.aws.m.upbound.io":                "rolesanywhere",
+	"route53.aws.m.upbound.io":                      "route53",
+	"route53recoverycontrolconfig.aws.m.upbound.io": "route53recoverycontrolconfig",
+	"route53recoveryreadiness.aws.m.upbound.io":     "route53recoveryreadiness",
+	"waf.aws.m.upbound.io":                          "waf",
 }
 
 func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:gocyclo


### PR DESCRIPTION
### Description of your changes

We maintain the set of global (regionless) AWS api groups and resources, to correctly set the proper region in TF configuration.
The set was missing the new namespaced `aws.m.upbound.io` in the global groups and resources. This PR adds the missing entries.

Fixes #1842

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

manually

```
NAMESPACE        NAME                                             SYNCED   READY   EXTERNAL-NAME        AGE
upbound-system   policy.iam.aws.m.upbound.io/sample-user-policy   True     True    sample-user-policy   18h

NAMESPACE        NAME                                                                 SYNCED   READY   EXTERNAL-NAME                                                       AGE
upbound-system   rolepolicyattachment.iam.aws.m.upbound.io/sample-cluster-policy      True     True    sample-eks-cluster/arn:aws:iam::aws:policy/AmazonEKSClusterPolicy   53m
upbound-system   rolepolicyattachment.iam.aws.m.upbound.io/sample-policy-attachment   True     True    sample-role/arn:aws:iam::153891904029:policy/sample-user-policy     18h

NAMESPACE        NAME                                           SYNCED   READY   EXTERNAL-NAME        AGE
upbound-system   role.iam.aws.m.upbound.io/sample-eks-cluster   True     True    sample-eks-cluster   53m
upbound-system   role.iam.aws.m.upbound.io/sample-role          True     True    sample-role          18h
```