### PR TITLE
fix(clients): preserve refreshable no-fork AWS credentials

### DIFF
--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/upjet/v2/pkg/metrics"
 	"github.com/crossplane/upjet/v2/pkg/terraform"
+	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/xpprovider"
@@ -340,21 +341,73 @@ func withExternalAPICallCounter(stack *middleware.Stack) error {
 	return stack.Deserialize.Add(externalAPICallCounterMiddleware, middleware.After)
 }
 
+func buildNoForkAWSConfig(region string, creds aws.Credentials, pc *namespacedv1beta1.ClusterProviderConfig) xpprovider.AWSConfig {
+	tfAwsConnsCfg := xpprovider.AWSConfig{
+		Endpoints:               map[string]string{},
+		Region:                  region,
+		SkipCredsValidation:     true, // disabled to prevent extra AWS STS call
+		SkipRequestingAccountId: true, // disabled to prevent extra AWS STS call
+	}
+	if pc != nil {
+		tfAwsConnsCfg.S3UsePathStyle = pc.Spec.S3UsePathStyle
+		tfAwsConnsCfg.SkipRegionValidation = pc.Spec.SkipRegionValidation
+	}
+
+	// Keep IRSA and PodIdentity credentials dynamic in no-fork mode so the
+	// underlying Terraform AWS client can auto-refresh temporary credentials.
+	if useDynamicNoForkCredentials(pc) {
+		tfAwsConnsCfg.AssumeRole = toAWSBaseAssumeRoleChain(pc.Spec.AssumeRoleChain)
+		return tfAwsConnsCfg
+	}
+
+	// Fallback for auth methods that currently rely on pre-resolved credentials.
+	tfAwsConnsCfg.AccessKey = creds.AccessKeyID
+	tfAwsConnsCfg.SecretKey = creds.SecretAccessKey
+	tfAwsConnsCfg.Token = creds.SessionToken
+	return tfAwsConnsCfg
+}
+
+func useDynamicNoForkCredentials(pc *namespacedv1beta1.ClusterProviderConfig) bool {
+	if pc == nil {
+		return false
+	}
+	switch pc.Spec.Credentials.Source {
+	case authKeyIRSA, authKeyPodIdentity:
+		return true
+	default:
+		return false
+	}
+}
+
+func toAWSBaseAssumeRoleChain(chain []namespacedv1beta1.AssumeRoleOptions) []awsbase.AssumeRole {
+	if len(chain) == 0 {
+		return nil
+	}
+
+	result := make([]awsbase.AssumeRole, 0, len(chain))
+	for _, role := range chain {
+		r := awsbase.AssumeRole{
+			RoleARN:           aws.ToString(role.RoleARN),
+			ExternalID:        aws.ToString(role.ExternalID),
+			TransitiveTagKeys: append([]string(nil), role.TransitiveTagKeys...),
+		}
+		if len(role.Tags) > 0 {
+			r.Tags = make(map[string]string, len(role.Tags))
+			for _, t := range role.Tags {
+				r.Tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+		}
+		result = append(result, r)
+	}
+
+	return result
+}
+
 // configureNoForkAWSClient populates the supplied *terraform.Setup with
 // Terraform Plugin SDK style AWS client (Meta) and Terraform Plugin Framework
 // style FrameworkProvider
 func configureNoForkAWSClient(ctx context.Context, ps *terraform.Setup, config *SetupConfig, region string, creds aws.Credentials, pc *namespacedv1beta1.ClusterProviderConfig) error { //nolint:gocyclo
-	tfAwsConnsCfg := xpprovider.AWSConfig{
-		AccessKey:               creds.AccessKeyID,
-		Endpoints:               map[string]string{},
-		Region:                  region,
-		S3UsePathStyle:          pc.Spec.S3UsePathStyle,
-		SecretKey:               creds.SecretAccessKey,
-		SkipCredsValidation:     true, // disabled to prevent extra AWS STS call
-		SkipRegionValidation:    pc.Spec.SkipRegionValidation,
-		SkipRequestingAccountId: true, // disabled to prevent extra AWS STS call
-		Token:                   creds.SessionToken,
-	}
+	tfAwsConnsCfg := buildNoForkAWSConfig(region, creds, pc)
 
 	if pc.Spec.SkipMetadataApiCheck {
 		tfAwsConnsCfg.EC2MetadataServiceEnableState = imds.ClientDisabled

--- a/internal/clients/aws_test.go
+++ b/internal/clients/aws_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/google/go-cmp/cmp"
+	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
+	namespacedv1beta1 "github.com/upbound/provider-aws/v2/apis/namespaced/v1beta1"
+	"k8s.io/utils/ptr"
+)
+
+func TestBuildNoForkAWSConfig(t *testing.T) {
+	creds := aws.Credentials{
+		AccessKeyID:     "access-key",
+		SecretAccessKey: "secret-key",
+		SessionToken:    "session-token",
+	}
+	region := "us-west-2"
+
+	cases := map[string]struct {
+		reason         string
+		pc             *namespacedv1beta1.ClusterProviderConfig
+		wantStaticCred bool
+		wantAssumeRole []awsbase.AssumeRole
+	}{
+		"IRSADynamicWithoutRoleChain": {
+			reason: "IRSA auth should keep credentials dynamic so they can be refreshed by Terraform provider.",
+			pc: &namespacedv1beta1.ClusterProviderConfig{
+				Spec: namespacedv1beta1.ProviderConfigSpec{
+					Credentials: namespacedv1beta1.ProviderCredentials{
+						Source: xpv1.CredentialsSource(authKeyIRSA),
+					},
+				},
+			},
+			wantStaticCred: false,
+		},
+		"PodIdentityDynamicWithRoleChain": {
+			reason: "PodIdentity auth should also use dynamic credentials and pass role chain to Terraform config.",
+			pc: &namespacedv1beta1.ClusterProviderConfig{
+				Spec: namespacedv1beta1.ProviderConfigSpec{
+					Credentials: namespacedv1beta1.ProviderCredentials{
+						Source: xpv1.CredentialsSource(authKeyPodIdentity),
+					},
+					S3UsePathStyle:       true,
+					SkipRegionValidation: true,
+					AssumeRoleChain: []namespacedv1beta1.AssumeRoleOptions{
+						{
+							RoleARN:    ptr.To("arn:aws:iam::111111111111:role/target"),
+							ExternalID: ptr.To("external-id"),
+							Tags: []namespacedv1beta1.Tag{
+								{
+									Key:   ptr.To("team"),
+									Value: ptr.To("platform"),
+								},
+							},
+							TransitiveTagKeys: []string{"team"},
+						},
+					},
+				},
+			},
+			wantStaticCred: false,
+			wantAssumeRole: []awsbase.AssumeRole{
+				{
+					RoleARN:           "arn:aws:iam::111111111111:role/target",
+					ExternalID:        "external-id",
+					Tags:              map[string]string{"team": "platform"},
+					TransitiveTagKeys: []string{"team"},
+				},
+			},
+		},
+		"SecretAuthUsesStaticCredentials": {
+			reason: "Secret-based auth should preserve existing static credential behavior.",
+			pc: &namespacedv1beta1.ClusterProviderConfig{
+				Spec: namespacedv1beta1.ProviderConfigSpec{
+					Credentials: namespacedv1beta1.ProviderCredentials{
+						Source: xpv1.CredentialsSourceSecret,
+					},
+				},
+			},
+			wantStaticCred: true,
+		},
+		"NilProviderConfigFallsBackToStatic": {
+			reason:         "A nil ProviderConfig should defensively fall back to static credentials.",
+			pc:             nil,
+			wantStaticCred: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := buildNoForkAWSConfig(region, creds, tc.pc)
+
+			if got.Region != region {
+				t.Fatalf("%s: got region %q, want %q", tc.reason, got.Region, region)
+			}
+			if !got.SkipCredsValidation {
+				t.Fatalf("%s: SkipCredsValidation should be true", tc.reason)
+			}
+			if !got.SkipRequestingAccountId {
+				t.Fatalf("%s: SkipRequestingAccountId should be true", tc.reason)
+			}
+
+			if tc.wantStaticCred {
+				if got.AccessKey != creds.AccessKeyID {
+					t.Fatalf("%s: got access key %q, want %q", tc.reason, got.AccessKey, creds.AccessKeyID)
+				}
+				if got.SecretKey != creds.SecretAccessKey {
+					t.Fatalf("%s: got secret key %q, want %q", tc.reason, got.SecretKey, creds.SecretAccessKey)
+				}
+				if got.Token != creds.SessionToken {
+					t.Fatalf("%s: got session token %q, want %q", tc.reason, got.Token, creds.SessionToken)
+				}
+			} else {
+				if got.AccessKey != "" || got.SecretKey != "" || got.Token != "" {
+					t.Fatalf("%s: expected dynamic credentials configuration without static key material", tc.reason)
+				}
+			}
+
+			if diff := cmp.Diff(tc.wantAssumeRole, got.AssumeRole); diff != "" {
+				t.Fatalf("%s: AssumeRole mismatch (-want,+got):\n%s", tc.reason, diff)
+			}
+
+			if tc.pc != nil {
+				if got.S3UsePathStyle != tc.pc.Spec.S3UsePathStyle {
+					t.Fatalf("%s: got S3UsePathStyle %t, want %t", tc.reason, got.S3UsePathStyle, tc.pc.Spec.S3UsePathStyle)
+				}
+				if got.SkipRegionValidation != tc.pc.Spec.SkipRegionValidation {
+					t.Fatalf("%s: got SkipRegionValidation %t, want %t", tc.reason, got.SkipRegionValidation, tc.pc.Spec.SkipRegionValidation)
+				}
+			}
+		})
+	}
+}

--- a/internal/clients/aws_test.go
+++ b/internal/clients/aws_test.go
@@ -85,6 +85,28 @@ func TestBuildNoForkAWSConfig(t *testing.T) {
 			},
 			wantStaticCred: true,
 		},
+		"WebIdentityAuthUsesStaticCredentials": {
+			reason: "WebIdentity currently relies on pre-resolved credentials and should keep static fields populated.",
+			pc: &namespacedv1beta1.ClusterProviderConfig{
+				Spec: namespacedv1beta1.ProviderConfigSpec{
+					Credentials: namespacedv1beta1.ProviderCredentials{
+						Source: xpv1.CredentialsSource(authKeyWebIdentity),
+					},
+				},
+			},
+			wantStaticCred: true,
+		},
+		"UpboundAuthUsesStaticCredentials": {
+			reason: "Upbound auth currently relies on pre-resolved credentials and should keep static fields populated.",
+			pc: &namespacedv1beta1.ClusterProviderConfig{
+				Spec: namespacedv1beta1.ProviderConfigSpec{
+					Credentials: namespacedv1beta1.ProviderCredentials{
+						Source: xpv1.CredentialsSource(authKeyUpbound),
+					},
+				},
+			},
+			wantStaticCred: true,
+		},
 		"NilProviderConfigFallsBackToStatic": {
 			reason:         "A nil ProviderConfig should defensively fall back to static credentials.",
 			pc:             nil,
@@ -135,5 +157,37 @@ func TestBuildNoForkAWSConfig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUseDynamicNoForkCredentials(t *testing.T) {
+	cases := map[string]struct {
+		source xpv1.CredentialsSource
+		want   bool
+	}{
+		"IRSA":        {source: xpv1.CredentialsSource(authKeyIRSA), want: true},
+		"PodIdentity": {source: xpv1.CredentialsSource(authKeyPodIdentity), want: true},
+		"Secret":      {source: xpv1.CredentialsSourceSecret, want: false},
+		"WebIdentity": {source: xpv1.CredentialsSource(authKeyWebIdentity), want: false},
+		"Upbound":     {source: xpv1.CredentialsSource(authKeyUpbound), want: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			pc := &namespacedv1beta1.ClusterProviderConfig{
+				Spec: namespacedv1beta1.ProviderConfigSpec{
+					Credentials: namespacedv1beta1.ProviderCredentials{
+						Source: tc.source,
+					},
+				},
+			}
+			if got := useDynamicNoForkCredentials(pc); got != tc.want {
+				t.Fatalf("useDynamicNoForkCredentials() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+
+	if got := useDynamicNoForkCredentials(nil); got {
+		t.Fatalf("useDynamicNoForkCredentials(nil) = true, want false")
 	}
 }

--- a/internal/clients/creds_cache_test.go
+++ b/internal/clients/creds_cache_test.go
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/upbound/provider-aws/v2/apis/namespaced/v1beta1"
+)
+
+type fakeCredentialsProvider struct {
+	creds  aws.Credentials
+	err    error
+	called int32
+}
+
+func (f *fakeCredentialsProvider) Retrieve(context.Context) (aws.Credentials, error) {
+	atomic.AddInt32(&f.called, 1)
+	if f.err != nil {
+		return aws.Credentials{}, f.err
+	}
+	return f.creds, nil
+}
+
+func newClusterProviderConfig(source xpv1.CredentialsSource, uid string, generation int64) *v1beta1.ClusterProviderConfig {
+	return &v1beta1.ClusterProviderConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:        types.UID(uid),
+			Generation: generation,
+		},
+		Spec: v1beta1.ProviderConfigSpec{
+			Credentials: v1beta1.ProviderCredentials{
+				Source: source,
+			},
+		},
+	}
+}
+
+func TestAWSCredentialsProviderCacheRetrieveCredentialsIRSACachesAccountID(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "web-identity-token")
+	if err := os.WriteFile(tokenFile, []byte("token"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(tokenFile): %v", err)
+	}
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFile)
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::111111111111:role/test")
+
+	provider := &fakeCredentialsProvider{
+		creds: aws.Credentials{
+			AccessKeyID:     "access-key",
+			SecretAccessKey: "secret-key",
+			SessionToken:    "session-token",
+		},
+	}
+	credCache := aws.NewCredentialsCache(provider)
+	cache := NewAWSCredentialsProviderCache()
+	pc := newClusterProviderConfig(xpv1.CredentialsSource(authKeyIRSA), "pc-irsa", 1)
+
+	accountIDCalls := 0
+	accountIDFn := func(context.Context) (string, error) {
+		accountIDCalls++
+		return "111111111111", nil
+	}
+
+	first, err := cache.RetrieveCredentials(context.Background(), pc, "us-west-2", credCache, accountIDFn)
+	if err != nil {
+		t.Fatalf("RetrieveCredentials(first): %v", err)
+	}
+	second, err := cache.RetrieveCredentials(context.Background(), pc, "us-west-2", credCache, accountIDFn)
+	if err != nil {
+		t.Fatalf("RetrieveCredentials(second): %v", err)
+	}
+
+	if first.accountID != "111111111111" || second.accountID != "111111111111" {
+		t.Fatalf("expected cached account ID to be preserved, got first=%q second=%q", first.accountID, second.accountID)
+	}
+	if accountIDCalls != 1 {
+		t.Fatalf("accountIDFn calls = %d, want 1", accountIDCalls)
+	}
+	if got := atomic.LoadInt32(&provider.called); got != 1 {
+		t.Fatalf("credentials provider retrieve calls = %d, want 1", got)
+	}
+	if len(cache.cache) != 1 {
+		t.Fatalf("cache size = %d, want 1", len(cache.cache))
+	}
+}
+
+func TestAWSCredentialsProviderCacheRetrieveCredentialsNonIRSASkipsAccountIDFn(t *testing.T) {
+	provider := &fakeCredentialsProvider{
+		creds: aws.Credentials{
+			AccessKeyID:     "access-key",
+			SecretAccessKey: "secret-key",
+			SessionToken:    "session-token",
+		},
+	}
+	cache := NewAWSCredentialsProviderCache()
+	pc := newClusterProviderConfig(xpv1.CredentialsSourceSecret, "pc-secret", 1)
+
+	accountIDCalled := false
+	got, err := cache.RetrieveCredentials(context.Background(), pc, "us-west-2", provider, func(context.Context) (string, error) {
+		accountIDCalled = true
+		return "111111111111", nil
+	})
+	if err != nil {
+		t.Fatalf("RetrieveCredentials(non-irsa): %v", err)
+	}
+
+	if accountIDCalled {
+		t.Fatalf("accountIDFn should not be called for non-IRSA credentials")
+	}
+	if got.accountID != "" {
+		t.Fatalf("account ID = %q, want empty", got.accountID)
+	}
+	if len(cache.cache) != 0 {
+		t.Fatalf("cache size = %d, want 0", len(cache.cache))
+	}
+}
+
+func TestAWSCredentialsProviderCacheRetrieveCredentialsIRSAWithoutCredentialCacheSkipsAccountIDFn(t *testing.T) {
+	provider := &fakeCredentialsProvider{
+		creds: aws.Credentials{
+			AccessKeyID:     "access-key",
+			SecretAccessKey: "secret-key",
+			SessionToken:    "session-token",
+		},
+	}
+	cache := NewAWSCredentialsProviderCache()
+	pc := newClusterProviderConfig(xpv1.CredentialsSource(authKeyIRSA), "pc-irsa-no-cache", 1)
+
+	accountIDCalled := false
+	got, err := cache.RetrieveCredentials(context.Background(), pc, "us-west-2", provider, func(context.Context) (string, error) {
+		accountIDCalled = true
+		return "111111111111", nil
+	})
+	if err != nil {
+		t.Fatalf("RetrieveCredentials(irsa-no-cache): %v", err)
+	}
+
+	if accountIDCalled {
+		t.Fatalf("accountIDFn should not be called when credentials provider is not aws.CredentialsCache")
+	}
+	if got.accountID != "" {
+		t.Fatalf("account ID = %q, want empty", got.accountID)
+	}
+	if len(cache.cache) != 0 {
+		t.Fatalf("cache size = %d, want 0", len(cache.cache))
+	}
+}


### PR DESCRIPTION
### Description of your changes

Related: #2128

This PR addresses `ExpiredToken` failures in the no-fork auth path for long-running async reconciliations (for example, RDS create/update flows that can run long enough for a temporary session to expire).

#### Root cause

In `configureNoForkAWSClient`, we always converted credentials retrieved from the AWS SDK into static values:

- `AccessKey`
- `SecretKey`
- `Token`

That conversion effectively removed refresh behavior for temporary credentials in no-fork mode. If an operation outlived the session TTL, reconciles could fail with `ExpiredToken`.

#### What this PR changes

1. Keeps credentials **dynamic** for `IRSA` and `PodIdentity` in no-fork mode (no static key/token injection).
2. Preserves role chaining in that dynamic path by mapping `spec.assumeRoleChain` into Terraform AWS config.
3. Leaves existing static behavior unchanged for `Secret`, `WebIdentity`, and `Upbound` auth sources to minimize regression risk.

#### Concrete before/after

- **Before**: one-time credential materialization -> static token in no-fork client -> token can expire mid-async operation.
- **After**: IRSA/PodIdentity rely on provider-chain credentials in no-fork client -> token can refresh during long operations.

#### Scope and non-goals

- This PR is scoped to the no-fork auth credential handoff path.
- It does **not** claim to solve all failure modes in #2128 (e.g., identity mismatch after a prior failure), but it removes one major trigger condition: token expiry caused by static credential injection.

### I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added/updated unit tests for changed behavior.
- [x] Kept changes scoped to non-generated client logic and tests.

### How has this code been tested

- [x] `go test ./internal/clients -run "TestBuildNoForkAWSConfig" -count=1`
- [x] `go test ./internal/clients -count=1`
- [x] `go test ./internal/clients -coverprofile=/tmp/internal-clients.cover.out -count=1 && go tool cover -func=/tmp/internal-clients.cover.out`

Additional coverage added in this PR:

- `internal/clients/aws_test.go`
  - dynamic vs static auth-mode selection guardrails
  - explicit behavior checks for `IRSA`, `PodIdentity`, `Secret`, `WebIdentity`, `Upbound`
  - assume-role chain mapping assertions
- `internal/clients/creds_cache_test.go`
  - IRSA cache hit/miss behavior
  - non-IRSA and non-`aws.CredentialsCache` branches
  - account ID callback/caching semantics

Coverage observations from `go tool cover -func` for the touched logic:

- `buildNoForkAWSConfig`: 100%
- `useDynamicNoForkCredentials`: 100%
- `toAWSBaseAssumeRoleChain`: 100%
- `AWSCredentialsProviderCache.RetrieveCredentials`: 91.2%

[contribution process]: https://git.io/fj2m9