### PR TITLE
Add bobh66 as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,4 +19,4 @@
 # See also OWNERS.md for governance details
 
 # Fallback owners
-*			@sergenyalcin @turkenf @jastang @erhancagirici @ulucinar
+*			@sergenyalcin @turkenf @jastang @erhancagirici @ulucinar @bobh66

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -17,6 +17,7 @@ repository maintainers in their own `OWNERS.md` file.
 * Jason Tang <jasont@upbound.io> ([jastang](https://github.com/jastang))
 * Erhan Cagirici <erhan@upbound.io> ([erhancagirici](https://github.com/erhancagirici))
 * Alper Ulucinar <alper@upbound.io> ([ulucinar](https://github.com/ulucinar))
+* Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
 
 See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.
 


### PR DESCRIPTION
### Description of your changes

Adds Bob Haddleton ([bobh66](https://github.com/bobh66)) as a maintainer of `provider-upjet-aws` per the [Crossplane governance process](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md).

- `OWNERS.md`: adds Bob's entry under Maintainers (email taken from [crossplane/crossplane OWNERS.md](https://github.com/crossplane/crossplane/blob/main/OWNERS.md)).
- `CODEOWNERS`: adds `@bobh66` as a fallback reviewer for automatic PR assignment, matching the precedent set in commit 0efb79b6b ("Add ulucinar as codeowner").

The remaining governance steps (CNCF `project-maintainers.csv` update, GitHub team membership, and `cncf-crossplane-maintainers@lists.cncf.io` mailing list) require existing-maintainer action outside this repo.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `make generate` and committed the results (ideally in a separate commit).~~ N/A — no generated files affected.
- [ ] ~~Not made any manual changes to generated files, and verified this with `make check-diff`.~~ N/A — no generated files affected.

### How has this code been tested

This change is governance metadata only — no runtime/code behavior to test. Verification is by review:

- Visual review of the `OWNERS.md` and `CODEOWNERS` diff.
- Approval per the 2/3 super-majority requirement of existing maintainers in [GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md).

[contribution process]: https://git.io/fj2m9