### PR TITLE
Add custom diff and custom late initialize function for elbv2.LBListenerRule resource

### DIFF
--- a/apis/cluster/elbv2/v1beta1/zz_lblistenerrule_terraformed.go
+++ b/apis/cluster/elbv2/v1beta1/zz_lblistenerrule_terraformed.go
@@ -120,10 +120,58 @@ func (tr *LBListenerRule) LateInitialize(attrs []byte) (bool, error) {
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 
 	li := resource.NewGenericLateInitializer(opts...)
-	return li.LateInitialize(&tr.Spec.ForProvider, params)
+	changed, err := li.LateInitialize(&tr.Spec.ForProvider, params)
+	if err != nil {
+		return false, err
+	}
+	forcedChanged, err := lbListenerRuleForcedLateInitAction(&tr.Spec.ForProvider, params)
+	if err != nil {
+		return false, err
+	}
+	return changed || forcedChanged, nil
 }
 
 // GetTerraformSchemaVersion returns the associated Terraform schema version
 func (tr *LBListenerRule) GetTerraformSchemaVersion() int {
 	return 0
+}
+
+// lbListenerRuleForcedLateInitAction forces late-initialization of nil fields
+// within each element of the action slice. The generic late-initializer skips
+// the entire action slice once it is non-nil (i.e. the user set any action
+// field), so auto-assigned fields like order are never written back to spec,
+// causing a perpetual reconcile loop. This function re-runs late-init at the
+// individual action-element level so that all remaining nil fields are
+// populated from the observed Terraform state.
+//
+// It also recurses into each element of a partially filled Forward slice so
+// that nil sub-fields (e.g. Stickiness) are populated as well.
+func lbListenerRuleForcedLateInitAction(spec, observed *LBListenerRuleParameters) (bool, error) {
+	if len(spec.Action) == 0 || len(spec.Action) != len(observed.Action) {
+		return false, nil
+	}
+	li := resource.NewGenericLateInitializer(resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard))
+	changed := false
+	for i := range spec.Action {
+		c, err := li.LateInitialize(&spec.Action[i], &observed.Action[i])
+		if err != nil {
+			return false, err
+		}
+		changed = changed || c
+		if len(observed.Action[i].Forward) > 0 {
+			if len(spec.Action[i].Forward) == 0 {
+				spec.Action[i].Forward = observed.Action[i].Forward
+				changed = true
+			} else if len(spec.Action[i].Forward) == len(observed.Action[i].Forward) {
+				for j := range spec.Action[i].Forward {
+					c, err = li.LateInitialize(&spec.Action[i].Forward[j], &observed.Action[i].Forward[j])
+					if err != nil {
+						return false, err
+					}
+					changed = changed || c
+				}
+			}
+		}
+	}
+	return changed, nil
 }

--- a/apis/cluster/elbv2/v1beta2/zz_lblistenerrule_terraformed.go
+++ b/apis/cluster/elbv2/v1beta2/zz_lblistenerrule_terraformed.go
@@ -122,10 +122,56 @@ func (tr *LBListenerRule) LateInitialize(attrs []byte) (bool, error) {
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 
 	li := resource.NewGenericLateInitializer(opts...)
-	return li.LateInitialize(&tr.Spec.ForProvider, params)
+	changed, err := li.LateInitialize(&tr.Spec.ForProvider, params)
+	if err != nil {
+		return false, err
+	}
+	forcedChanged, err := lbListenerRuleForcedLateInitAction(&tr.Spec.ForProvider, params)
+	if err != nil {
+		return false, err
+	}
+	return changed || forcedChanged, nil
 }
 
 // GetTerraformSchemaVersion returns the associated Terraform schema version
 func (tr *LBListenerRule) GetTerraformSchemaVersion() int {
 	return 0
+}
+
+// lbListenerRuleForcedLateInitAction forces late-initialization of nil fields
+// within each element of the action slice. The generic late-initializer skips
+// the entire action slice once it is non-nil (i.e. the user set any action
+// field), so auto-assigned fields like order are never written back to spec,
+// causing a perpetual reconcile loop. This function re-runs late-init at the
+// individual action-element level so that all remaining nil fields are
+// populated from the observed Terraform state.
+//
+// It also recurses into a partially filled Forward block so that nil
+// sub-fields (e.g. Stickiness) are populated as well.
+func lbListenerRuleForcedLateInitAction(spec, observed *LBListenerRuleParameters) (bool, error) {
+	if len(spec.Action) == 0 || len(spec.Action) != len(observed.Action) {
+		return false, nil
+	}
+	li := resource.NewGenericLateInitializer(resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard))
+	changed := false
+	for i := range spec.Action {
+		c, err := li.LateInitialize(&spec.Action[i], &observed.Action[i])
+		if err != nil {
+			return false, err
+		}
+		changed = changed || c
+		if observed.Action[i].Forward != nil {
+			if spec.Action[i].Forward == nil {
+				spec.Action[i].Forward = observed.Action[i].Forward
+				changed = true
+			} else {
+				c, err = li.LateInitialize(spec.Action[i].Forward, observed.Action[i].Forward)
+				if err != nil {
+					return false, err
+				}
+				changed = changed || c
+			}
+		}
+	}
+	return changed, nil
 }

--- a/apis/namespaced/elbv2/v1beta1/zz_lblistenerrule_terraformed.go
+++ b/apis/namespaced/elbv2/v1beta1/zz_lblistenerrule_terraformed.go
@@ -122,10 +122,56 @@ func (tr *LBListenerRule) LateInitialize(attrs []byte) (bool, error) {
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 
 	li := resource.NewGenericLateInitializer(opts...)
-	return li.LateInitialize(&tr.Spec.ForProvider, params)
+	changed, err := li.LateInitialize(&tr.Spec.ForProvider, params)
+	if err != nil {
+		return false, err
+	}
+	forcedChanged, err := lbListenerRuleForcedLateInitAction(&tr.Spec.ForProvider, params)
+	if err != nil {
+		return false, err
+	}
+	return changed || forcedChanged, nil
 }
 
 // GetTerraformSchemaVersion returns the associated Terraform schema version
 func (tr *LBListenerRule) GetTerraformSchemaVersion() int {
 	return 0
+}
+
+// lbListenerRuleForcedLateInitAction forces late-initialization of nil fields
+// within each element of the action slice. The generic late-initializer skips
+// the entire action slice once it is non-nil (i.e. the user set any action
+// field), so auto-assigned fields like order are never written back to spec,
+// causing a perpetual reconcile loop. This function re-runs late-init at the
+// individual action-element level so that all remaining nil fields are
+// populated from the observed Terraform state.
+//
+// It also recurses into a partially filled Forward block so that nil
+// sub-fields (e.g. Stickiness) are populated as well.
+func lbListenerRuleForcedLateInitAction(spec, observed *LBListenerRuleParameters) (bool, error) {
+	if len(spec.Action) == 0 || len(spec.Action) != len(observed.Action) {
+		return false, nil
+	}
+	li := resource.NewGenericLateInitializer(resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard))
+	changed := false
+	for i := range spec.Action {
+		c, err := li.LateInitialize(&spec.Action[i], &observed.Action[i])
+		if err != nil {
+			return false, err
+		}
+		changed = changed || c
+		if observed.Action[i].Forward != nil {
+			if spec.Action[i].Forward == nil {
+				spec.Action[i].Forward = observed.Action[i].Forward
+				changed = true
+			} else {
+				c, err = li.LateInitialize(spec.Action[i].Forward, observed.Action[i].Forward)
+				if err != nil {
+					return false, err
+				}
+				changed = changed || c
+			}
+		}
+	}
+	return changed, nil
 }

--- a/config/cluster/elbv2/config.go
+++ b/config/cluster/elbv2/config.go
@@ -5,7 +5,9 @@
 package elbv2
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -123,6 +125,10 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 	})
 
+	p.AddResourceConfigurator("aws_lb_listener_rule", func(r *config.Resource) {
+		r.TerraformCustomDiff = lbListenerRuleCustomDiff
+	})
+
 	p.AddResourceConfigurator("aws_lb_target_group", func(r *config.Resource) {
 		r.ExternalName.OmittedFields = append(r.ExternalName.OmittedFields, "name_prefix")
 		if s, ok := r.TerraformResource.Schema["name"]; ok {
@@ -159,4 +165,56 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.ShortGroup = "elbv2"
 		r.Kind = "LBTrustStore"
 	})
+}
+
+func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
+		return diff, nil
+	}
+	for k, attrDiff := range diff.Attributes {
+		if attrDiff == nil || !strings.HasPrefix(k, "action.") || !strings.HasSuffix(k, ".target_group_arn") {
+			continue
+		}
+		idx := strings.TrimPrefix(k, "action.")
+		idx = strings.TrimSuffix(idx, ".target_group_arn")
+
+		// Case A: arn absent from state, present in config — late-init artifact
+		// when the provider's Read took the flattenForwardActionOneOf path because
+		// forward is configured, stripping arn from state while late-init had
+		// already written it to spec.
+		if attrDiff.Old == "" && attrDiff.New != "" && configActionHasForward(cfg, idx) {
+			delete(diff.Attributes, k)
+		}
+
+		// Case B: arn present in state, absent from config — the provider's Read
+		// took the flattenForwardActionBoth path (null RawPlan after Update or
+		// restart), writing arn to state, while spec only declares forward.
+		if attrDiff.Old != "" && attrDiff.New == "" && attrDiff.NewRemoved {
+			forwardKey := fmt.Sprintf("action.%s.forward.#", idx)
+			if state != nil && state.Attributes[forwardKey] != "" && state.Attributes[forwardKey] != "0" {
+				delete(diff.Attributes, k)
+			}
+		}
+	}
+	return diff, nil
+}
+
+func configActionHasForward(cfg *terraform.ResourceConfig, actionIdx string) bool {
+	if cfg == nil || cfg.Config == nil {
+		return false
+	}
+	actions, ok := cfg.Config["action"].([]interface{})
+	if !ok {
+		return false
+	}
+	idx, err := strconv.Atoi(actionIdx)
+	if err != nil || idx < 0 || idx >= len(actions) {
+		return false
+	}
+	actionMap, ok := actions[idx].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	forwards, _ := actionMap["forward"].([]interface{})
+	return len(forwards) > 0
 }

--- a/config/cluster/elbv2/config.go
+++ b/config/cluster/elbv2/config.go
@@ -167,7 +167,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	})
 }
 
-func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo // easier to follow as a unit
 	if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
 		return diff, nil
 	}

--- a/config/cluster/elbv2/config_test.go
+++ b/config/cluster/elbv2/config_test.go
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package elbv2
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const testARN = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-tg/abc123"
+
+func configWithForward() *terraform.ResourceConfig {
+	return &terraform.ResourceConfig{
+		Config: map[string]interface{}{
+			"action": []interface{}{
+				map[string]interface{}{
+					"forward": []interface{}{
+						map[string]interface{}{
+							"target_group": []interface{}{
+								map[string]interface{}{"arn": testARN, "weight": 1},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func configWithARNOnly() *terraform.ResourceConfig {
+	return &terraform.ResourceConfig{
+		Config: map[string]interface{}{
+			"action": []interface{}{
+				map[string]interface{}{
+					"target_group_arn": testARN,
+				},
+			},
+		},
+	}
+}
+
+func TestLBListenerRuleCustomDiff(t *testing.T) {
+	cases := map[string]struct {
+		reason   string
+		diff     *terraform.InstanceDiff
+		state    *terraform.InstanceState
+		cfg      *terraform.ResourceConfig
+		wantKeys []string
+		goneKeys []string
+	}{
+		"NilDiff": {
+			reason: "nil diff passes through unchanged",
+			diff:   nil,
+		},
+		"EmptyDiff": {
+			reason: "empty diff passes through unchanged",
+			diff:   &terraform.InstanceDiff{},
+		},
+		"DestroyDiff": {
+			reason: "destroy diff is never modified",
+			diff: &terraform.InstanceDiff{
+				Destroy: true,
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		// Case A: arn absent from state (Old=""), present in config — late-init artifact
+		"CaseA_Suppressed": {
+			reason: "spurious arn addition is suppressed when the same action has forward configured",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg:      configWithForward(),
+			goneKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseA_NotSuppressed_NoForwardInConfig": {
+			reason: "arn addition is kept when action only has target_group_arn (real user intent)",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg:      configWithARNOnly(),
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseA_NotSuppressed_NilConfig": {
+			reason: "arn addition is kept when config is nil",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg:      nil,
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		// Case B: arn present in state (Old=arn), absent from config — null RawPlan path
+		"CaseB_Suppressed": {
+			reason: "spurious arn removal is suppressed when forward is active in state",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"action.0.forward.#": "1"},
+			},
+			goneKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseB_NotSuppressed_NoForwardInState": {
+			reason: "arn removal is kept when forward count is 0 in state",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"action.0.forward.#": "0"},
+			},
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseB_NotSuppressed_NilState": {
+			reason: "arn removal is kept when state is nil",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			state:    nil,
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"RealArnUpdate_NotSuppressed": {
+			reason: "a real arn change (both Old and New non-empty) is never suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "arn:old", New: "arn:new"},
+				},
+			},
+			cfg:      configWithForward(),
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"UnrelatedKeysUntouched": {
+			reason: "keys that do not match action.*.target_group_arn are left untouched",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.type":             {Old: "", New: "forward"},
+					"other.0.target_group_arn":  {Old: "", New: testARN},
+				},
+			},
+			cfg:      configWithForward(),
+			wantKeys: []string{"action.0.type", "other.0.target_group_arn"},
+		},
+		"MultipleActions_OnlySuppressesMatchingIndex": {
+			reason: "when two actions are present, only the one with forward in config is suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+					"action.1.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						// action 0: only arn, no forward
+						map[string]interface{}{"target_group_arn": testARN},
+						// action 1: forward configured
+						map[string]interface{}{
+							"forward": []interface{}{
+								map[string]interface{}{
+									"target_group": []interface{}{
+										map[string]interface{}{"arn": testARN, "weight": 1},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantKeys: []string{"action.0.target_group_arn"},
+			goneKeys: []string{"action.1.target_group_arn"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := lbListenerRuleCustomDiff(tc.diff, tc.state, tc.cfg)
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.reason, err)
+			}
+			if tc.diff == nil {
+				if got != nil {
+					t.Errorf("%s: expected nil diff, got non-nil", tc.reason)
+				}
+				return
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got.Attributes[k]; !ok {
+					t.Errorf("%s: key %q should be present but is missing", tc.reason, k)
+				}
+			}
+			for _, k := range tc.goneKeys {
+				if _, ok := got.Attributes[k]; ok {
+					t.Errorf("%s: key %q should have been suppressed but is still present", tc.reason, k)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigActionHasForward(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		cfg    *terraform.ResourceConfig
+		idx    string
+		want   bool
+	}{
+		"NilConfig": {
+			reason: "nil config returns false",
+			cfg:    nil,
+			idx:    "0",
+			want:   false,
+		},
+		"NilConfigMap": {
+			reason: "config with nil inner map returns false",
+			cfg:    &terraform.ResourceConfig{},
+			idx:    "0",
+			want:   false,
+		},
+		"NoActionsKey": {
+			reason: "config without an action key returns false",
+			cfg:    &terraform.ResourceConfig{Config: map[string]interface{}{}},
+			idx:    "0",
+			want:   false,
+		},
+		"InvalidIndex": {
+			reason: "non-numeric index returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{map[string]interface{}{}},
+				},
+			},
+			idx:  "abc",
+			want: false,
+		},
+		"OutOfRangeIndex": {
+			reason: "index beyond action slice length returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{map[string]interface{}{}},
+				},
+			},
+			idx:  "5",
+			want: false,
+		},
+		"NoForward": {
+			reason: "action with only target_group_arn returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"target_group_arn": testARN},
+					},
+				},
+			},
+			idx:  "0",
+			want: false,
+		},
+		"EmptyForwardSlice": {
+			reason: "action with an empty forward slice returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"forward": []interface{}{}},
+					},
+				},
+			},
+			idx:  "0",
+			want: false,
+		},
+		"HasForward": {
+			reason: "action with a non-empty forward slice returns true",
+			cfg:    configWithForward(),
+			idx:    "0",
+			want:   true,
+		},
+		"SecondActionHasForward": {
+			reason: "checks the correct index when multiple actions exist",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"target_group_arn": testARN},
+						map[string]interface{}{
+							"forward": []interface{}{
+								map[string]interface{}{"target_group": []interface{}{}},
+							},
+						},
+					},
+				},
+			},
+			idx:  "1",
+			want: true,
+		},
+		"FirstActionNoForward_SecondHasForward": {
+			reason: "index 0 returns false even when index 1 has forward",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"target_group_arn": testARN},
+						map[string]interface{}{
+							"forward": []interface{}{
+								map[string]interface{}{"target_group": []interface{}{}},
+							},
+						},
+					},
+				},
+			},
+			idx:  "0",
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := configActionHasForward(tc.cfg, tc.idx)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("%s: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/config/cluster/elbv2/config_test.go
+++ b/config/cluster/elbv2/config_test.go
@@ -150,8 +150,8 @@ func TestLBListenerRuleCustomDiff(t *testing.T) {
 			reason: "keys that do not match action.*.target_group_arn are left untouched",
 			diff: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
-					"action.0.type":             {Old: "", New: "forward"},
-					"other.0.target_group_arn":  {Old: "", New: testARN},
+					"action.0.type":            {Old: "", New: "forward"},
+					"other.0.target_group_arn": {Old: "", New: testARN},
 				},
 			},
 			cfg:      configWithForward(),

--- a/config/namespaced/elbv2/config.go
+++ b/config/namespaced/elbv2/config.go
@@ -5,7 +5,9 @@
 package elbv2
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -123,6 +125,10 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 	})
 
+	p.AddResourceConfigurator("aws_lb_listener_rule", func(r *config.Resource) {
+		r.TerraformCustomDiff = lbListenerRuleCustomDiff
+	})
+
 	p.AddResourceConfigurator("aws_lb_target_group", func(r *config.Resource) {
 		r.ExternalName.OmittedFields = append(r.ExternalName.OmittedFields, "name_prefix")
 		if s, ok := r.TerraformResource.Schema["name"]; ok {
@@ -159,4 +165,56 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.ShortGroup = "elbv2"
 		r.Kind = "LBTrustStore"
 	})
+}
+
+func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
+		return diff, nil
+	}
+	for k, attrDiff := range diff.Attributes {
+		if attrDiff == nil || !strings.HasPrefix(k, "action.") || !strings.HasSuffix(k, ".target_group_arn") {
+			continue
+		}
+		idx := strings.TrimPrefix(k, "action.")
+		idx = strings.TrimSuffix(idx, ".target_group_arn")
+
+		// Case A: arn absent from state, present in config — late-init artifact
+		// when the provider's Read took the flattenForwardActionOneOf path because
+		// forward is configured, stripping arn from state while late-init had
+		// already written it to spec.
+		if attrDiff.Old == "" && attrDiff.New != "" && configActionHasForward(cfg, idx) {
+			delete(diff.Attributes, k)
+		}
+
+		// Case B: arn present in state, absent from config — the provider's Read
+		// took the flattenForwardActionBoth path (null RawPlan after Update or
+		// restart), writing arn to state, while spec only declares forward.
+		if attrDiff.Old != "" && attrDiff.New == "" && attrDiff.NewRemoved {
+			forwardKey := fmt.Sprintf("action.%s.forward.#", idx)
+			if state != nil && state.Attributes[forwardKey] != "" && state.Attributes[forwardKey] != "0" {
+				delete(diff.Attributes, k)
+			}
+		}
+	}
+	return diff, nil
+}
+
+func configActionHasForward(cfg *terraform.ResourceConfig, actionIdx string) bool {
+	if cfg == nil || cfg.Config == nil {
+		return false
+	}
+	actions, ok := cfg.Config["action"].([]interface{})
+	if !ok {
+		return false
+	}
+	idx, err := strconv.Atoi(actionIdx)
+	if err != nil || idx < 0 || idx >= len(actions) {
+		return false
+	}
+	actionMap, ok := actions[idx].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	forwards, _ := actionMap["forward"].([]interface{})
+	return len(forwards) > 0
 }

--- a/config/namespaced/elbv2/config.go
+++ b/config/namespaced/elbv2/config.go
@@ -167,7 +167,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	})
 }
 
-func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo // easier to follow as a unit
 	if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
 		return diff, nil
 	}

--- a/config/namespaced/elbv2/config_test.go
+++ b/config/namespaced/elbv2/config_test.go
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package elbv2
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const testARN = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-tg/abc123"
+
+func configWithForward() *terraform.ResourceConfig {
+	return &terraform.ResourceConfig{
+		Config: map[string]interface{}{
+			"action": []interface{}{
+				map[string]interface{}{
+					"forward": []interface{}{
+						map[string]interface{}{
+							"target_group": []interface{}{
+								map[string]interface{}{"arn": testARN, "weight": 1},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func configWithARNOnly() *terraform.ResourceConfig {
+	return &terraform.ResourceConfig{
+		Config: map[string]interface{}{
+			"action": []interface{}{
+				map[string]interface{}{
+					"target_group_arn": testARN,
+				},
+			},
+		},
+	}
+}
+
+func TestLBListenerRuleCustomDiff(t *testing.T) {
+	cases := map[string]struct {
+		reason   string
+		diff     *terraform.InstanceDiff
+		state    *terraform.InstanceState
+		cfg      *terraform.ResourceConfig
+		wantKeys []string
+		goneKeys []string
+	}{
+		"NilDiff": {
+			reason: "nil diff passes through unchanged",
+			diff:   nil,
+		},
+		"EmptyDiff": {
+			reason: "empty diff passes through unchanged",
+			diff:   &terraform.InstanceDiff{},
+		},
+		"DestroyDiff": {
+			reason: "destroy diff is never modified",
+			diff: &terraform.InstanceDiff{
+				Destroy: true,
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		// Case A: arn absent from state (Old=""), present in config — late-init artifact
+		"CaseA_Suppressed": {
+			reason: "spurious arn addition is suppressed when the same action has forward configured",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg:      configWithForward(),
+			goneKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseA_NotSuppressed_NoForwardInConfig": {
+			reason: "arn addition is kept when action only has target_group_arn (real user intent)",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg:      configWithARNOnly(),
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseA_NotSuppressed_NilConfig": {
+			reason: "arn addition is kept when config is nil",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg:      nil,
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		// Case B: arn present in state (Old=arn), absent from config — null RawPlan path
+		"CaseB_Suppressed": {
+			reason: "spurious arn removal is suppressed when forward is active in state",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"action.0.forward.#": "1"},
+			},
+			goneKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseB_NotSuppressed_NoForwardInState": {
+			reason: "arn removal is kept when forward count is 0 in state",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"action.0.forward.#": "0"},
+			},
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"CaseB_NotSuppressed_NilState": {
+			reason: "arn removal is kept when state is nil",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: testARN, New: "", NewRemoved: true},
+				},
+			},
+			state:    nil,
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"RealArnUpdate_NotSuppressed": {
+			reason: "a real arn change (both Old and New non-empty) is never suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "arn:old", New: "arn:new"},
+				},
+			},
+			cfg:      configWithForward(),
+			wantKeys: []string{"action.0.target_group_arn"},
+		},
+		"UnrelatedKeysUntouched": {
+			reason: "keys that do not match action.*.target_group_arn are left untouched",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.type":             {Old: "", New: "forward"},
+					"other.0.target_group_arn":  {Old: "", New: testARN},
+				},
+			},
+			cfg:      configWithForward(),
+			wantKeys: []string{"action.0.type", "other.0.target_group_arn"},
+		},
+		"MultipleActions_OnlySuppressesMatchingIndex": {
+			reason: "when two actions are present, only the one with forward in config is suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"action.0.target_group_arn": {Old: "", New: testARN},
+					"action.1.target_group_arn": {Old: "", New: testARN},
+				},
+			},
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						// action 0: only arn, no forward
+						map[string]interface{}{"target_group_arn": testARN},
+						// action 1: forward configured
+						map[string]interface{}{
+							"forward": []interface{}{
+								map[string]interface{}{
+									"target_group": []interface{}{
+										map[string]interface{}{"arn": testARN, "weight": 1},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantKeys: []string{"action.0.target_group_arn"},
+			goneKeys: []string{"action.1.target_group_arn"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := lbListenerRuleCustomDiff(tc.diff, tc.state, tc.cfg)
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.reason, err)
+			}
+			if tc.diff == nil {
+				if got != nil {
+					t.Errorf("%s: expected nil diff, got non-nil", tc.reason)
+				}
+				return
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got.Attributes[k]; !ok {
+					t.Errorf("%s: key %q should be present but is missing", tc.reason, k)
+				}
+			}
+			for _, k := range tc.goneKeys {
+				if _, ok := got.Attributes[k]; ok {
+					t.Errorf("%s: key %q should have been suppressed but is still present", tc.reason, k)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigActionHasForward(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		cfg    *terraform.ResourceConfig
+		idx    string
+		want   bool
+	}{
+		"NilConfig": {
+			reason: "nil config returns false",
+			cfg:    nil,
+			idx:    "0",
+			want:   false,
+		},
+		"NilConfigMap": {
+			reason: "config with nil inner map returns false",
+			cfg:    &terraform.ResourceConfig{},
+			idx:    "0",
+			want:   false,
+		},
+		"NoActionsKey": {
+			reason: "config without an action key returns false",
+			cfg:    &terraform.ResourceConfig{Config: map[string]interface{}{}},
+			idx:    "0",
+			want:   false,
+		},
+		"InvalidIndex": {
+			reason: "non-numeric index returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{map[string]interface{}{}},
+				},
+			},
+			idx:  "abc",
+			want: false,
+		},
+		"OutOfRangeIndex": {
+			reason: "index beyond action slice length returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{map[string]interface{}{}},
+				},
+			},
+			idx:  "5",
+			want: false,
+		},
+		"NoForward": {
+			reason: "action with only target_group_arn returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"target_group_arn": testARN},
+					},
+				},
+			},
+			idx:  "0",
+			want: false,
+		},
+		"EmptyForwardSlice": {
+			reason: "action with an empty forward slice returns false",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"forward": []interface{}{}},
+					},
+				},
+			},
+			idx:  "0",
+			want: false,
+		},
+		"HasForward": {
+			reason: "action with a non-empty forward slice returns true",
+			cfg:    configWithForward(),
+			idx:    "0",
+			want:   true,
+		},
+		"SecondActionHasForward": {
+			reason: "checks the correct index when multiple actions exist",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"target_group_arn": testARN},
+						map[string]interface{}{
+							"forward": []interface{}{
+								map[string]interface{}{"target_group": []interface{}{}},
+							},
+						},
+					},
+				},
+			},
+			idx:  "1",
+			want: true,
+		},
+		"FirstActionNoForward_SecondHasForward": {
+			reason: "index 0 returns false even when index 1 has forward",
+			cfg: &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"action": []interface{}{
+						map[string]interface{}{"target_group_arn": testARN},
+						map[string]interface{}{
+							"forward": []interface{}{
+								map[string]interface{}{"target_group": []interface{}{}},
+							},
+						},
+					},
+				},
+			},
+			idx:  "0",
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := configActionHasForward(tc.cfg, tc.idx)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("%s: -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/config/namespaced/elbv2/config_test.go
+++ b/config/namespaced/elbv2/config_test.go
@@ -150,8 +150,8 @@ func TestLBListenerRuleCustomDiff(t *testing.T) {
 			reason: "keys that do not match action.*.target_group_arn are left untouched",
 			diff: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
-					"action.0.type":             {Old: "", New: "forward"},
-					"other.0.target_group_arn":  {Old: "", New: testARN},
+					"action.0.type":            {Old: "", New: "forward"},
+					"other.0.target_group_arn": {Old: "", New: testARN},
 				},
 			},
 			cfg:      configWithForward(),

--- a/config/templates/terraformed.go.tmpl
+++ b/config/templates/terraformed.go.tmpl
@@ -141,10 +141,61 @@ func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
     {{ end }}
 
     li := resource.NewGenericLateInitializer(opts...)
+    {{- if eq .Terraform.ResourceType "aws_lb_listener_rule" }}
+    changed, err := li.LateInitialize(&tr.Spec.ForProvider, params)
+    if err != nil {
+        return false, err
+    }
+    forcedChanged, err := lbListenerRuleForcedLateInitAction(&tr.Spec.ForProvider, params)
+    if err != nil {
+        return false, err
+    }
+    return changed || forcedChanged, nil
+    {{- else }}
     return li.LateInitialize(&tr.Spec.ForProvider, params)
+    {{- end }}
 }
 
 // GetTerraformSchemaVersion returns the associated Terraform schema version
 func (tr *{{ .CRD.Kind }}) GetTerraformSchemaVersion() int {
     return {{ .Terraform.ResourceSchema.SchemaVersion }}
 }
+{{ if eq .Terraform.ResourceType "aws_lb_listener_rule" }}
+// lbListenerRuleForcedLateInitAction forces late-initialization of nil fields
+// within each element of the action slice. The generic late-initializer skips
+// the entire action slice once it is non-nil (i.e. the user set any action
+// field), so auto-assigned fields like order are never written back to spec,
+// causing a perpetual reconcile loop. This function re-runs late-init at the
+// individual action-element level so that all remaining nil fields are
+// populated from the observed Terraform state.
+//
+// It also recurses into a partially filled Forward block so that nil
+// sub-fields (e.g. Stickiness) are populated as well.
+func lbListenerRuleForcedLateInitAction(spec, observed *{{ .CRD.ParametersTypeName }}) (bool, error) {
+    if len(spec.Action) == 0 || len(spec.Action) != len(observed.Action) {
+        return false, nil
+    }
+    li := resource.NewGenericLateInitializer(resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard))
+    changed := false
+    for i := range spec.Action {
+        c, err := li.LateInitialize(&spec.Action[i], &observed.Action[i])
+        if err != nil {
+            return false, err
+        }
+        changed = changed || c
+        if observed.Action[i].Forward != nil {
+            if spec.Action[i].Forward == nil {
+                spec.Action[i].Forward = observed.Action[i].Forward
+                changed = true
+            } else {
+                c, err = li.LateInitialize(spec.Action[i].Forward, observed.Action[i].Forward)
+                if err != nil {
+                    return false, err
+                }
+                changed = changed || c
+            }
+        }
+    }
+    return changed, nil
+}
+{{ end -}}


### PR DESCRIPTION
### Description of your changes

### Problem

`aws_lb_listener_rule` resources using the `action` and `action.forward` block trigger a perpetual reconcile loop, every Observe/Update cycle produces a diff even when nothing has changed.

The Terraform provider's `flattenForwardAction*` function attempts to distinguish between different operation contexts (create/update vs. refresh vs. import) by inspecting low-level `GetRawConfig()` and `GetRawPlan()` values. In native Terraform these differ per operation, so the provider uses their null-ness as a signal: null `RawPlan`/`RawConfig` → treat as refresh/import → write both `target_group_arn` and forward to state (`flattenForwardActionBoth`); forward present in `RawConfig` → treat as normal plan/apply → strip `target_group_arn` (`flattenForwardActionOneOf`).

This assumption is incompatible with upjet. Upjet doesn't map to Terraform's operation primitives, all reconciliation flows through the operation calls.

Late-init then copies it to spec. On the following `Observe()`, `RawConfig` is populated (as upjet sets it explicitly), so `flattenForwardActionOneOf` fires and strips `target_group_arn` from state, leaving spec with the arn and state without it, producing a diff that triggers another `Update()`. The cycle repeats indefinitely.

A secondary issue: the generic `LateInitializer` skips the entire action slice once any field is set, so auto-assigned fields like order and provider-defaulted forward.stickiness values are never written back to spec.

### Fix

Forced late-init (`lbListenerRuleForcedLateInitAction`): Re-runs late-init at the individual action-element level, bypassing the "skip non-nil slice" behavior. Also recurses into the Forward sub-block to populate nil sub-fields.

Custom diff (`lbListenerRuleCustomDiff`): Suppresses the remaining spurious Update caused by the RawPlan cycle:

- Case A (Old="", New=arn): suppress when forward is present in the ResourceConfig for that action index — the provider stripped arn via flattenForwardActionOneOf and the arn in spec is a late-init artifact.
- Case B (Old=arn, New="", NewRemoved): suppress when forward is active in the observed state — arn was backfilled by flattenForwardActionBoth, not user-specified.

Real arn changes (actual user edits) are never suppressed.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

- Cluster scoped v1beta1 -> https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/29194425501
- Cluster scoped v1beta2 -> https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/29198145181
- Namespaced v1beta1 -> https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/29199070538

[contribution process]: https://git.io/fj2m9
