### PR TITLE
fix: set UID and generation at effective provider config

### DIFF
--- a/internal/clients/pc_resolver.go
+++ b/internal/clients/pc_resolver.go
@@ -38,6 +38,8 @@ func legacyToModernProviderConfigSpec(pc *clusterv1beta1.ProviderConfig) (*names
 		Name:        pc.GetName(),
 		Labels:      pc.GetLabels(),
 		Annotations: pc.GetAnnotations(),
+		Generation:  pc.GetGeneration(),
+		UID:         pc.GetUID(),
 	}
 	return &mSpec, err
 }
@@ -124,6 +126,8 @@ func resolveProviderConfigModern(ctx context.Context, crClient client.Client, mg
 				Name:        pc.GetName(),
 				Labels:      pc.GetLabels(),
 				Annotations: pc.GetAnnotations(),
+				Generation:  pc.GetGeneration(),
+				UID:         pc.GetUID(),
 			},
 			Spec: pc.Spec,
 		}


### PR DESCRIPTION
### Description of your changes

sets `metadata.UID` and `metadata.generation` fields in effective provider config

Background: 
To work with a common single provider config kind in runtime code, `ProviderConfig.aws.m` and `ProviderConfig.aws` are transformed into the equivalent `ClusterProviderConfig.aws.m` runtime object. During this transformation, `metadata.UID` and `metadata.generation` was not set. This causes wrong cache key calculations when there are multiple IRSA provider configs, with different role chains.

Fixes #1853

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested
manually using the reproducer at the issue description #1853

[contribution process]: https://git.io/fj2m9
