### PR TITLE
Fix API Gateway v1 external name oscillation causing perpetual delete/recreate

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -272,17 +272,17 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	// API Gateway domain names can be imported using their name
 	"aws_api_gateway_domain_name": config.IdentifierFromProvider,
 	// aws_api_gateway_gateway_response can be imported using REST-API-ID/RESPONSE-TYPE
-	"aws_api_gateway_gateway_response": FormattedIdentifierFromProvider("/", "rest_api_id", "response_type"),
+	"aws_api_gateway_gateway_response": apiGatewayFormattedIdentifier("aggr", "rest_api_id", "response_type"),
 	// aws_api_gateway_integration can be imported using REST-API-ID/RESOURCE-ID/HTTP-METHOD
-	"aws_api_gateway_integration": FormattedIdentifierFromProvider("/", "rest_api_id", "resource_id", "http_method"),
+	"aws_api_gateway_integration": apiGatewayFormattedIdentifier("agi", "rest_api_id", "resource_id", "http_method"),
 	// aws_api_gateway_integration_response can be imported using REST-API-ID/RESOURCE-ID/HTTP-METHOD/STATUS-CODE
-	"aws_api_gateway_integration_response": FormattedIdentifierFromProvider("/", "rest_api_id", "resource_id", "http_method", "status_code"),
+	"aws_api_gateway_integration_response": apiGatewayFormattedIdentifier("agir", "rest_api_id", "resource_id", "http_method", "status_code"),
 	// aws_api_gateway_method can be imported using REST-API-ID/RESOURCE-ID/HTTP-METHOD
-	"aws_api_gateway_method": FormattedIdentifierFromProvider("/", "rest_api_id", "resource_id", "http_method"),
+	"aws_api_gateway_method": apiGatewayFormattedIdentifier("agm", "rest_api_id", "resource_id", "http_method"),
 	// aws_api_gateway_method_response can be imported using REST-API-ID/RESOURCE-ID/HTTP-METHOD/STATUS-CODE
-	"aws_api_gateway_method_response": FormattedIdentifierFromProvider("/", "rest_api_id", "resource_id", "http_method", "status_code"),
+	"aws_api_gateway_method_response": apiGatewayFormattedIdentifier("agmr", "rest_api_id", "resource_id", "http_method", "status_code"),
 	// aws_api_gateway_method_settings can be imported using REST-API-ID/STAGE-NAME/METHOD-PATH
-	"aws_api_gateway_method_settings": FormattedIdentifierFromProvider("/", "rest_api_id", "stage_name", "method_path"),
+	"aws_api_gateway_method_settings": apiGatewayFormattedIdentifier("", "rest_api_id", "stage_name", "method_path"),
 	// aws_api_gateway_model can be imported using REST-API-ID/NAME
 	"aws_api_gateway_model": config.IdentifierFromProvider,
 	// aws_api_gateway_request_validator can be imported using REST-API-ID/REQUEST-VALIDATOR-ID
@@ -294,7 +294,7 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	// aws_api_gateway_rest_api_policy can be imported by using the REST API ID
 	"aws_api_gateway_rest_api_policy": FormattedIdentifierFromProvider("", "rest_api_id"),
 	// aws_api_gateway_stage can be imported using REST-API-ID/STAGE-NAME
-	"aws_api_gateway_stage": FormattedIdentifierFromProvider("/", "rest_api_id", "stage_name"),
+	"aws_api_gateway_stage": apiGatewayFormattedIdentifier("ags", "rest_api_id", "stage_name"),
 	// AWS API Gateway Usage Plan can be imported using the id
 	"aws_api_gateway_usage_plan": config.IdentifierFromProvider,
 	// AWS API Gateway Usage Plan Key can be imported using the USAGE-PLAN-ID/USAGE-PLAN-KEY-ID
@@ -3372,6 +3372,51 @@ func apiGatewayAccount() config.ExternalName {
 			return "api-gateway-account", nil
 		}
 		return externalName, nil
+	}
+	return e
+}
+
+// apiGatewayFormattedIdentifier configures external name for API Gateway
+// v1 resources where the Terraform internal ID format differs from the import
+// format. GetExternalNameFn reads tfstate fields directly (e.g.,
+// tfstate["rest_api_id"]) and joins them with "/" separators. GetIDFn reads
+// parameters and joins them with "-" separators, optionally adding a prefix.
+// This ensures consistent values to prevent external name oscillation.
+func apiGatewayFormattedIdentifier(prefix string, keys ...string) config.ExternalName {
+	e := config.IdentifierFromProvider
+	e.GetExternalNameFn = func(tfstate map[string]interface{}) (string, error) {
+		vals := make([]string, len(keys))
+		for i, key := range keys {
+			val, ok := tfstate[key]
+			if !ok {
+				return "", errors.Errorf("parameter %q cannot be empty", key)
+			}
+			s, ok := val.(string)
+			if !ok {
+				return "", errors.Errorf("parameter %q must be a string", key)
+			}
+			vals[i] = s
+		}
+		return strings.Join(vals, "/"), nil
+	}
+	e.GetIDFn = func(_ context.Context, _ string, parameters map[string]interface{}, _ map[string]interface{}) (string, error) {
+		vals := make([]string, len(keys))
+		for i, key := range keys {
+			val, ok := parameters[key]
+			if !ok {
+				return "", errors.Errorf("parameter %q cannot be empty", key)
+			}
+			s, ok := val.(string)
+			if !ok {
+				return "", errors.Errorf("parameter %q must be a string", key)
+			}
+			vals[i] = s
+		}
+		id := strings.Join(vals, "-")
+		if prefix != "" {
+			return prefix + "-" + id, nil
+		}
+		return id, nil
 	}
 	return e
 }

--- a/examples/apigateway/cluster/v1beta1/integrationresponse.yaml
+++ b/examples/apigateway/cluster/v1beta1/integrationresponse.yaml
@@ -20,8 +20,6 @@ apiVersion: apigateway.aws.upbound.io/v1beta1
 kind: IntegrationResponse
 metadata:
   annotations:
-    # Disabling import step because of the unstable ID
-    uptest.upbound.io/disable-import: "true"
     meta.upbound.io/example-id: apigateway/v1beta1/integrationresponse
   labels:
     testing.upbound.io/example-name: integration
@@ -53,7 +51,6 @@ apiVersion: apigateway.aws.upbound.io/v1beta1
 kind: Integration
 metadata:
   annotations:
-    uptest.upbound.io/disable-import: "true"
     meta.upbound.io/example-id: apigateway/v1beta1/integrationresponse
   labels:
     testing.upbound.io/example-name: integration
@@ -76,7 +73,6 @@ apiVersion: apigateway.aws.upbound.io/v1beta1
 kind: Method
 metadata:
   annotations:
-    uptest.upbound.io/disable-import: "true"
     meta.upbound.io/example-id: apigateway/v1beta1/integrationresponse
   labels:
     testing.upbound.io/example-name: integration
@@ -97,7 +93,6 @@ apiVersion: apigateway.aws.upbound.io/v1beta1
 kind: MethodResponse
 metadata:
   annotations:
-    uptest.upbound.io/disable-import: "true"
     meta.upbound.io/example-id: apigateway/v1beta1/integrationresponse
   labels:
     testing.upbound.io/example-name: integration

--- a/examples/apigateway/cluster/v1beta2/integrationresponse.yaml
+++ b/examples/apigateway/cluster/v1beta2/integrationresponse.yaml
@@ -23,7 +23,6 @@ kind: IntegrationResponse
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: mydemointegrationresponse
@@ -57,7 +56,6 @@ kind: Integration
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: mydemointegration
@@ -82,7 +80,6 @@ kind: Method
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: mydemomethod
@@ -105,7 +102,6 @@ kind: MethodResponse
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: response-200

--- a/examples/apigateway/cluster/v1beta2/methodsettings.yaml
+++ b/examples/apigateway/cluster/v1beta2/methodsettings.yaml
@@ -7,7 +7,6 @@ kind: MethodSettings
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/methodsettings
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: example-methodsettings
   name: example-methodsettings-all
@@ -29,7 +28,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/methodsettings
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: example-methodsettings
   name: example-methodsettings-stage

--- a/examples/apigateway/cluster/v1beta2/stage.yaml
+++ b/examples/apigateway/cluster/v1beta2/stage.yaml
@@ -7,7 +7,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/stage
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: stage
   name: example-stage

--- a/examples/apigateway/cluster/v1beta2/usageplan.yaml
+++ b/examples/apigateway/cluster/v1beta2/usageplan.yaml
@@ -90,7 +90,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/usageplan
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: stage
   name: development
@@ -110,7 +109,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta2/usageplan
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: stage
   name: production

--- a/examples/apigateway/namespaced/v1beta1/integrationresponse.yaml
+++ b/examples/apigateway/namespaced/v1beta1/integrationresponse.yaml
@@ -22,7 +22,6 @@ kind: IntegrationResponse
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: mydemointegrationresponse
@@ -55,7 +54,6 @@ kind: Integration
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: mydemointegration
@@ -79,7 +77,6 @@ kind: Method
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: mydemomethod
@@ -101,7 +98,6 @@ kind: MethodResponse
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/restapi
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: integration
   name: response-200

--- a/examples/apigateway/namespaced/v1beta1/methodsettings.yaml
+++ b/examples/apigateway/namespaced/v1beta1/methodsettings.yaml
@@ -7,7 +7,6 @@ kind: MethodSettings
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/methodsettings
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: example-methodsettings
   name: example-methodsettings-all
@@ -30,7 +29,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/methodsettings
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: example-methodsettings
   name: example-methodsettings-stage

--- a/examples/apigateway/namespaced/v1beta1/stage.yaml
+++ b/examples/apigateway/namespaced/v1beta1/stage.yaml
@@ -7,7 +7,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/stage
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: stage
   name: example-stage

--- a/examples/apigateway/namespaced/v1beta1/usageplan.yaml
+++ b/examples/apigateway/namespaced/v1beta1/usageplan.yaml
@@ -93,7 +93,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/usageplan
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: stage
   name: development
@@ -114,7 +113,6 @@ kind: Stage
 metadata:
   annotations:
     meta.upbound.io/example-id: apigateway/v1beta1/usageplan
-    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: stage
   name: production


### PR DESCRIPTION
## Summary

Fixes #1974

7 API Gateway v1 resources using `FormattedIdentifierFromProvider("/", ...)` suffer from an external-name annotation oscillation bug. Each reconciliation cycle the `crossplane.io/external-name` annotation changes, triggering perpetual delete/recreate cycles and AWS 429 throttling.

### Root Cause

`FormattedIdentifierFromProvider` inherits `GetExternalNameFn = IDAsExternalName` (reads `tfstate["id"]` as-is) but overrides `GetIDFn` to join parameters with `/`. The Terraform AWS provider stores internal IDs in a **different format** than the import format:

| Resource | `GetIDFn` produces (slash) | `tfstate["id"]` stores (internal) |
|---|---|---|
| `aws_api_gateway_method` | `{restApiId}/{resourceId}/{httpMethod}` | `agm-{restApiId}-{resourceId}-{httpMethod}` |
| `aws_api_gateway_integration` | `{restApiId}/{resourceId}/{httpMethod}` | `agi-{restApiId}-{resourceId}-{httpMethod}` |
| `aws_api_gateway_stage` | `{restApiId}/{stageName}` | `ags-{restApiId}-{stageName}` |
| `aws_api_gateway_method_settings` | `{restApiId}/{stageName}/{methodPath}` | `{restApiId}-{stageName}-{methodPath}` |
| `aws_api_gateway_gateway_response` | `{restApiId}/{responseType}` | `aggr-{restApiId}-{responseType}` |
| `aws_api_gateway_integration_response` | `{restApiId}/{resourceId}/{httpMethod}/{statusCode}` | `agir-{restApiId}-{resourceId}-{httpMethod}-{statusCode}` |
| `aws_api_gateway_method_response` | `{restApiId}/{resourceId}/{httpMethod}/{statusCode}` | `agmr-{restApiId}-{resourceId}-{httpMethod}-{statusCode}` |

Since `GetExternalNameFn` returns the internal format (e.g., `agm-abc-def-GET`) but the controller expects the slash format (e.g., `abc/def/GET`), the annotation oscillates every reconciliation.

### Fix

New helper `apiGatewayFormattedIdentifier(prefix, keys...)` that bypasses `tfstate["id"]` entirely and reads individual tfstate fields directly:

- **`GetExternalNameFn`**: Reads individual tfstate fields (e.g., `tfstate["rest_api_id"]`, `tfstate["resource_id"]`, `tfstate["http_method"]`) and joins them with `/` separators. This avoids the `tfstate["id"]` format mismatch entirely.
- **`GetIDFn`**: Reads the same fields from parameters, joins them with `-` separators, and prepends the prefix (e.g., `agm-`). This produces the internal format Terraform expects.

This approach is simpler and more robust than parsing the internal ID format — it reads canonical field values directly from tfstate rather than reverse-engineering the prefix/separator encoding.

Round-trip: `GetExternalNameFn(tfstate) → slash format → (annotation) → GetIDFn(params) → internal format → (Terraform) → tfstate fields unchanged → GetExternalNameFn → same slash format`. No oscillation.

### Changes

- **`config/externalname.go`**: Added `apiGatewayFormattedIdentifier()` helper; replaced all 7 affected resource entries.

### Verification

- `go build ./config/...` — passes
- `go vet ./config/...` — passes

### Full audit

All other API Gateway v1 resources were audited and confirmed unaffected — they either use `config.IdentifierFromProvider` (where `tfstate["id"]` is a bare ID or already matches the import format) or `FormattedIdentifierFromProvider` where the internal ID happens to match the slash format. Details in #1974.

### Testing
7 resources are fixed, below uptest runs cover all.

[Uptest-examples/apigateway/cluster/v1beta1/stage.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/23108989893) — Passed
  - aws_api_gateway_method_settings
  - aws_api_gateway_stage
[Uptest-examples/apigateway/namespaced/v1beta1/integrationresponse.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/23110496202) — Passed
  - aws_api_gateway_integration
  - aws_api_gateway_integration_response
  - aws_api_gateway_method
  - aws_api_gateway_method_response
[Uptest-examples/apigateway/namespaced/v1beta1/restapi.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/23114719016) — Passed
  - aws_api_gateway_gateway_response