### PR TITLE
examples: remove namespace from spec.writeConnectionSecretToRef for namespaced MRs

### DIFF
--- a/examples/acmpca/namespaced/v1beta1/certificate.yaml
+++ b/examples/acmpca/namespaced/v1beta1/certificate.yaml
@@ -28,4 +28,3 @@ spec:
     kind: ClusterProviderConfig
   writeConnectionSecretToRef:
     name: acmpca-certificate
-    namespace: upbound-system

--- a/examples/acmpca/namespaced/v1beta1/certificateauthority.yaml
+++ b/examples/acmpca/namespaced/v1beta1/certificateauthority.yaml
@@ -25,4 +25,3 @@ spec:
     kind: ClusterProviderConfig
   writeConnectionSecretToRef:
     name: acmpca-ca
-    namespace: upbound-system

--- a/examples/docdb/namespaced/v1beta1/cluster.yaml
+++ b/examples/docdb/namespaced/v1beta1/cluster.yaml
@@ -14,7 +14,6 @@ metadata:
 spec:
   writeConnectionSecretToRef:
     name: docdb-cluster-secret
-    namespace: upbound-system
   forProvider:
     region: us-west-2
     engine: "docdb"

--- a/examples/eks/namespaced/v1beta1/clusterauth.yaml
+++ b/examples/eks/namespaced/v1beta1/clusterauth.yaml
@@ -19,7 +19,6 @@ spec:
         testing.upbound.io/example-name: example-clusterauth
   writeConnectionSecretToRef:
     name: sample-eks-cluster-conn
-    namespace: upbound-system
 ---
 apiVersion: eks.aws.m.upbound.io/v1beta1
 kind: Cluster

--- a/examples/eks/namespaced/v1beta1/nodegroup.yaml
+++ b/examples/eks/namespaced/v1beta1/nodegroup.yaml
@@ -121,7 +121,6 @@ spec:
     region: us-west-1
   writeConnectionSecretToRef:
     name: cluster-conn
-    namespace: upbound-system
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: Role

--- a/examples/elasticache/namespaced/v1beta1/cluster.yaml
+++ b/examples/elasticache/namespaced/v1beta1/cluster.yaml
@@ -29,7 +29,6 @@ spec:
         testing.upbound.io/example-name: example
   writeConnectionSecretToRef:
     name: sample-cluster
-    namespace: default
 ---
 apiVersion: ec2.aws.m.upbound.io/v1beta1
 kind: SecurityGroup

--- a/examples/elasticache/namespaced/v1beta1/replicationgroup.yaml
+++ b/examples/elasticache/namespaced/v1beta1/replicationgroup.yaml
@@ -102,4 +102,3 @@ spec:
     region: us-east-1
   writeConnectionSecretToRef:
     name: redis-conn
-    namespace: upbound-system

--- a/examples/elasticache/namespaced/v1beta1/user.yaml
+++ b/examples/elasticache/namespaced/v1beta1/user.yaml
@@ -23,4 +23,3 @@ spec:
     userName: testUserName
   writeConnectionSecretToRef:
     name: user-conn
-    namespace: default

--- a/examples/globalaccelerator/namespaced/v1beta1/accelerator.yaml
+++ b/examples/globalaccelerator/namespaced/v1beta1/accelerator.yaml
@@ -15,4 +15,3 @@ spec:
     name: sample-accelerator
   writeConnectionSecretToRef:
     name: accelerator
-    namespace: upbound-system

--- a/examples/globalaccelerator/namespaced/v1beta1/endpoint-group.yaml
+++ b/examples/globalaccelerator/namespaced/v1beta1/endpoint-group.yaml
@@ -13,4 +13,3 @@ spec:
       name: sample-listener
   writeConnectionSecretToRef:
     name: endpoint
-    namespace: upbound-system

--- a/examples/globalaccelerator/namespaced/v1beta1/listener.yaml
+++ b/examples/globalaccelerator/namespaced/v1beta1/listener.yaml
@@ -18,4 +18,3 @@ spec:
         toPort: 80
   writeConnectionSecretToRef:
     name: listener
-    namespace: upbound-system

--- a/examples/iam/namespaced/v1beta1/accesskey.yaml
+++ b/examples/iam/namespaced/v1beta1/accesskey.yaml
@@ -18,7 +18,6 @@ spec:
         testing.upbound.io/example-name: accesskey
   writeConnectionSecretToRef:
     name: sample-access-key-secret
-    namespace: upbound-system
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: User

--- a/examples/iam/namespaced/v1beta1/user.yaml
+++ b/examples/iam/namespaced/v1beta1/user.yaml
@@ -26,7 +26,6 @@ spec:
         testing.upbound.io/example-name: user
   writeConnectionSecretToRef:
     name: sample-access-key-secret
-    namespace: upbound-system
 ---
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: Group

--- a/examples/memorydb/namespaced/v1beta1/cluster.yaml
+++ b/examples/memorydb/namespaced/v1beta1/cluster.yaml
@@ -26,7 +26,6 @@ spec:
         testing.upbound.io/example-name: example
   writeConnectionSecretToRef:
     name: memorydb-example
-    namespace: upbound-system
 ---
 apiVersion: ec2.aws.m.upbound.io/v1beta1
 kind: SecurityGroup

--- a/examples/memorydb/namespaced/v1beta1/user.yaml
+++ b/examples/memorydb/namespaced/v1beta1/user.yaml
@@ -24,7 +24,6 @@ spec:
     region: us-west-1
   writeConnectionSecretToRef:
     name: user-conn
-    namespace: default
 ---
 apiVersion: v1
 kind: Secret

--- a/examples/opensearch/namespaced/v1beta1/domain-with-advanced-security-options.yaml
+++ b/examples/opensearch/namespaced/v1beta1/domain-with-advanced-security-options.yaml
@@ -14,7 +14,6 @@ metadata:
 spec:
   writeConnectionSecretToRef:
     name: example-aso-domain
-    namespace: default
   forProvider:
     domainName: ${Rand.RFC1123Subdomain}
     engineVersion: OpenSearch_1.0

--- a/examples/opensearch/namespaced/v1beta1/domain.yaml
+++ b/examples/opensearch/namespaced/v1beta1/domain.yaml
@@ -15,7 +15,6 @@ metadata:
 spec:
   writeConnectionSecretToRef:
     name: example-domain
-    namespace: default
   forProvider:
     clusterConfig:
       instanceType: m4.large.search

--- a/examples/sqs/namespaced/v1beta1/queue-with-policy.yaml
+++ b/examples/sqs/namespaced/v1beta1/queue-with-policy.yaml
@@ -35,4 +35,3 @@ spec:
       Environment: production
   writeConnectionSecretToRef:
     name: "upbound-sqs-with-policy"
-    namespace: "upbound-system"

--- a/examples/sqs/namespaced/v1beta1/queue.yaml
+++ b/examples/sqs/namespaced/v1beta1/queue.yaml
@@ -21,4 +21,3 @@ spec:
       Environment: production
   writeConnectionSecretToRef:
     name: "sqs-example"
-    namespace: "upbound-system"


### PR DESCRIPTION
### Description of your changes

remove spec.writeConnectionSecretToRef.namespace from namespace-scoped examples as it no longer exists in CRDs

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

manually in kind

[contribution process]: https://git.io/fj2m9
