### PR TITLE
fix: namespaced MR aware PasswordGenerator configuration

### DIFF
--- a/config/namespaced/common/common_test.go
+++ b/config/namespaced/common/common_test.go
@@ -50,10 +50,51 @@ func TestPasswordGenerator(t *testing.T) {
 				},
 				secretRefFieldPath: "",
 				toggleFieldPath:    "",
-				mg:                 &fake.Managed{},
+				mg: &fake.Managed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-mgd",
+						Namespace: "bar",
+					},
+				},
 			},
 			want: want{
 				err: errors.Wrap(errBoom, ErrGetPasswordSecret),
+			},
+		},
+		"ClusterScopedMR": {
+			reason: "should return an error if the MR has no namespace (cluster-scoped)",
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("needs to be secret")
+						}
+						s.Data = map[string][]byte{
+							"password": []byte("foo"),
+						}
+						return nil
+					},
+				},
+				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
+				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "foo-mgd",
+						},
+					},
+					Parameterizable: ujfake.Parameterizable{
+						Parameters: map[string]any{
+							"passwordSecretRef": map[string]any{
+								"name": "foo",
+								"key":  "password",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.New(errManagedNotNamespaced),
 			},
 		},
 		"SecretAlreadyFull": {
@@ -73,12 +114,17 @@ func TestPasswordGenerator(t *testing.T) {
 				},
 				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"passwordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 						},
 					},
@@ -102,12 +148,17 @@ func TestPasswordGenerator(t *testing.T) {
 				},
 				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"masterPasswordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 						},
 					},
@@ -119,6 +170,12 @@ func TestPasswordGenerator(t *testing.T) {
 			args: args{
 				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"another": "field",
@@ -132,6 +189,12 @@ func TestPasswordGenerator(t *testing.T) {
 			args: args{
 				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"another": "field",
@@ -149,12 +212,17 @@ func TestPasswordGenerator(t *testing.T) {
 				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
 				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"passwordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 						},
 					},
@@ -170,6 +238,12 @@ func TestPasswordGenerator(t *testing.T) {
 				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
 				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"masterPasswordSecretRef": map[string]any{
@@ -191,12 +265,17 @@ func TestPasswordGenerator(t *testing.T) {
 				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
 				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"passwordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 							"autoGeneratePassword": false,
 						},
@@ -213,6 +292,12 @@ func TestPasswordGenerator(t *testing.T) {
 				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
 				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"masterPasswordSecretRef": map[string]any{
@@ -255,12 +340,17 @@ func TestPasswordGenerator(t *testing.T) {
 				secretRefFieldPath: "parameterizable.parameters.passwordSecretRef",
 				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"passwordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 							"autoGeneratePassword": true,
 						},
@@ -297,12 +387,17 @@ func TestPasswordGenerator(t *testing.T) {
 				secretRefFieldPath: "parameterizable.parameters.masterPasswordSecretRef",
 				toggleFieldPath:    "parameterizable.parameters.autoGeneratePassword",
 				mg: &ujfake.Terraformed{
+					Managed: fake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo-mgd",
+							Namespace: "bar",
+						},
+					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"masterPasswordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 							"autoGeneratePassword": true,
 						},
@@ -335,15 +430,15 @@ func TestPasswordGenerator(t *testing.T) {
 				mg: &ujfake.Terraformed{
 					Managed: fake.Managed{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "foo-mgd",
+							Name:      "foo-mgd",
+							Namespace: "bar",
 						},
 					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"passwordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 							"autoGeneratePassword": true,
 						},
@@ -376,15 +471,15 @@ func TestPasswordGenerator(t *testing.T) {
 				mg: &ujfake.Terraformed{
 					Managed: fake.Managed{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "foo-mgd",
+							Name:      "foo-mgd",
+							Namespace: "bar",
 						},
 					},
 					Parameterizable: ujfake.Parameterizable{
 						Parameters: map[string]any{
 							"masterPasswordSecretRef": map[string]any{
-								"name":      "foo",
-								"namespace": "bar",
-								"key":       "password",
+								"name": "foo",
+								"key":  "password",
 							},
 							"autoGeneratePassword": true,
 						},


### PR DESCRIPTION
### Description of your changes

This PR fixes `PasswordGenerator` initializer function by making it namespaced MR aware. It should have operated on a namespaced MR and a LocalSecretRef. Unit tests are updated.

Fixes #1855 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
