### PR TITLE
Use go.mod as single source of truth for Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
-env:
-  GO_VERSION: "1.25.8"
-
 jobs:
   detect-noop:
     runs-on: ubuntu-latest
@@ -75,7 +72,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Analysis Cache
         id: analysis_cache
@@ -123,7 +120,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports
@@ -176,7 +173,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -206,7 +203,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.github/workflows/uptest-trigger.yaml
+++ b/.github/workflows/uptest-trigger.yaml
@@ -8,9 +8,6 @@ on:
   issue_comment:
     types: [created]
 
-env:
-  GO_VERSION: "1.25.8"
-
 jobs:
   check-permissions:
     runs-on: ubuntu-latest
@@ -21,7 +18,6 @@ jobs:
         id: check-permissions
         run: |
           echo "Trigger keyword: '/test-examples'"
-          echo "Go version: ${{ env.GO_VERSION }}"
 
           REPO=${{ github.repository }}
           COMMENTER=${{ github.event.comment.user.login }}
@@ -114,11 +110,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Checkout PR
         id: checkout-pr
         env:
@@ -128,6 +119,11 @@ jobs:
           git submodule update --init --recursive
           OUTPUT=$(git log -1 --format='%H')
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 # correctly.
 export GOPRIVATE = github.com/upbound/*
 
-GO_REQUIRED_VERSION ?= 1.25.7
+GO_REQUIRED_VERSION ?= $(shell grep -E '^go ' go.mod | awk '{print $2}')
 # GOLANGCILINT_VERSION is inherited from build submodule by default.
 # Uncomment below if you need to override the version.
 GOLANGCILINT_VERSION ?= 2.11.3


### PR DESCRIPTION
This PR eliminates hardcoded Go version values across the repository by making `go.mod` the single source of truth for the Go version.

- **Workflows**: Updated `ci.yml` and `uptest-trigger.yaml` to use `go-version-file: go.mod` instead of the hardcoded `GO_VERSION` environment variable
- **Makefile**: Changed `GO_REQUIRED_VERSION` to dynamically read from `go.mod` using shell parsing
- **uptest-trigger.yaml**: Moved Setup Go step to after Checkout PR step to ensure `go.mod` is available before reading it

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
