### PR TITLE
fix: clustermode field backport for v1beta1 ReplicationGroup.elasticache

### DIFF
--- a/apis/cluster/elasticache/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/elasticache/v1beta1/zz_generated.deepcopy.go
@@ -2538,6 +2538,11 @@ func (in *ReplicationGroupInitParameters) DeepCopyInto(out *ReplicationGroupInit
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ClusterOperationMode != nil {
+		in, out := &in.ClusterOperationMode, &out.ClusterOperationMode
+		*out = new(string)
+		**out = **in
+	}
 	if in.DataTieringEnabled != nil {
 		in, out := &in.DataTieringEnabled, &out.DataTieringEnabled
 		*out = new(bool)
@@ -3000,6 +3005,11 @@ func (in *ReplicationGroupObservation) DeepCopyInto(out *ReplicationGroupObserva
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ClusterOperationMode != nil {
+		in, out := &in.ClusterOperationMode, &out.ClusterOperationMode
+		*out = new(string)
+		**out = **in
+	}
 	if in.ConfigurationEndpointAddress != nil {
 		in, out := &in.ConfigurationEndpointAddress, &out.ConfigurationEndpointAddress
 		*out = new(string)
@@ -3339,6 +3349,11 @@ func (in *ReplicationGroupParameters) DeepCopyInto(out *ReplicationGroupParamete
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.ClusterOperationMode != nil {
+		in, out := &in.ClusterOperationMode, &out.ClusterOperationMode
+		*out = new(string)
+		**out = **in
 	}
 	if in.DataTieringEnabled != nil {
 		in, out := &in.DataTieringEnabled, &out.DataTieringEnabled

--- a/apis/cluster/elasticache/v1beta1/zz_replicationgroup_types.go
+++ b/apis/cluster/elasticache/v1beta1/zz_replicationgroup_types.go
@@ -162,6 +162,15 @@ type ReplicationGroupInitParameters struct {
 	// Create a native Redis cluster. automatic_failover_enabled must be set to true. Cluster Mode documented below. Only 1 cluster_mode block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter cluster-enabled set to true.
 	ClusterMode []ClusterModeInitParameters `json:"clusterMode,omitempty" tf:"cluster_mode,omitempty"`
 
+	// Specifies whether cluster mode is enabled or disabled. Valid values are enabled or disabled or compatible
+	// To modify cluster mode from Disabled to Enabled, you must
+	// first set the cluster mode to Compatible. Compatible mode allows your Valkey or
+	// Redis OSS clients to connect using both cluster mode enabled and cluster mode
+	// disabled. After you migrate all Valkey or Redis OSS clients to use cluster mode
+	// enabled, you can then complete cluster mode configuration and set the cluster
+	// mode to Enabled.
+	ClusterOperationMode *string `json:"clusterOperationMode,omitempty" tf:"cluster_operation_mode,omitempty"`
+
 	// Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to true when using r6gd nodes.
 	DataTieringEnabled *bool `json:"dataTieringEnabled,omitempty" tf:"data_tiering_enabled,omitempty"`
 
@@ -400,6 +409,15 @@ type ReplicationGroupObservation struct {
 	// Create a native Redis cluster. automatic_failover_enabled must be set to true. Cluster Mode documented below. Only 1 cluster_mode block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter cluster-enabled set to true.
 	ClusterMode []ClusterModeObservation `json:"clusterMode,omitempty" tf:"cluster_mode,omitempty"`
 
+	// Specifies whether cluster mode is enabled or disabled. Valid values are enabled or disabled or compatible
+	// To modify cluster mode from Disabled to Enabled, you must
+	// first set the cluster mode to Compatible. Compatible mode allows your Valkey or
+	// Redis OSS clients to connect using both cluster mode enabled and cluster mode
+	// disabled. After you migrate all Valkey or Redis OSS clients to use cluster mode
+	// enabled, you can then complete cluster mode configuration and set the cluster
+	// mode to Enabled.
+	ClusterOperationMode *string `json:"clusterOperationMode,omitempty" tf:"cluster_operation_mode,omitempty"`
+
 	// Address of the replication group configuration endpoint when cluster mode is enabled.
 	ConfigurationEndpointAddress *string `json:"configurationEndpointAddress,omitempty" tf:"configuration_endpoint_address,omitempty"`
 
@@ -589,6 +607,15 @@ type ReplicationGroupParameters struct {
 	// Create a native Redis cluster. automatic_failover_enabled must be set to true. Cluster Mode documented below. Only 1 cluster_mode block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter cluster-enabled set to true.
 	// +kubebuilder:validation:Optional
 	ClusterMode []ClusterModeParameters `json:"clusterMode,omitempty" tf:"cluster_mode,omitempty"`
+
+	// Specifies whether cluster mode is enabled or disabled. Valid values are enabled or disabled or compatible
+	// To modify cluster mode from Disabled to Enabled, you must
+	// first set the cluster mode to Compatible. Compatible mode allows your Valkey or
+	// Redis OSS clients to connect using both cluster mode enabled and cluster mode
+	// disabled. After you migrate all Valkey or Redis OSS clients to use cluster mode
+	// enabled, you can then complete cluster mode configuration and set the cluster
+	// mode to Enabled.
+	ClusterOperationMode *string `json:"clusterOperationMode,omitempty" tf:"cluster_operation_mode,omitempty"`
 
 	// Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to true when using r6gd nodes.
 	// +kubebuilder:validation:Optional

--- a/config/cluster/elasticache/config.go
+++ b/config/cluster/elasticache/config.go
@@ -142,6 +142,16 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 						targetTyped.Status.AtProvider.ReplicasPerNodeGroup = srcTyped.Status.AtProvider.ClusterMode[0].ReplicasPerNodeGroup
 					}
 				}
+				// cluster_mode renaming
+				if srcTyped.Spec.ForProvider.ClusterOperationMode != nil {
+					targetTyped.Spec.ForProvider.ClusterMode = srcTyped.Spec.ForProvider.ClusterOperationMode
+				}
+				if srcTyped.Spec.InitProvider.ClusterOperationMode != nil {
+					targetTyped.Spec.InitProvider.ClusterMode = srcTyped.Spec.InitProvider.ClusterOperationMode
+				}
+				if srcTyped.Status.AtProvider.ClusterOperationMode != nil {
+					targetTyped.Status.AtProvider.ClusterMode = srcTyped.Status.AtProvider.ClusterOperationMode
+				}
 				return nil
 			}),
 			conversion.NewCustomConverter("v1beta2", "v1beta1", func(src, target xpresource.Managed) error {
@@ -173,6 +183,17 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 					cmo.ReplicasPerNodeGroup = srcTyped.Status.AtProvider.ReplicasPerNodeGroup
 				}
 				targetTyped.Status.AtProvider.ClusterMode = []v1beta1.ClusterModeObservation{cmo}
+
+				// cluster_mode renaming
+				if srcTyped.Spec.ForProvider.ClusterMode != nil {
+					targetTyped.Spec.ForProvider.ClusterOperationMode = srcTyped.Spec.ForProvider.ClusterMode
+				}
+				if srcTyped.Spec.InitProvider.ClusterMode != nil {
+					targetTyped.Spec.InitProvider.ClusterOperationMode = srcTyped.Spec.InitProvider.ClusterMode
+				}
+				if srcTyped.Status.AtProvider.ClusterMode != nil {
+					targetTyped.Status.AtProvider.ClusterOperationMode = srcTyped.Status.AtProvider.ClusterMode
+				}
 				return nil
 			}),
 		)

--- a/package/crds/elasticache.aws.upbound.io_replicationgroups.yaml
+++ b/package/crds/elasticache.aws.upbound.io_replicationgroups.yaml
@@ -153,6 +153,16 @@ spec:
                           type: number
                       type: object
                     type: array
+                  clusterOperationMode:
+                    description: |-
+                      Specifies whether cluster mode is enabled or disabled. Valid values are enabled or disabled or compatible
+                      To modify cluster mode from Disabled to Enabled, you must
+                      first set the cluster mode to Compatible. Compatible mode allows your Valkey or
+                      Redis OSS clients to connect using both cluster mode enabled and cluster mode
+                      disabled. After you migrate all Valkey or Redis OSS clients to use cluster mode
+                      enabled, you can then complete cluster mode configuration and set the cluster
+                      mode to Enabled.
+                    type: string
                   dataTieringEnabled:
                     description: Enables data tiering. Data tiering is only supported
                       for replication groups using the r6gd node type. This parameter
@@ -802,6 +812,16 @@ spec:
                           type: number
                       type: object
                     type: array
+                  clusterOperationMode:
+                    description: |-
+                      Specifies whether cluster mode is enabled or disabled. Valid values are enabled or disabled or compatible
+                      To modify cluster mode from Disabled to Enabled, you must
+                      first set the cluster mode to Compatible. Compatible mode allows your Valkey or
+                      Redis OSS clients to connect using both cluster mode enabled and cluster mode
+                      disabled. After you migrate all Valkey or Redis OSS clients to use cluster mode
+                      enabled, you can then complete cluster mode configuration and set the cluster
+                      mode to Enabled.
+                    type: string
                   dataTieringEnabled:
                     description: Enables data tiering. Data tiering is only supported
                       for replication groups using the r6gd node type. This parameter
@@ -1509,6 +1529,16 @@ spec:
                           type: number
                       type: object
                     type: array
+                  clusterOperationMode:
+                    description: |-
+                      Specifies whether cluster mode is enabled or disabled. Valid values are enabled or disabled or compatible
+                      To modify cluster mode from Disabled to Enabled, you must
+                      first set the cluster mode to Compatible. Compatible mode allows your Valkey or
+                      Redis OSS clients to connect using both cluster mode enabled and cluster mode
+                      disabled. After you migrate all Valkey or Redis OSS clients to use cluster mode
+                      enabled, you can then complete cluster mode configuration and set the cluster
+                      mode to Enabled.
+                    type: string
                   configurationEndpointAddress:
                     description: Address of the replication group configuration endpoint
                       when cluster mode is enabled.


### PR DESCRIPTION
### Description of your changes

This PR fixes a missing field backport in the cluster-scoped `v1beta1` API for `ReplicationGroup.elasticache.aws.upbound.io`.

The change is **not breaking**,  it only adds the field for for roundtrippability purposes, that was previously not specifiable in `v1beta1` . The storage and the reconcile version is already v1beta2.

> [!NOTE]
> Cluster-scoped `v1beta2`+ and namespaced APIs (`*.elasticache.aws.m.upbound.io`) are not affected/changed.

The `cluster_mode` Terraform attribute was renamed/split across provider versions: the legacy block-style `cluster_mode {}` (with `num_node_groups` / `replicas_per_node_group`) is still represented in v1beta1 as the existing `clusterMode[]` array, but the newer scalar attribute `cluster_operation_mode` (a string with values `enabled`, `disabled`, or `compatible`) was present in v1beta2 as `clusterMode *string` but had no corresponding field in v1beta1.

Added `clusterOperationMode` (string) to v1beta1 and the bidirectional conversion logic to round-trip it against v1beta2's `clusterMode` string field:

- `spec.forProvider.clusterOperationMode`
- `spec.initProvider.clusterOperationMode`
- `status.atProvider.clusterOperationMode`

**Conversion mapping** (`config/cluster/elasticache/config.go`):
- `v1beta1 → v1beta2`: `spec.forProvider.clusterOperationMode` → `spec.forProvider.clusterMode`
- `v1beta1 → v1beta2`: `spec.initProvider.clusterOperationMode` → `spec.initProvider.clusterMode`
- `v1beta1 → v1beta2`: `status.atProvider.clusterOperationMode` → `status.atProvider.clusterMode`
- `v1beta2 → v1beta1`: reverse of the above

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

- using the new roundtrip testing library at https://github.com/crossplane/upjet/pull/636
- uptest manually

[contribution process]: https://git.io/fj2m9
