### PR TITLE
examples/rds: stop hardcoding engineVersion in Instance examples

### DIFF
--- a/examples/rds/cluster/v1beta1/dbinstanceautomatedbackupsreplication.yaml
+++ b/examples/rds/cluster/v1beta1/dbinstanceautomatedbackupsreplication.yaml
@@ -35,9 +35,7 @@ spec:
     allocatedStorage: 10
     dbName: mydb
     engine: mysql
-    engineVersion: "5.7"
     instanceClass: db.t3.micro
-    parameterGroupName: default.mysql5.7
     autoGeneratePassword: true
     passwordSecretRef:
       key: password

--- a/examples/rds/cluster/v1beta1/dbsnapshotcopy.yaml
+++ b/examples/rds/cluster/v1beta1/dbsnapshotcopy.yaml
@@ -55,7 +55,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "13.7"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:

--- a/examples/rds/cluster/v1beta1/instance.yaml
+++ b/examples/rds/cluster/v1beta1/instance.yaml
@@ -20,7 +20,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "16.6"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:

--- a/examples/rds/cluster/v1beta1/instanceroleassociation.yaml
+++ b/examples/rds/cluster/v1beta1/instanceroleassociation.yaml
@@ -41,7 +41,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "13.7"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:

--- a/examples/rds/cluster/v1beta1/instancestate.yaml
+++ b/examples/rds/cluster/v1beta1/instancestate.yaml
@@ -36,7 +36,6 @@ spec:
     backupWindow: 09:46-10:16
     name: example
     engine: postgres
-    engineVersion: "16.6"
     instanceClass: db.t3.micro
     kmsKeyIdSelector:
       matchLabels:

--- a/examples/rds/cluster/v1beta1/instancestate.yaml
+++ b/examples/rds/cluster/v1beta1/instancestate.yaml
@@ -34,7 +34,7 @@ spec:
     autoMinorVersionUpgrade: true
     backupRetentionPeriod: 14
     backupWindow: 09:46-10:16
-    name: example
+    dbName: example
     engine: postgres
     instanceClass: db.t3.micro
     kmsKeyIdSelector:

--- a/examples/rds/cluster/v1beta1/snapshot.yaml
+++ b/examples/rds/cluster/v1beta1/snapshot.yaml
@@ -37,7 +37,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "13.7"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:

--- a/examples/rds/cluster/v1beta2/instance.yaml
+++ b/examples/rds/cluster/v1beta2/instance.yaml
@@ -20,7 +20,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "16.6"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:

--- a/examples/rds/cluster/v1beta3/instance-custom-parametergroup.yaml
+++ b/examples/rds/cluster/v1beta3/instance-custom-parametergroup.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This example attaches a custom, provider-managed ParameterGroup to the
+# Instance via a cross-resource reference (parameterGroupNameSelector). Because
+# the ParameterGroup has a fixed family (postgres16), the Instance must pin a
+# matching engine major version (engineVersion: "16"); otherwise AWS would pick
+# a default engine version that may not match the parameter group family and the
+# instance creation would fail. Keep engineVersion and the ParameterGroup family
+# in sync when bumping the version.
+apiVersion: rds.aws.upbound.io/v1beta3
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta3/instance
+    uptest.upbound.io/timeout: "3600"
+  labels:
+    testing.upbound.io/example-name: instance-custom-parametergroup
+  name: example-dbinstance-custompg-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    allocatedStorage: 20
+    autoGeneratePassword: true
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 14
+    backupWindow: 09:46-10:16
+    dbName: example
+    engine: postgres
+    engineVersion: "16"
+    instanceClass: db.t3.micro
+    maintenanceWindow: Mon:00:00-Mon:03:00
+    parameterGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: instance-custom-parametergroup
+    passwordSecretRef:
+      key: password
+      name: example-dbinstance-custompg
+      namespace: upbound-system
+    publiclyAccessible: false
+    region: us-west-1
+    skipFinalSnapshot: true
+    storageType: gp2
+    username: adminuser
+  writeConnectionSecretToRef:
+    name: example-dbinstance-custompg-out
+    namespace: default
+
+---
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta3/instance
+  labels:
+    testing.upbound.io/example-name: instance-custom-parametergroup
+  name: example-custom-pg-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    description: Custom parameter group for the RDS instance example
+    family: postgres16
+    parameter:
+      - name: application_name
+        value: example
+        applyMethod: immediate
+    region: us-west-1

--- a/examples/rds/cluster/v1beta3/instance-engineversion.yaml
+++ b/examples/rds/cluster/v1beta3/instance-engineversion.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This example intentionally pins the engine version. When you do so, make sure
+# the parameterGroupName corresponds to the same engine major version: the
+# parameter group family (here postgres16) must match engineVersion, otherwise
+# the instance creation fails with an engine-family mismatch. Keep the two in
+# sync when bumping the version. For examples that should always track a
+# currently-available version, omit both fields and let AWS pick the defaults.
+apiVersion: rds.aws.upbound.io/v1beta3
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta3/instance
+    uptest.upbound.io/timeout: "3600"
+  labels:
+    testing.upbound.io/example-name: instance-engineversion
+  name: example-dbinstance-pinned-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    allocatedStorage: 20
+    autoGeneratePassword: true
+    autoMinorVersionUpgrade: true
+    backupRetentionPeriod: 14
+    backupWindow: 09:46-10:16
+    dbName: example
+    engine: postgres
+    engineVersion: "16"
+    instanceClass: db.t3.micro
+    maintenanceWindow: Mon:00:00-Mon:03:00
+    parameterGroupName: default.postgres16
+    passwordSecretRef:
+      key: password
+      name: example-dbinstance-pinned
+      namespace: upbound-system
+    publiclyAccessible: false
+    region: us-west-1
+    skipFinalSnapshot: true
+    storageType: gp2
+    username: adminuser
+  writeConnectionSecretToRef:
+    name: example-dbinstance-pinned-out
+    namespace: default

--- a/examples/rds/cluster/v1beta3/instance.yaml
+++ b/examples/rds/cluster/v1beta3/instance.yaml
@@ -20,7 +20,6 @@ spec:
     backupWindow: 09:46-10:16
     dbName: example
     engine: postgres
-    engineVersion: "16.6"
     instanceClass: db.t3.micro
     kmsKeyIdSelector:
       matchLabels:

--- a/examples/rds/namespaced/v1beta1/dbinstanceautomatedbackupsreplication.yaml
+++ b/examples/rds/namespaced/v1beta1/dbinstanceautomatedbackupsreplication.yaml
@@ -35,9 +35,7 @@ spec:
     allocatedStorage: 10
     dbName: mydb
     engine: mysql
-    engineVersion: "5.7"
     instanceClass: db.t3.micro
-    parameterGroupName: default.mysql5.7
     autoGeneratePassword: true
     passwordSecretRef:
       key: password

--- a/examples/rds/namespaced/v1beta1/dbsnapshotcopy.yaml
+++ b/examples/rds/namespaced/v1beta1/dbsnapshotcopy.yaml
@@ -54,7 +54,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "13.7"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:

--- a/examples/rds/namespaced/v1beta1/instance.yaml
+++ b/examples/rds/namespaced/v1beta1/instance.yaml
@@ -21,7 +21,6 @@ spec:
     backupWindow: 09:46-10:16
     dbName: example
     engine: postgres
-    engineVersion: "16.6"
     instanceClass: db.t3.micro
     kmsKeyIdSelector:
       matchLabels:

--- a/examples/rds/namespaced/v1beta1/instanceroleassociation.yaml
+++ b/examples/rds/namespaced/v1beta1/instanceroleassociation.yaml
@@ -41,7 +41,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "13.7"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:

--- a/examples/rds/namespaced/v1beta1/instancestate.yaml
+++ b/examples/rds/namespaced/v1beta1/instancestate.yaml
@@ -38,7 +38,6 @@ spec:
     backupWindow: 09:46-10:16
     name: example
     engine: postgres
-    engineVersion: "16.6"
     instanceClass: db.t3.micro
     kmsKeyIdSelector:
       matchLabels:

--- a/examples/rds/namespaced/v1beta1/instancestate.yaml
+++ b/examples/rds/namespaced/v1beta1/instancestate.yaml
@@ -36,7 +36,7 @@ spec:
     autoMinorVersionUpgrade: true
     backupRetentionPeriod: 14
     backupWindow: 09:46-10:16
-    name: example
+    dbName: example
     engine: postgres
     instanceClass: db.t3.micro
     kmsKeyIdSelector:

--- a/examples/rds/namespaced/v1beta1/snapshot.yaml
+++ b/examples/rds/namespaced/v1beta1/snapshot.yaml
@@ -37,7 +37,6 @@ spec:
     backupRetentionPeriod: 14
     instanceClass: db.t3.micro
     engine: postgres
-    engineVersion: "13.7"
     username: adminuser
     autoGeneratePassword: true
     passwordSecretRef:


### PR DESCRIPTION
### Description of your changes

The `rds.aws.upbound.io` `Instance` examples hardcoded a specific `engineVersion`
(e.g. `"16.6"`, `"13.7"`, `"5.7"`). Once RDS retires that exact version, applying
the example fails. `engineVersion` is optional on the `Instance` CRD, so
it can safely be omitted and left for AWS to default.

This PR:

- **Removes the hardcoded `engineVersion`** from all 14 `Instance` examples under
  `examples/rds/` (cluster + namespaced, `v1beta1`/`v1beta2`/`v1beta3`), including
  the ones where the `Instance` is a dependency (`snapshot`, `dbsnapshotcopy`,
  `instancestate`, `instanceroleassociation`, `dbinstanceautomatedbackupsreplication`).
  AWS then selects a currently-available default engine version at creation time.
- In the two `dbinstanceautomatedbackupsreplication.yaml` examples, **also removes
  the coupled `parameterGroupName: default.mysql5.7`.** That default parameter group
  is only valid for a MySQL 5.7 instance, so dropping only `engineVersion` would
  leave an engine-family mismatch. With both removed, AWS attaches the matching
  default parameter group for whichever engine version it selects.
- **Adds two new `v1beta3` (latest cluster-scoped) `Instance` examples** that
  intentionally demonstrate *explicit* version pinning, for testing those configurations,
  and document the coupling that must be kept consistent:
  - `instance-engineversion.yaml`: pins `engineVersion` and pairs it with the
    matching AWS default parameter group (`default.postgres16`).
  - `instance-custom-parametergroup.yaml`: attaches a custom, provider-managed
    `ParameterGroup` via `parameterGroupNameSelector`. There was previously no
    example wiring an `Instance` to an `rds.aws.upbound.io` `ParameterGroup`.
    Because the parameter group has a fixed `family` (`postgres16`), the engine
    version is pinned to match it.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit).
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
