### PR TITLE
conditionally select GHA runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           make schema-version-diff
 
   lint:
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: ${{ (github.repository_owner == 'crossplane-contrib' && 'oracle-vm-16cpu-64gb-x86-64' || 'Ubuntu-Jumbo-Runner') }}
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
@@ -105,7 +105,7 @@ jobs:
         run: make lint
 
   check-diff:
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: ${{ (github.repository_owner == 'crossplane-contrib' && 'oracle-vm-16cpu-64gb-x86-64' || 'Ubuntu-Jumbo-Runner') }}
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
@@ -155,7 +155,7 @@ jobs:
           path: _output/skipped_resources.csv
 
   unit-tests:
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: ${{ (github.repository_owner == 'crossplane-contrib' && 'oracle-vm-16cpu-64gb-x86-64' || 'Ubuntu-Jumbo-Runner') }}
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Follow-up to #1838 to conditionally select the runner, since not all repository owners will have access to the CNCF Oracle runners if they fork this repository. Proposed an "equivalent" GitHub-hosted runner by spec for wider coverage on the fallback option.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

ensure the "ternary" expression works on a fork. the trigger from this PR should also show the Oracle runner being selected.

[contribution process]: https://git.io/fj2m9
