### PR TITLE
Run uptest conditionally on oracle-vm-16cpu-64gb-x86-64 in crossplane-contrib repo

### DIFF
--- a/.github/workflows/uptest-trigger.yaml
+++ b/.github/workflows/uptest-trigger.yaml
@@ -96,7 +96,7 @@ jobs:
       - check-permissions
       - get-example-list
     if: ${{ (needs.check-permissions.outputs.permission == 'admin' || needs.check-permissions.outputs.permission == 'write') && github.event.issue.pull_request != null && contains(github.event.comment.body, '/test-examples')}}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'crossplane-contrib' && 'oracle-vm-16cpu-64gb-x86-64' || 'Ubuntu-Jumbo-Runner' }}
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

We've been hitting issues with insufficient storage in the `uptest` runs of https://github.com/crossplane-contrib/provider-upjet-aws/pull/1880: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/18526939839/job/52799918606
<img width="1308" height="196" alt="image" src="https://github.com/user-attachments/assets/1f3467a1-be4d-4a9f-afaf-14641a45c501" />

Following @sergenyalcin's suggestion, this PR conditionally switches to Oracle runners when the workflow is run under the `crossplane-contrib` Github organization using the template from: https://github.com/crossplane-contrib/provider-upjet-aws/pull/1881.

The ternary conditional expression follows the example given [here](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#example).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
