### PR TITLE
Move myself to emeritus maintainer status

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,4 +19,4 @@
 # See also OWNERS.md for governance details
 
 # Fallback owners
-*			@sergenyalcin @turkenf @mbbush @jastang
+*			@sergenyalcin @turkenf @jastang

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -14,7 +14,10 @@ repository maintainers in their own `OWNERS.md` file.
 
 * Sergen Yalcin <sergen@upbound.io> ([sergenyalcin](https://github.com/sergenyalcin))
 * Fatih Turken <fatih@upbound.io> ([turkenf](https://github.com/turkenf)))
-* Matt Bush <mbbush@gmail.com> ([mbbush](https://github.com/mbbush))
 * Jason Tang <jasont@upbound.io> ([jastang](https://github.com/jastang))
 
 See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.
+
+## Emeritus Maintainers
+
+* Matt Bush <mbbush@gmail.com> ([mbbush](https://github.com/mbbush))


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

It's been a long time since I've been substantially engaged with crossplane, and I no longer use it regularly at work. I've enjoyed being a maintainer here, interacting with the community, and learning a lot, but I don't think it makes sense for me to continue to be listed as a maintainer. 

I wish everyone here all the best!

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

