### PR TITLE
Update underlying provider fork to support updates in VaultLockConfiguration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)/v2
 
 export TERRAFORM_VERSION := 1.5.5
 export TERRAFORM_PROVIDER_VERSION := 6.55.0
-export TERRAFORM_PROVIDER_RELEASE := v$(TERRAFORM_PROVIDER_VERSION)-upjet.1
+export TERRAFORM_PROVIDER_RELEASE := v$(TERRAFORM_PROVIDER_VERSION)-upjet.2
 export TERRAFORM_PROVIDER_SOURCE := hashicorp/aws
 export TERRAFORM_PROVIDER_REPO ?= https://github.com/hashicorp/terraform-provider-aws
 export TERRAFORM_DOCS_PATH ?= website/docs/r

--- a/apis/cluster/backup/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/backup/v1beta1/zz_generated.deepcopy.go
@@ -4005,6 +4005,16 @@ func (in *VaultLockConfigurationObservation) DeepCopyInto(out *VaultLockConfigur
 		*out = new(string)
 		**out = **in
 	}
+	if in.LockDate != nil {
+		in, out := &in.LockDate, &out.LockDate
+		*out = new(string)
+		**out = **in
+	}
+	if in.Locked != nil {
+		in, out := &in.Locked, &out.Locked
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MaxRetentionDays != nil {
 		in, out := &in.MaxRetentionDays, &out.MaxRetentionDays
 		*out = new(float64)

--- a/apis/cluster/backup/v1beta1/zz_vaultlockconfiguration_types.go
+++ b/apis/cluster/backup/v1beta1/zz_vaultlockconfiguration_types.go
@@ -50,6 +50,10 @@ type VaultLockConfigurationObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
+	LockDate *string `json:"lockDate,omitempty" tf:"lock_date,omitempty"`
+
+	Locked *bool `json:"locked,omitempty" tf:"locked,omitempty"`
+
 	// The maximum retention period that the vault retains its recovery points.
 	MaxRetentionDays *float64 `json:"maxRetentionDays,omitempty" tf:"max_retention_days,omitempty"`
 

--- a/apis/namespaced/backup/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/backup/v1beta1/zz_generated.deepcopy.go
@@ -3975,6 +3975,16 @@ func (in *VaultLockConfigurationObservation) DeepCopyInto(out *VaultLockConfigur
 		*out = new(string)
 		**out = **in
 	}
+	if in.LockDate != nil {
+		in, out := &in.LockDate, &out.LockDate
+		*out = new(string)
+		**out = **in
+	}
+	if in.Locked != nil {
+		in, out := &in.Locked, &out.Locked
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MaxRetentionDays != nil {
 		in, out := &in.MaxRetentionDays, &out.MaxRetentionDays
 		*out = new(float64)

--- a/apis/namespaced/backup/v1beta1/zz_vaultlockconfiguration_types.go
+++ b/apis/namespaced/backup/v1beta1/zz_vaultlockconfiguration_types.go
@@ -51,6 +51,10 @@ type VaultLockConfigurationObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
+	LockDate *string `json:"lockDate,omitempty" tf:"lock_date,omitempty"`
+
+	Locked *bool `json:"locked,omitempty" tf:"locked,omitempty"`
+
 	// The maximum retention period that the vault retains its recovery points.
 	MaxRetentionDays *float64 `json:"maxRetentionDays,omitempty" tf:"max_retention_days,omitempty"`
 

--- a/examples/backup/cluster/v1beta1/vaultlockconfiguration.yaml
+++ b/examples/backup/cluster/v1beta1/vaultlockconfiguration.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: backup.aws.upbound.io/v1beta1
+kind: Vault
+metadata:
+  name: vaultlock-${Rand.RFC1123Subdomain}
+  annotations:
+    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
+  labels:
+    testing.upbound.io/example-name: vaultlockconfiguration
+spec:
+  forProvider:
+    region: us-west-1
+---
+apiVersion: backup.aws.upbound.io/v1beta1
+kind: VaultLockConfiguration
+metadata:
+  name: vaultlockconfiguration
+  annotations:
+    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
+  labels:
+    testing.upbound.io/example-name: vaultlockconfiguration
+spec:
+  forProvider:
+    region: us-west-1
+    backupVaultNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: vaultlockconfiguration
+    changeableForDays: 3
+    maxRetentionDays: 1200
+    minRetentionDays: 7

--- a/examples/backup/namespaced/v1beta1/vaultlockconfiguration.yaml
+++ b/examples/backup/namespaced/v1beta1/vaultlockconfiguration.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: backup.aws.m.upbound.io/v1beta1
+kind: Vault
+metadata:
+  name: vaultlock-${Rand.RFC1123Subdomain}
+  annotations:
+    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
+  labels:
+    testing.upbound.io/example-name: vaultlockconfiguration
+spec:
+  forProvider:
+    region: us-west-1
+---
+apiVersion: backup.aws.m.upbound.io/v1beta1
+kind: VaultLockConfiguration
+metadata:
+  name: vaultlockconfiguration
+  annotations:
+    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
+  labels:
+    testing.upbound.io/example-name: vaultlockconfiguration
+spec:
+  forProvider:
+    region: us-west-1
+    backupVaultNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: vaultlockconfiguration
+    changeableForDays: 3
+    maxRetentionDays: 1200
+    minRetentionDays: 7

--- a/go.mod
+++ b/go.mod
@@ -495,4 +495,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20260722064508-f132c16d90d8
+replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20260730085822-da37777269ac

--- a/go.sum
+++ b/go.sum
@@ -985,8 +985,8 @@ github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uL
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/upbound/terraform-provider-aws v0.0.0-20260722064508-f132c16d90d8 h1:Kg4/Hb4xMfIqi0J5M6WFNLfFiYspvn29Xc4FnB9m1gY=
-github.com/upbound/terraform-provider-aws v0.0.0-20260722064508-f132c16d90d8/go.mod h1:fAVczQxhoaO/s+GbG21ZzXr/ZERIeq92yRN4I/fWvfA=
+github.com/upbound/terraform-provider-aws v0.0.0-20260730085822-da37777269ac h1:LfPg2bJZUdLAMWYtX5UdeCJR9nTiQrCFE+qEEYi4YPQ=
+github.com/upbound/terraform-provider-aws v0.0.0-20260730085822-da37777269ac/go.mod h1:fAVczQxhoaO/s+GbG21ZzXr/ZERIeq92yRN4I/fWvfA=
 github.com/upbound/uptest v0.12.1-0.20260123170102-8965579a213b h1:3skJb1zt9rBR/4wUWMT32Ip02OckGzYyMhjCkEeCdfA=
 github.com/upbound/uptest v0.12.1-0.20260123170102-8965579a213b/go.mod h1:LaaCdCFepE8h8UtssvRbKBgrNUK4CKNh+bEyE0HnLvc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/package/crds/backup.aws.m.upbound.io_vaultlockconfigurations.yaml
+++ b/package/crds/backup.aws.m.upbound.io_vaultlockconfigurations.yaml
@@ -353,6 +353,10 @@ spec:
                     type: number
                   id:
                     type: string
+                  lockDate:
+                    type: string
+                  locked:
+                    type: boolean
                   maxRetentionDays:
                     description: The maximum retention period that the vault retains
                       its recovery points.

--- a/package/crds/backup.aws.upbound.io_vaultlockconfigurations.yaml
+++ b/package/crds/backup.aws.upbound.io_vaultlockconfigurations.yaml
@@ -383,6 +383,10 @@ spec:
                     type: number
                   id:
                     type: string
+                  lockDate:
+                    type: string
+                  locked:
+                    type: boolean
                   maxRetentionDays:
                     description: The maximum retention period that the vault retains
                       its recovery points.


### PR DESCRIPTION
### Description of your changes
Consumes terraform provider update - https://github.com/upbound/terraform-provider-aws/pull/321

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [X] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested
E2E test of create/import/delete:
/test-examples="examples/backup/cluster/v1beta1/vaultlockconfiguration.yaml" - https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/30538586217

Manual tests of the update path:

Apply

```yaml
apiVersion: backup.aws.upbound.io/v1beta1
kind: VaultLockConfiguration
metadata:
  annotations:
    crossplane.io/external-create-pending: "2026-07-30T05:30:41Z"
    crossplane.io/external-create-succeeded: "2026-07-30T05:30:41Z"
    crossplane.io/external-name: vaultlock-buiqdwhu
    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
  creationTimestamp: "2026-07-30T05:30:40Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 3
  labels:
    testing.upbound.io/example-name: vaultlockconfiguration
  name: vaultlockconfiguration
  resourceVersion: "3659"
  uid: 38b25691-0853-4676-adc8-2116fc30e88f
spec:
  deletionPolicy: Delete
  forProvider:
    backupVaultName: vaultlock-buiqdwhu
    backupVaultNameRef:
      name: vaultlock-buiqdwhu
    backupVaultNameSelector:
      matchLabels:
        testing.upbound.io/example-name: vaultlockconfiguration
    changeableForDays: 3
    maxRetentionDays: 1200
    minRetentionDays: 7
    region: us-west-1
  initProvider: {}
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    backupVaultArn: arn:aws:backup:us-west-1:153891904029:backup-vault:vaultlock-buiqdwhu
    backupVaultName: vaultlock-buiqdwhu
    changeableForDays: 3
    id: vaultlock-buiqdwhu
    lockDate: "2026-08-02T05:30:41Z"
    locked: true
    maxRetentionDays: 1200
    minRetentionDays: 7
    region: us-west-1
  conditions:
  - lastTransitionTime: "2026-07-30T05:30:41Z"
    observedGeneration: 3
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2026-07-30T05:30:43Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2026-07-30T05:30:42Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
```

Update - lockDate gets updated on every operation changing changeableForDays, maxRetentionDays and minRetentionDays

```shell
kubectl patch vaultlockconfiguration.backup.aws.upbound.io/vaultlockconfiguration --type=merge -p '{"spec":{"forProvider":{"minRetentionDays": 14}}}'
```

```yaml
piVersion: backup.aws.upbound.io/v1beta1
kind: VaultLockConfiguration
metadata:
  annotations:
    crossplane.io/external-create-pending: "2026-07-30T05:30:41Z"
    crossplane.io/external-create-succeeded: "2026-07-30T05:30:41Z"
    crossplane.io/external-name: vaultlock-buiqdwhu
    meta.upbound.io/example-id: backup/v1beta1/vaultlockconfiguration
  creationTimestamp: "2026-07-30T05:30:40Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 4
  labels:
    testing.upbound.io/example-name: vaultlockconfiguration
  name: vaultlockconfiguration
  resourceVersion: "3947"
  uid: 38b25691-0853-4676-adc8-2116fc30e88f
spec:
  deletionPolicy: Delete
  forProvider:
    backupVaultName: vaultlock-buiqdwhu
    backupVaultNameRef:
      name: vaultlock-buiqdwhu
    backupVaultNameSelector:
      matchLabels:
        testing.upbound.io/example-name: vaultlockconfiguration
    changeableForDays: 3
    maxRetentionDays: 1200
    minRetentionDays: 14
    region: us-west-1
  initProvider: {}
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    backupVaultArn: arn:aws:backup:us-west-1:153891904029:backup-vault:vaultlock-buiqdwhu
    backupVaultName: vaultlock-buiqdwhu
    changeableForDays: 3
    id: vaultlock-buiqdwhu
    lockDate: "2026-08-02T05:32:40Z"
    locked: true
    maxRetentionDays: 1200
    minRetentionDays: 14
    region: us-west-1
  conditions:
  - lastTransitionTime: "2026-07-30T05:32:40Z"
    observedGeneration: 4
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2026-07-30T05:30:43Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2026-07-30T05:30:42Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
```



[contribution process]: https://git.io/fj2m9
