### PR TITLE
renovate: Remove invalid wildcards from renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -149,7 +149,7 @@
       // We want dedicated PRs for each bump to non-kubernetes Go dependencies, but
       // only if there are known vulnerabilities in the current version.
       "matchDatasources": ["go"],
-      "matchPackageNames": ["*", "!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
+      "matchPackageNames": ["!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
       "enabled": false,
       "matchUpdateTypes": ["major"]
     },
@@ -158,7 +158,7 @@
       // dependencies, but only if there are known vulnerabilities in the current
       // version.
       "matchDatasources": ["go"],
-      "matchPackageNames": ["*", "!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
+      "matchPackageNames": ["!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
       "enabled": false,
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "groupName": "all non-major go dependencies"


### PR DESCRIPTION
### Description of your changes

Removed unnecessary wildcards from the renovate config

I have:

- [X] Read and followed Crossplane's [contribution process].
~- [] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->~
- [X] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested
renovate-config-validator ran successfully.

[contribution process]: https://git.io/fj2m9
