### PR TITLE
add jonasz-lasut as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,4 +19,4 @@
 # See also OWNERS.md for governance details
 
 # Fallback owners
-*			@sergenyalcin @turkenf @jastang @erhancagirici @ulucinar @bobh66
+*			@sergenyalcin @turkenf @jastang @erhancagirici @ulucinar @bobh66 @jonasz-lasut

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -18,6 +18,7 @@ repository maintainers in their own `OWNERS.md` file.
 * Erhan Cagirici <erhan@upbound.io> ([erhancagirici](https://github.com/erhancagirici))
 * Alper Ulucinar <alper@upbound.io> ([ulucinar](https://github.com/ulucinar))
 * Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
+* Jonasz Lasut-Balcerzak <jonasz@upbound.io> ([jonasz-lasut](https://github.com/jonasz-lasut))
 
 See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.
 


### PR DESCRIPTION
### Description of your changes

Adds Jonasz Łasut-Balcerzak ([jonasz-lasut](https://github.com/jonasz-lasut)) as a maintainer of `provider-upjet-aws` per the [Crossplane governance process](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md).

- adds `OWNERS.md` entry
- adds `@jonasz-lasut` to `CODEOWNERS` as a fallback reviewer

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `make generate` and committed the results (ideally in a separate commit).~~ N/A — no generated files affected.
- [ ] ~~Not made any manual changes to generated files, and verified this with `make check-diff`.~~ N/A — no generated files affected.

### How has this code been tested
N/A

- Visual review of the `OWNERS.md` and `CODEOWNERS` diff.
- Approval per the 2/3 super-majority requirement of existing maintainers in [GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md).

[contribution process]: https://git.io/fj2m9