### PR TITLE
Ignore lateinitialize for availability_zone field in rds instance resource

### DIFF
--- a/apis/cluster/rds/v1beta1/zz_instance_terraformed.go
+++ b/apis/cluster/rds/v1beta1/zz_instance_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AvailabilityZone"))
 	opts = append(opts, resource.WithNameFilter("DBName"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/apis/cluster/rds/v1beta2/zz_instance_terraformed.go
+++ b/apis/cluster/rds/v1beta2/zz_instance_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AvailabilityZone"))
 	opts = append(opts, resource.WithNameFilter("DBName"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/apis/cluster/rds/v1beta3/zz_instance_terraformed.go
+++ b/apis/cluster/rds/v1beta3/zz_instance_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AvailabilityZone"))
 	opts = append(opts, resource.WithNameFilter("DBName"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/apis/namespaced/rds/v1beta1/zz_instance_terraformed.go
+++ b/apis/namespaced/rds/v1beta1/zz_instance_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AvailabilityZone"))
 	opts = append(opts, resource.WithNameFilter("DBName"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/config/cluster/rds/config.go
+++ b/config/cluster/rds/config.go
@@ -149,7 +149,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 		r.UseAsync = true
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"name", "db_name"},
+			IgnoredFields: []string{"name", "db_name", "availability_zone"},
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}

--- a/config/namespaced/rds/config.go
+++ b/config/namespaced/rds/config.go
@@ -149,7 +149,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 		r.UseAsync = true
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"name", "db_name"},
+			IgnoredFields: []string{"name", "db_name", "availability_zone"},
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}


### PR DESCRIPTION
### Description of your changes

Ignore lateinitialize for availability_zone field in rds instance resource

Fixes https://github.com/crossplane-contrib/provider-upjet-aws/issues/1379

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

Manually and [Uptest-examples/rds/cluster/v1beta1/instance.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/17643297700)

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
